### PR TITLE
Add Docker support with multi-stage build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,15 @@
+FROM python:3.13 AS docs
+WORKDIR /src
+COPY mkdocs.yml ./
+COPY docs/ docs/
+RUN pip install uv && uvx --with mkdocs-material mkdocs build --site-dir internal/docs/site
+
 FROM golang:1.24 AS build
 WORKDIR /src
 COPY go.mod go.sum ./
 RUN go mod download
 COPY . .
+COPY --from=docs /src/internal/docs/site internal/docs/site
 RUN CGO_ENABLED=0 go build -ldflags '-X main.version=docker' -o /ghp ./cmd/ghp
 
 FROM gcr.io/distroless/static-debian12


### PR DESCRIPTION
## Summary
This PR adds Docker containerization support for the ghp application, enabling it to be built and run as a container image with embedded documentation.

## Key Changes
- Added `Dockerfile` with multi-stage build configuration
  - Docs stage: Uses `python:3.13` to build mkdocs documentation via `uvx` and `mkdocs-material`
  - Build stage: Uses `golang:1.24` to compile the application with version information embedded
    - Copies rendered documentation into `internal/docs/site` for embedding in the binary
  - Runtime stage: Uses `gcr.io/distroless/static-debian12` for a minimal, secure production image
  - Exposes port 8080 and sets default command to `serve`

## Implementation Details
- Three-stage build reduces final image size by excluding both Python and Go build dependencies
- Documentation is built from `mkdocs.yml` and `docs/` directory, then embedded into the Go binary
- Uses distroless base image for improved security and minimal attack surface
- Embeds version information during build via `-ldflags '-X main.version=docker'`
- Application binary is built from `./cmd/ghp` and placed at `/ghp` in the container
- Leverages Go's `CGO_ENABLED=0` flag to ensure static binary compilation for compatibility with distroless image

https://claude.ai/code/session_01Kefjc2vRMQPLRxa9U76SAK