### PR TITLE
feat: allow admins to edit app token scopes

### DIFF
--- a/internal/database/models.go
+++ b/internal/database/models.go
@@ -13,12 +13,11 @@ import (
 	"time"
 )
 
-// ErrNotFound is returned by DeleteApp, UpdateApp, and UpdateProxyTokenAppID
-// when the target record does not exist. Other mutating operations
-// (RevokeProxyToken) and all read operations (Get*,
-// List*) do not wrap ErrNotFound — reads return (nil, nil) for missing
-// records. Callers can distinguish "not found" from other errors using
-// errors.Is(err, ErrNotFound).
+// ErrNotFound is returned by DeleteApp, UpdateApp, UpdateProxyTokenAppID, and
+// UpdateProxyTokenScopes when the target record does not exist. Other mutating
+// operations (RevokeProxyToken) and all read operations (Get*, List*) do not
+// wrap ErrNotFound — reads return (nil, nil) for missing records. Callers can
+// distinguish "not found" from other errors using errors.Is(err, ErrNotFound).
 var ErrNotFound = errors.New("not found")
 
 // DefaultTokenType is the default ProxyToken.TokenType used when none is
@@ -158,6 +157,9 @@ type Store interface {
 	ListActiveProxyTokens(ctx context.Context) ([]*ProxyToken, error)
 	RevokeProxyToken(ctx context.Context, id string) error
 	UpdateProxyTokenAppID(ctx context.Context, id string, appID string) error
+	// UpdateProxyTokenScopes updates the repositories and scopes of an existing
+	// proxy token. Returns ErrNotFound if the token does not exist.
+	UpdateProxyTokenScopes(ctx context.Context, id string, repositories json.RawMessage, scopes json.RawMessage) error
 	// DeleteExpiredProxyTokens hard-deletes proxy tokens that have been
 	// expired or revoked for longer than olderThan.  It returns the number
 	// of rows deleted.  Tokens with no expiry (expires_at IS NULL) are only

--- a/internal/database/postgres.go
+++ b/internal/database/postgres.go
@@ -403,6 +403,23 @@ func (s *PostgresStore) UpdateProxyTokenAppID(ctx context.Context, id string, ap
 	return nil
 }
 
+func (s *PostgresStore) UpdateProxyTokenScopes(ctx context.Context, id string, repositories json.RawMessage, scopes json.RawMessage) error {
+	result, err := s.db.ExecContext(ctx,
+		`UPDATE proxy_tokens SET repositories = $1, scopes = $2 WHERE id = $3`,
+		string(repositories), string(scopes), id)
+	if err != nil {
+		return err
+	}
+	n, err := result.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if n == 0 {
+		return fmt.Errorf("proxy token %s: %w", id, ErrNotFound)
+	}
+	return nil
+}
+
 func (s *PostgresStore) DeleteExpiredProxyTokens(ctx context.Context, olderThan time.Duration) (int64, error) {
 	if olderThan <= 0 {
 		return 0, fmt.Errorf("DeleteExpiredProxyTokens: olderThan must be positive, got %v", olderThan)

--- a/internal/database/sqlite.go
+++ b/internal/database/sqlite.go
@@ -504,6 +504,23 @@ func (s *SQLiteStore) UpdateProxyTokenAppID(ctx context.Context, id string, appI
 	return nil
 }
 
+func (s *SQLiteStore) UpdateProxyTokenScopes(ctx context.Context, id string, repositories json.RawMessage, scopes json.RawMessage) error {
+	result, err := s.db.ExecContext(ctx,
+		`UPDATE proxy_tokens SET repositories = ?, scopes = ? WHERE id = ?`,
+		string(repositories), string(scopes), id)
+	if err != nil {
+		return err
+	}
+	n, err := result.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if n == 0 {
+		return fmt.Errorf("proxy token %s: %w", id, ErrNotFound)
+	}
+	return nil
+}
+
 func (s *SQLiteStore) DeleteExpiredProxyTokens(ctx context.Context, olderThan time.Duration) (int64, error) {
 	if olderThan <= 0 {
 		return 0, fmt.Errorf("DeleteExpiredProxyTokens: olderThan must be positive, got %v", olderThan)

--- a/internal/database/store_test.go
+++ b/internal/database/store_test.go
@@ -723,6 +723,13 @@ func testUpdateProxyTokenScopes(t *testing.T, store Store) {
 	if len(clearedRepos) != 0 {
 		t.Errorf("expected empty repositories after clear, got %v", clearedRepos)
 	}
+	var clearedScopes map[string]string
+	if err := json.Unmarshal(got2.Scopes, &clearedScopes); err != nil {
+		t.Fatalf("unmarshal cleared scopes: %v", err)
+	}
+	if len(clearedScopes) != 0 {
+		t.Errorf("expected empty scopes after clear, got %v", clearedScopes)
+	}
 
 	// ErrNotFound for missing token.
 	err = store.UpdateProxyTokenScopes(ctx, "00000000-0000-0000-0000-000000000000", newRepos, newScopes)

--- a/internal/database/store_test.go
+++ b/internal/database/store_test.go
@@ -20,6 +20,7 @@ func testStoreContract(t *testing.T, store Store) {
 	t.Run("ProxyTokenWithAppID", func(t *testing.T) { testProxyTokenWithAppID(t, store) })
 	t.Run("ProxyTokenNoExpiry", func(t *testing.T) { testProxyTokenNoExpiry(t, store) })
 	t.Run("UpdateProxyTokenAppID", func(t *testing.T) { testUpdateProxyTokenAppID(t, store) })
+	t.Run("UpdateProxyTokenScopes", func(t *testing.T) { testUpdateProxyTokenScopes(t, store) })
 	t.Run("GitHubTokenAppID", func(t *testing.T) { testGitHubTokenAppID(t, store) })
 	t.Run("SyncAdminRoles", func(t *testing.T) { testSyncAdminRoles(t, store) })
 	t.Run("CachedRepositoryCRUD", func(t *testing.T) { testCachedRepositoryCRUD(t, store) })
@@ -653,6 +654,80 @@ func testUpdateProxyTokenAppID(t *testing.T, store Store) {
 	// Cleanup.
 	if err := store.DeleteApp(ctx, app.ID); err != nil {
 		t.Errorf("cleanup DeleteApp: %v", err)
+	}
+}
+
+func testUpdateProxyTokenScopes(t *testing.T, store Store) {
+	ctx := context.Background()
+
+	user := &User{GitHubID: 99099, GitHubUsername: "scopeuser", Role: "user"}
+	if err := store.UpsertUser(ctx, user); err != nil {
+		t.Fatal(err)
+	}
+
+	pt := &ProxyToken{
+		TokenHash:    "contract_hash_scopes_001",
+		TokenPrefix:  "ghx_sc1",
+		TokenType:    "proxy",
+		UserID:       &user.ID,
+		Repositories: json.RawMessage(`["org/repo1"]`),
+		Scopes:       json.RawMessage(`{"contents":"read"}`),
+		ExpiresAt:    timePtr(time.Now().Add(24 * time.Hour)),
+	}
+	if err := store.CreateProxyToken(ctx, pt); err != nil {
+		t.Fatalf("CreateProxyToken: %v", err)
+	}
+
+	newRepos := json.RawMessage(`["org/repo1","org/repo2"]`)
+	newScopes := json.RawMessage(`{"contents":"write","pull_requests":"read"}`)
+	if err := store.UpdateProxyTokenScopes(ctx, pt.ID, newRepos, newScopes); err != nil {
+		t.Fatalf("UpdateProxyTokenScopes: %v", err)
+	}
+
+	got, err := store.GetProxyTokenByHash(ctx, "contract_hash_scopes_001")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var gotRepos []string
+	if err := json.Unmarshal(got.Repositories, &gotRepos); err != nil {
+		t.Fatalf("unmarshal repositories: %v", err)
+	}
+	if len(gotRepos) != 2 || gotRepos[0] != "org/repo1" || gotRepos[1] != "org/repo2" {
+		t.Errorf("repositories = %v, want [org/repo1 org/repo2]", gotRepos)
+	}
+
+	var gotScopes map[string]string
+	if err := json.Unmarshal(got.Scopes, &gotScopes); err != nil {
+		t.Fatalf("unmarshal scopes: %v", err)
+	}
+	if gotScopes["contents"] != "write" {
+		t.Errorf("scopes[contents] = %q, want write", gotScopes["contents"])
+	}
+	if gotScopes["pull_requests"] != "read" {
+		t.Errorf("scopes[pull_requests] = %q, want read", gotScopes["pull_requests"])
+	}
+
+	// Clear to open-scoped (empty arrays/objects).
+	if err := store.UpdateProxyTokenScopes(ctx, pt.ID, json.RawMessage(`[]`), json.RawMessage(`{}`)); err != nil {
+		t.Fatalf("UpdateProxyTokenScopes (clear): %v", err)
+	}
+	got2, err := store.GetProxyTokenByHash(ctx, "contract_hash_scopes_001")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var clearedRepos []string
+	if err := json.Unmarshal(got2.Repositories, &clearedRepos); err != nil {
+		t.Fatalf("unmarshal cleared repositories: %v", err)
+	}
+	if len(clearedRepos) != 0 {
+		t.Errorf("expected empty repositories after clear, got %v", clearedRepos)
+	}
+
+	// ErrNotFound for missing token.
+	err = store.UpdateProxyTokenScopes(ctx, "00000000-0000-0000-0000-000000000000", newRepos, newScopes)
+	if !errors.Is(err, ErrNotFound) {
+		t.Errorf("expected ErrNotFound for missing token, got: %v", err)
 	}
 }
 

--- a/internal/database/vault.go
+++ b/internal/database/vault.go
@@ -718,6 +718,19 @@ func (s *VaultStore) UpdateProxyTokenAppID(ctx context.Context, id string, appID
 	return s.writeProxyToken(ctx, token)
 }
 
+func (s *VaultStore) UpdateProxyTokenScopes(ctx context.Context, id string, repositories json.RawMessage, scopes json.RawMessage) error {
+	token, err := s.GetProxyTokenByID(ctx, id)
+	if err != nil {
+		return err
+	}
+	if token == nil {
+		return fmt.Errorf("proxy token %s: %w", id, ErrNotFound)
+	}
+	token.Repositories = repositories
+	token.Scopes = scopes
+	return s.writeProxyToken(ctx, token)
+}
+
 func (s *VaultStore) DeleteExpiredProxyTokens(ctx context.Context, olderThan time.Duration) (int64, error) {
 	if olderThan <= 0 {
 		return 0, fmt.Errorf("DeleteExpiredProxyTokens: olderThan must be positive, got %v", olderThan)

--- a/internal/github/registry_test.go
+++ b/internal/github/registry_test.go
@@ -2,6 +2,7 @@ package github
 
 import (
 	"context"
+	"encoding/json"
 	"log/slog"
 	"testing"
 	"time"
@@ -68,6 +69,9 @@ func (m *mockStore) ListActiveProxyTokens(ctx context.Context) ([]*database.Prox
 }
 func (m *mockStore) RevokeProxyToken(ctx context.Context, id string) error { panic("unexpected") }
 func (m *mockStore) UpdateProxyTokenAppID(ctx context.Context, id string, appID string) error {
+	panic("unexpected")
+}
+func (m *mockStore) UpdateProxyTokenScopes(_ context.Context, _ string, _ json.RawMessage, _ json.RawMessage) error {
 	panic("unexpected")
 }
 func (m *mockStore) DeleteExpiredProxyTokens(_ context.Context, _ time.Duration) (int64, error) {

--- a/internal/server/api.go
+++ b/internal/server/api.go
@@ -130,6 +130,7 @@ func (a *API) RegisterRoutes(mux *http.ServeMux) {
 	mux.Handle("GET /api/tokens", a.authHandler.RequireAuth(http.HandlerFunc(a.handleListTokens)))
 	mux.Handle("GET /api/tokens/{id}", a.authHandler.RequireAuth(http.HandlerFunc(a.handleGetToken)))
 	mux.Handle("DELETE /api/tokens/{id}", a.authHandler.RequireAuth(http.HandlerFunc(a.handleRevokeToken)))
+	mux.Handle("PATCH /api/tokens/{id}", a.authHandler.RequireAdmin(http.HandlerFunc(a.handleUpdateTokenScopes)))
 
 	mux.Handle("GET /api/users", a.authHandler.RequireAdmin(http.HandlerFunc(a.handleListUsers)))
 	mux.Handle("GET /api/users/{id}/tokens", a.authHandler.RequireAdmin(http.HandlerFunc(a.handleListUserTokens)))
@@ -445,6 +446,103 @@ func (a *API) handleRevokeToken(w http.ResponseWriter, r *http.Request) {
 	a.logger.Info("token_revoked", "user", session.Username, "token_id", id)
 
 	writeJSON(w, http.StatusOK, map[string]string{"message": "Token revoked"})
+}
+
+type updateTokenScopesRequest struct {
+	Repositories *[]string         `json:"repositories"`
+	Scopes       *map[string]string `json:"scopes"`
+}
+
+func (a *API) handleUpdateTokenScopes(w http.ResponseWriter, r *http.Request) {
+	session := auth.SessionFromContext(r.Context())
+	id := r.PathValue("id")
+
+	if !isValidUUID(id) {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"message": "Invalid token ID"})
+		return
+	}
+
+	r.Body = http.MaxBytesReader(w, r.Body, maxRequestBodySize)
+	var req updateTokenScopesRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		var maxErr *http.MaxBytesError
+		if errors.As(err, &maxErr) {
+			writeJSON(w, http.StatusRequestEntityTooLarge, map[string]string{"message": "Request body too large"})
+		} else {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"message": "Invalid request body"})
+		}
+		return
+	}
+
+	if req.Repositories == nil && req.Scopes == nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"message": "At least one of repositories or scopes must be provided"})
+		return
+	}
+
+	pt, err := a.store.GetProxyTokenByID(r.Context(), id)
+	if err != nil {
+		a.logger.Error("failed to get token for scope update", "error", err)
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"message": "Internal error"})
+		return
+	}
+	if pt == nil {
+		writeJSON(w, http.StatusNotFound, map[string]string{"message": "Token not found"})
+		return
+	}
+	if pt.RevokedAt != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"message": "Cannot update a revoked token"})
+		return
+	}
+
+	newRepos := pt.Repositories
+	if req.Repositories != nil {
+		enc, err := json.Marshal(*req.Repositories)
+		if err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"message": "Invalid repositories"})
+			return
+		}
+		newRepos = enc
+	}
+
+	newScopes := pt.Scopes
+	if req.Scopes != nil {
+		for perm, level := range *req.Scopes {
+			if level != "read" && level != "write" {
+				writeJSON(w, http.StatusBadRequest, map[string]string{"message": "Invalid scope level for " + perm + ": must be read or write"})
+				return
+			}
+		}
+		enc, err := json.Marshal(*req.Scopes)
+		if err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"message": "Invalid scopes"})
+			return
+		}
+		newScopes = enc
+	}
+
+	if err := a.store.UpdateProxyTokenScopes(r.Context(), id, newRepos, newScopes); err != nil {
+		a.logger.Error("failed to update token scopes", "error", err)
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"message": "Internal error"})
+		return
+	}
+
+	a.auditLog.writeEntry(&auditLogEntry{
+		Msg:       "audit event",
+		Action:    "token_scopes_updated",
+		UserID:    session.UserID,
+		Username:  session.Username,
+		TokenID:   id,
+		TokenType: pt.TokenType,
+	})
+
+	a.logger.Info("token_scopes_updated", "user", session.Username, "token_id", id)
+
+	updated, err := a.store.GetProxyTokenByID(r.Context(), id)
+	if err != nil || updated == nil {
+		writeJSON(w, http.StatusOK, map[string]string{"message": "Token scopes updated"})
+		return
+	}
+	writeJSON(w, http.StatusOK, updated)
 }
 
 func (a *API) handleListUsers(w http.ResponseWriter, r *http.Request) {

--- a/internal/server/api.go
+++ b/internal/server/api.go
@@ -490,7 +490,7 @@ func (a *API) handleUpdateTokenScopes(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if pt.RevokedAt != nil {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"message": "Cannot update a revoked token"})
+		writeJSON(w, http.StatusConflict, map[string]string{"message": "Cannot update a revoked token"})
 		return
 	}
 
@@ -521,10 +521,15 @@ func (a *API) handleUpdateTokenScopes(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := a.store.UpdateProxyTokenScopes(r.Context(), id, newRepos, newScopes); err != nil {
+		if errors.Is(err, database.ErrNotFound) {
+			writeJSON(w, http.StatusNotFound, map[string]string{"message": "Token not found"})
+			return
+		}
 		a.logger.Error("failed to update token scopes", "error", err)
 		writeJSON(w, http.StatusInternalServerError, map[string]string{"message": "Internal error"})
 		return
 	}
+	a.tokenService.InvalidateByID(id)
 
 	a.auditLog.writeEntry(&auditLogEntry{
 		Msg:       "audit event",

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/goodtune/ghp/internal/config"
 	"github.com/goodtune/ghp/internal/database"
 	ghpgithub "github.com/goodtune/ghp/internal/github"
+	"github.com/goodtune/ghp/internal/token"
 )
 
 func TestHandleCreateToken_BodyTooLarge(t *testing.T) {
@@ -555,5 +556,146 @@ func TestCachedRepos_DuplicateCreate409(t *testing.T) {
 	a.handleCreateCachedRepo(w, req)
 	if w.Code != http.StatusConflict {
 		t.Fatalf("duplicate create: expected %d, got %d: %s", http.StatusConflict, w.Code, w.Body.String())
+	}
+}
+
+func timePtrServer(t time.Time) *time.Time { return &t }
+
+// newTestAPIFull builds an API with a real SQLite store, token service, and
+// discard audit log — enough to test handlers that touch all three.
+func newTestAPIFull(t *testing.T) *API {
+	t.Helper()
+	store, err := database.NewSQLiteStore(":memory:")
+	if err != nil {
+		t.Fatalf("create test store: %v", err)
+	}
+	migrator := database.NewMigrator(store, "sqlite")
+	if err := migrator.Migrate(context.Background()); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	ts := token.NewService(store, 24*time.Hour, false)
+	return &API{
+		store:        store,
+		tokenService: ts,
+		auditLog:     newAuditLogWriter(io.Discard),
+		logger:       slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+}
+
+func TestHandleUpdateTokenScopes_InvalidUUID(t *testing.T) {
+	a := &API{}
+	req := httptest.NewRequest("PATCH", "/api/tokens/not-a-uuid", strings.NewReader(`{"repositories":[]}`))
+	req.SetPathValue("id", "not-a-uuid")
+	req = req.WithContext(auth.NewContextWithSession(req.Context(), adminSession()))
+	w := httptest.NewRecorder()
+	a.handleUpdateTokenScopes(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestHandleUpdateTokenScopes_NotFound(t *testing.T) {
+	a := newTestAPIFull(t)
+	body := strings.NewReader(`{"repositories":["org/repo"]}`)
+	req := httptest.NewRequest("PATCH", "/api/tokens/00000000-0000-0000-0000-000000000000", body)
+	req.SetPathValue("id", "00000000-0000-0000-0000-000000000000")
+	req = req.WithContext(auth.NewContextWithSession(req.Context(), adminSession()))
+	w := httptest.NewRecorder()
+	a.handleUpdateTokenScopes(w, req)
+	if w.Code != http.StatusNotFound {
+		t.Errorf("expected 404, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestHandleUpdateTokenScopes_InvalidScopeLevel(t *testing.T) {
+	a := newTestAPIFull(t)
+
+	exp := timePtrServer(time.Now().Add(time.Hour))
+	pt := &database.ProxyToken{
+		TokenHash:   "hash_scope_level_test",
+		TokenPrefix: "ghx_sl1",
+		TokenType:   "proxy",
+		ExpiresAt:   exp,
+	}
+	if err := a.store.CreateProxyToken(context.Background(), pt); err != nil {
+		t.Fatalf("create token: %v", err)
+	}
+
+	body := strings.NewReader(`{"scopes":{"contents":"admin"}}`)
+	req := httptest.NewRequest("PATCH", "/api/tokens/"+pt.ID, body)
+	req.SetPathValue("id", pt.ID)
+	req = req.WithContext(auth.NewContextWithSession(req.Context(), adminSession()))
+	w := httptest.NewRecorder()
+	a.handleUpdateTokenScopes(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestHandleUpdateTokenScopes_RevokedToken(t *testing.T) {
+	a := newTestAPIFull(t)
+
+	exp := timePtrServer(time.Now().Add(time.Hour))
+	pt := &database.ProxyToken{
+		TokenHash:   "hash_revoked_scope_test",
+		TokenPrefix: "ghx_rv1",
+		TokenType:   "proxy",
+		ExpiresAt:   exp,
+	}
+	if err := a.store.CreateProxyToken(context.Background(), pt); err != nil {
+		t.Fatalf("create token: %v", err)
+	}
+	if err := a.store.RevokeProxyToken(context.Background(), pt.ID); err != nil {
+		t.Fatalf("revoke token: %v", err)
+	}
+
+	body := strings.NewReader(`{"repositories":["org/repo"]}`)
+	req := httptest.NewRequest("PATCH", "/api/tokens/"+pt.ID, body)
+	req.SetPathValue("id", pt.ID)
+	req = req.WithContext(auth.NewContextWithSession(req.Context(), adminSession()))
+	w := httptest.NewRecorder()
+	a.handleUpdateTokenScopes(w, req)
+	if w.Code != http.StatusConflict {
+		t.Errorf("expected 409, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestHandleUpdateTokenScopes_HappyPath(t *testing.T) {
+	a := newTestAPIFull(t)
+
+	exp := timePtrServer(time.Now().Add(time.Hour))
+	pt := &database.ProxyToken{
+		TokenHash:    "hash_scope_update_ok",
+		TokenPrefix:  "ghx_ok1",
+		TokenType:    "proxy",
+		Repositories: json.RawMessage(`["org/old"]`),
+		Scopes:       json.RawMessage(`{"contents":"read"}`),
+		ExpiresAt:    exp,
+	}
+	if err := a.store.CreateProxyToken(context.Background(), pt); err != nil {
+		t.Fatalf("create token: %v", err)
+	}
+
+	body := strings.NewReader(`{"repositories":["org/new"],"scopes":{"contents":"write"}}`)
+	req := httptest.NewRequest("PATCH", "/api/tokens/"+pt.ID, body)
+	req.SetPathValue("id", pt.ID)
+	req = req.WithContext(auth.NewContextWithSession(req.Context(), adminSession()))
+	w := httptest.NewRecorder()
+	a.handleUpdateTokenScopes(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp map[string]interface{}
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	repos, _ := resp["repositories"].([]interface{})
+	if len(repos) != 1 || repos[0] != "org/new" {
+		t.Errorf("repositories = %v, want [org/new]", repos)
+	}
+	scopes, _ := resp["scopes"].(map[string]interface{})
+	if scopes["contents"] != "write" {
+		t.Errorf("scopes[contents] = %v, want write", scopes["contents"])
 	}
 }

--- a/internal/token/cache_test.go
+++ b/internal/token/cache_test.go
@@ -60,6 +60,7 @@ func (m *mockStore) GetProxyTokenByID(_ context.Context, _ string) (*database.Pr
 func (m *mockStore) ListProxyTokens(_ context.Context, _ string) ([]*database.ProxyToken, error)   { return nil, nil }
 func (m *mockStore) ListAllProxyTokens(_ context.Context) ([]*database.ProxyToken, error)          { return nil, nil }
 func (m *mockStore) UpdateProxyTokenAppID(_ context.Context, _ string, _ string) error              { return nil }
+func (m *mockStore) UpdateProxyTokenScopes(_ context.Context, _ string, _ json.RawMessage, _ json.RawMessage) error { return nil }
 func (m *mockStore) DeleteExpiredProxyTokens(_ context.Context, _ time.Duration) (int64, error)     { return 0, nil }
 func (m *mockStore) GetDefaultApp(_ context.Context) (*database.App, error)                        { return nil, nil }
 func (m *mockStore) SetDefaultApp(_ context.Context, _ string) error                              { return nil }

--- a/internal/token/token.go
+++ b/internal/token/token.go
@@ -320,6 +320,15 @@ func (s *Service) Revoke(ctx context.Context, id string) error {
 	return nil
 }
 
+// InvalidateByID removes a token from the in-memory cache by its ID so that
+// the next request re-reads the updated record from the store. Used after
+// scope updates where the token remains valid but its fields have changed.
+func (s *Service) InvalidateByID(id string) {
+	if hashVal, ok := s.idToHash.LoadAndDelete(id); ok {
+		s.tokenCache.Delete(hashVal.(string))
+	}
+}
+
 // cacheToken stores a proxy token in the in-memory cache and records the
 // id→hash mapping so Revoke can invalidate by ID.
 func (s *Service) cacheToken(hash string, pt *database.ProxyToken) {

--- a/internal/web/middleware_test.go
+++ b/internal/web/middleware_test.go
@@ -3,6 +3,7 @@ package web
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
@@ -221,6 +222,7 @@ func (noopStore) ListAllProxyTokens(_ context.Context) ([]*database.ProxyToken, 
 func (noopStore) ListActiveProxyTokens(_ context.Context) ([]*database.ProxyToken, error)       { return nil, nil }
 func (noopStore) RevokeProxyToken(_ context.Context, _ string) error                            { return nil }
 func (noopStore) UpdateProxyTokenAppID(_ context.Context, _ string, _ string) error             { return nil }
+func (noopStore) UpdateProxyTokenScopes(_ context.Context, _ string, _ json.RawMessage, _ json.RawMessage) error { return nil }
 func (noopStore) DeleteExpiredProxyTokens(_ context.Context, _ time.Duration) (int64, error)    { return 0, nil }
 func (noopStore) CreateCachedRepository(_ context.Context, _ *database.CachedRepository) error  { return nil }
 func (noopStore) GetCachedRepositoryByID(_ context.Context, _ string) (*database.CachedRepository, error) {

--- a/internal/web/templates/admin.html
+++ b/internal/web/templates/admin.html
@@ -770,7 +770,7 @@
                 alert('Failed to revoke token: ' + e.message);
                 return;
             }
-            loadAllTokens();
+            reloadCurrentTokenView();
         }
 
         function editToken(id, reposJson, scopesJson) {

--- a/internal/web/templates/admin.html
+++ b/internal/web/templates/admin.html
@@ -666,7 +666,19 @@
             });
         }
 
+        // Tracks the current token view so edit-saves reload the right data.
+        let currentTokenView = { type: 'all' };
+
+        function reloadCurrentTokenView() {
+            if (currentTokenView.type === 'user') {
+                loadUserTokens(currentTokenView.userId, currentTokenView.username);
+            } else {
+                loadAllTokens();
+            }
+        }
+
         async function loadUserTokens(userId, username) {
+            currentTokenView = { type: 'user', userId, username };
             let tokens;
             try {
                 tokens = await api('GET', '/api/users/' + userId + '/tokens');
@@ -686,6 +698,7 @@
         }
 
         async function loadAllTokens() {
+            currentTokenView = { type: 'all' };
             let tokens;
             try {
                 tokens = await api('GET', '/api/tokens?all=true');
@@ -840,7 +853,7 @@
                 try {
                     await api('PATCH', '/api/tokens/' + id, { repositories: repoLines, scopes: parsedScopes });
                     editRow.remove();
-                    loadAllTokens();
+                    reloadCurrentTokenView();
                 } catch (e) {
                     errMsg.textContent = 'Failed to update token: ' + (e.message || 'Unknown error');
                     errMsg.style.display = 'block';

--- a/internal/web/templates/admin.html
+++ b/internal/web/templates/admin.html
@@ -708,6 +708,9 @@
             container.querySelectorAll('[data-revoke-token]').forEach(el => {
                 el.addEventListener('click', () => revokeToken(el.dataset.revokeToken));
             });
+            container.querySelectorAll('[data-edit-token]').forEach(el => {
+                el.addEventListener('click', () => editToken(el.dataset.editToken, el.dataset.tokenRepos, el.dataset.tokenScopes));
+            });
         }
 
         function renderTokenTable(tokens) {
@@ -722,7 +725,9 @@
 
                 const scopes = (t.scopes && typeof t.scopes === 'object' && Object.keys(t.scopes).length > 0) ? JSON.stringify(t.scopes) : (t.scopes || '(open)');
                 const repos = (Array.isArray(t.repositories) && t.repositories.length > 0) ? t.repositories.join(', ') : '(open)';
-                html += '<tr>';
+                const reposJson = JSON.stringify(Array.isArray(t.repositories) ? t.repositories : []);
+                const scopesJson = JSON.stringify((t.scopes && typeof t.scopes === 'object') ? t.scopes : {});
+                html += '<tr data-token-id="' + esc(t.id) + '">';
                 html += '<td>' + esc(t.token_prefix) + '...</td>';
                 html += '<td>' + esc(t.token_type || 'proxy') + '</td>';
                 html += '<td>' + esc(repos) + '</td>';
@@ -730,7 +735,14 @@
                 html += '<td>' + esc(t.session_id || '-') + '</td>';
                 html += '<td><span class="badge ' + badge + '">' + status + '</span></td>';
                 html += '<td>' + (expires ? expires.toLocaleString() : 'Never') + '</td>';
-                html += '<td>' + (status === 'Active' ? '<button class="btn btn-danger" data-revoke-token="' + esc(t.id) + '">Revoke</button>' : '') + '</td>';
+                if (status === 'Active') {
+                    html += '<td>'
+                        + '<button class="btn btn-secondary" style="margin-right:0.25rem" data-edit-token="' + esc(t.id) + '" data-token-repos="' + esc(reposJson) + '" data-token-scopes="' + esc(scopesJson) + '">Edit</button>'
+                        + '<button class="btn btn-danger" data-revoke-token="' + esc(t.id) + '">Revoke</button>'
+                        + '</td>';
+                } else {
+                    html += '<td></td>';
+                }
                 html += '</tr>';
             }
             html += '</table>';
@@ -746,6 +758,105 @@
                 return;
             }
             loadAllTokens();
+        }
+
+        function editToken(id, reposJson, scopesJson) {
+            // Remove any existing edit row.
+            const existing = document.getElementById('edit-token-row');
+            if (existing) existing.remove();
+
+            let currentRepos, currentScopes;
+            try { currentRepos = JSON.parse(reposJson); } catch { currentRepos = []; }
+            try { currentScopes = JSON.parse(scopesJson); } catch { currentScopes = {}; }
+
+            const tokenRow = document.querySelector('[data-token-id="' + CSS.escape(id) + '"]');
+            if (!tokenRow) return;
+
+            const editRow = document.createElement('tr');
+            editRow.id = 'edit-token-row';
+            const editCell = document.createElement('td');
+            editCell.colSpan = 8;
+            editCell.style.background = '#161b22';
+            editCell.style.padding = '1rem';
+
+            const reposLabel = document.createElement('label');
+            reposLabel.textContent = 'Repositories (one per line, leave empty for open-scoped)';
+            reposLabel.style.cssText = 'display:block;margin-bottom:0.25rem;font-size:0.875rem;color:#8b949e;';
+            const reposInput = document.createElement('textarea');
+            reposInput.rows = 4;
+            reposInput.value = currentRepos.join('\n');
+            reposInput.placeholder = 'org/repo\norg/another-repo';
+            reposInput.style.cssText = 'width:100%;padding:0.5rem;background:#0d1117;border:1px solid #30363d;border-radius:6px;color:#c9d1d9;font-size:0.875rem;font-family:monospace;margin-bottom:0.75rem;';
+
+            const scopesLabel = document.createElement('label');
+            scopesLabel.textContent = 'Scopes (JSON object, e.g. {"contents":"read"}, leave empty {} for open-scoped)';
+            scopesLabel.style.cssText = 'display:block;margin-bottom:0.25rem;font-size:0.875rem;color:#8b949e;';
+            const scopesInput = document.createElement('textarea');
+            scopesInput.rows = 4;
+            scopesInput.value = Object.keys(currentScopes).length > 0 ? JSON.stringify(currentScopes, null, 2) : '';
+            scopesInput.placeholder = '{\n  "contents": "read",\n  "pull_requests": "write"\n}';
+            scopesInput.style.cssText = 'width:100%;padding:0.5rem;background:#0d1117;border:1px solid #30363d;border-radius:6px;color:#c9d1d9;font-size:0.875rem;font-family:monospace;margin-bottom:0.75rem;';
+
+            const errMsg = document.createElement('div');
+            errMsg.style.cssText = 'color:#f85149;margin-bottom:0.5rem;display:none;';
+
+            const btnRow = document.createElement('div');
+            btnRow.style.display = 'flex';
+            btnRow.style.gap = '0.5rem';
+
+            const saveBtn = document.createElement('button');
+            saveBtn.className = 'btn';
+            saveBtn.textContent = 'Save';
+
+            const cancelBtn = document.createElement('button');
+            cancelBtn.className = 'btn btn-secondary';
+            cancelBtn.textContent = 'Cancel';
+            cancelBtn.addEventListener('click', () => editRow.remove());
+
+            btnRow.appendChild(saveBtn);
+            btnRow.appendChild(cancelBtn);
+
+            saveBtn.addEventListener('click', async () => {
+                errMsg.style.display = 'none';
+
+                const repoLines = reposInput.value.split('\n').map(s => s.trim()).filter(Boolean);
+                let parsedScopes;
+                const rawScopes = scopesInput.value.trim();
+                if (rawScopes === '' || rawScopes === '{}') {
+                    parsedScopes = {};
+                } else {
+                    try {
+                        parsedScopes = JSON.parse(rawScopes);
+                        if (typeof parsedScopes !== 'object' || Array.isArray(parsedScopes)) throw new Error('Must be a JSON object');
+                    } catch (e) {
+                        errMsg.textContent = 'Invalid scopes JSON: ' + e.message;
+                        errMsg.style.display = 'block';
+                        return;
+                    }
+                }
+
+                saveBtn.textContent = 'Saving…';
+                saveBtn.disabled = true;
+                try {
+                    await api('PATCH', '/api/tokens/' + id, { repositories: repoLines, scopes: parsedScopes });
+                    editRow.remove();
+                    loadAllTokens();
+                } catch (e) {
+                    errMsg.textContent = 'Failed to update token: ' + (e.message || 'Unknown error');
+                    errMsg.style.display = 'block';
+                    saveBtn.textContent = 'Save';
+                    saveBtn.disabled = false;
+                }
+            });
+
+            editCell.appendChild(reposLabel);
+            editCell.appendChild(reposInput);
+            editCell.appendChild(scopesLabel);
+            editCell.appendChild(scopesInput);
+            editCell.appendChild(errMsg);
+            editCell.appendChild(btnRow);
+            editRow.appendChild(editCell);
+            tokenRow.after(editRow);
         }
 
         // ── Cached Repositories ─────────────────────────────────────

--- a/internal/web/templates/admin.html
+++ b/internal/web/templates/admin.html
@@ -723,7 +723,7 @@
                 else if (expires && expires < now) { status = 'Expired'; badge = 'badge-expired'; }
                 else { status = 'Active'; badge = 'badge-active'; }
 
-                const scopes = (t.scopes && typeof t.scopes === 'object' && Object.keys(t.scopes).length > 0) ? JSON.stringify(t.scopes) : (t.scopes || '(open)');
+                const scopes = (t.scopes && typeof t.scopes === 'object' && Object.keys(t.scopes).length > 0) ? JSON.stringify(t.scopes) : '(open)';
                 const repos = (Array.isArray(t.repositories) && t.repositories.length > 0) ? t.repositories.join(', ') : '(open)';
                 const reposJson = JSON.stringify(Array.isArray(t.repositories) ? t.repositories : []);
                 const scopesJson = JSON.stringify((t.scopes && typeof t.scopes === 'object') ? t.scopes : {});


### PR DESCRIPTION
## Summary

- Adds `PATCH /api/tokens/{id}` endpoint (admin-only) to rescope an existing proxy token's repositories and/or permission grants without revoking and recreating it
- New `UpdateProxyTokenScopes` store method across SQLite, Postgres, and Vault backends; returns `ErrNotFound` for missing tokens
- Admin UI gains an "Edit" button on active tokens in the All Tokens table — opens an inline form to edit repositories (one per line) and scopes (JSON object) with client-side JSON validation before submit and error display on failure
- Contract tests cover: field round-trip, clear-to-open-scoped, `ErrNotFound` path

## Test plan

- [ ] `go test ./internal/database/... ./internal/server/...` passes
- [ ] Admin UI: edit button appears on active (non-revoked) tokens
- [ ] Repositories and scope object update correctly on save
- [ ] Revoked tokens are blocked (API returns 409)
- [ ] Malformed UUID or missing scope level returns 400

Closes TOU-84

🤖 Generated with [Claude Code](https://claude.com/claude-code)