### PR TITLE
feat(proxy): downscope GraphQL via deny-by-default static analysis

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -240,6 +240,61 @@ When working on `internal/github/registry.go`:
 - **Distinguish "no apps in store" from "apps exist but none loaded."** Expose both `Count()` (loaded providers) and `TotalApps()` (store records). Config-based fallback should only activate when the store genuinely has zero app records and `LoadAll` succeeded — never as a silent fallback when apps failed to load.
 - **Reject agent token creation when no usable provider exists.** If `TotalApps() > 0` but `Count() == 0` (all apps failed to load), return 503 rather than creating tokens that will fail at use-time.
 
+## GraphQL Scope Mapping
+
+`internal/proxy/graphql.go` enforces token scopes on `/graphql` requests via static analysis. The analyzer is **deny-by-default**: any field it cannot classify against the curated tables below produces a 403. When a legitimate query is rejected, the fix is almost always to add the field name to the right table — not to relax the analyzer.
+
+### The four tables
+
+| Table | Purpose | Add to it when… |
+|---|---|---|
+| `alwaysAllowedFields` | Metadata fields that need no scope (names, ids, urls, timestamps, pagination helpers, the bare root selectors `viewer`/`repository`/`organization`/`user`, etc.) | The field exposes only metadata that GitHub returns under any installation's metadata read. |
+| `fieldScopeRequirements` | Maps a query/read field name → `{permission, level}`. | The field exposes a permission-gated **read** resource (e.g. `pullRequests` → `pull_requests:read`, `discussions` → `discussions:read`). |
+| `mutationScopeRequirements` | Maps a top-level mutation name → `{permission, "write"}`. | A new mutation surfaces (e.g. `createIssue` → `issues:write`). Unmapped mutation root fields are denied — the proxy never grants a write scope it can't classify. |
+| `crossRepoAnywhereFields` / `crossRepoRootOnlyFields` | Field names that can leak data from outside the repository allowlist (`search`, `viewer.repositories`, root-level `node(id:)`, …). `*RootOnly` is for names that are cross-repo only at the operation root (e.g. `node`/`nodes`/`resource`); nested `Connection.nodes` is a benign helper and lives in `alwaysAllowedFields`. | The field can return repositories/objects the analyzer cannot statically pin to a `repository(owner, name)` selection. Repo-scoped tokens are rejected when any cross-repo field appears. |
+
+### How the analyzer decides
+
+For each field walked:
+
+1. **Mutation root field** (mutation operation, `atRoot==true`): looked up in `mutationScopeRequirements`. Hit → record the scope. Miss → flagged as unknown (denied).
+2. **Otherwise** the field is checked against the tables in this order:
+   1. `alwaysAllowedFields` — pass with no scope requirement.
+   2. `fieldScopeRequirements` — record the scope.
+   3. **Scalar leaf** (no selection set): permitted at non-root; denied at root (no parent scope to gate it).
+   4. **Object-typed field** (has a selection set) that fell through all of the above: flagged as unknown (denied).
+3. **Cross-repo check** runs in parallel — `crossRepoAnywhereFields` always; `crossRepoRootOnlyFields` only when `atRoot==true`.
+4. **Repository pinning** — `repository(owner, name)` with both arguments as **literal strings** records the repo. With non-literal args (variable, missing) it sets `hasUnpinnedRepositoryLookup`, which fails the request for repo-scoped tokens. A bare `repository` with **no arguments** (e.g. `Issue.repository`) is a nested type accessor, not a lookup, and is ignored.
+
+The lookup is **by field name only** — the analyzer doesn't load GitHub's SDL. Where the same name on different parent types could mean different things, err toward the stricter scope.
+
+### Workflow when a query is denied
+
+The 403 response names the fields the proxy could not classify (capped at `maxRenderedFieldNames` entries). To allow it:
+
+1. Identify the field from the message — `unmapped fields: <name>` or `cross-repository fields: <name>`.
+2. Decide which table fits per the table above. When in doubt, prefer the **stricter** mapping; demoting later is cheaper than an unintended bypass.
+3. Add the entry to the right map in `internal/proxy/graphql.go` (alphabetical within its section).
+4. Add a test in `internal/proxy/graphql_test.go`. Existing patterns to copy:
+   - `TestAnalyzeGraphQLRequest_PullRequestRequiresScope` — analyzer-level scope assertion for a query field.
+   - `TestAnalyzeGraphQLRequest_MutationRequiresWriteScope` — analyzer-level scope assertion for a mutation.
+   - `TestServeHTTP_GraphQL_PermissionScoped_*` — handler-level allow/deny.
+   - `TestServeHTTP_GraphQL_RepoScoped_*` — handler-level repo enforcement (use these for cross-repo additions).
+5. Do **not** widen the analyzer's defaults (e.g. don't allow scalar leaves at root, don't exempt `__*` fields, don't drop the `hasUnpinnedRepositoryLookup` check). The deny-by-default posture is the security model — the maps are the lever.
+
+### Things to never silently do
+
+- **Never** add a write-capable field to `alwaysAllowedFields`. That table is metadata-only.
+- **Never** add a mutation to `fieldScopeRequirements` (it's checked only for non-mutation paths). Mutations belong in `mutationScopeRequirements`.
+- **Never** skip the cross-repo classification just because a field also has a scope mapping. A field can require a scope **and** be cross-repo (e.g. `search` requires no specific scope but is cross-repo).
+- **Never** loosen `repositoryArgs` to accept variables. Variable-driven repo lookups can't be allowlist-checked; that's the whole point of `hasUnpinnedRepositoryLookup`.
+
+### When the user-facing docs need updating
+
+`docs/features/token-scoping.md` has a known-limitations section. Update it when:
+- A trade-off changes (currently: scalar leaves under always-allowed parents are not deny-by-default, repo-scoped GraphQL mutations are not supported).
+- A new class of field is added that operators may run into (e.g. a new cross-repo field).
+
 ## CI
 
 PRs trigger the Test workflow (`.github/workflows/test.yml`):

--- a/docs/features/token-scoping.md
+++ b/docs/features/token-scoping.md
@@ -130,6 +130,21 @@ fields" message can use the named field as a hint for extending
 `fieldScopeRequirements` or `mutationScopeRequirements` in
 `internal/proxy/graphql.go` to cover legitimate use cases.
 
+### Known limitations
+
+- **Scalar leaves under always-allowed parents are not deny-by-default.**
+  Without loading GitHub's full SDL the proxy cannot enumerate every
+  scalar field name, so unmapped scalars projected directly under an
+  always-allowed parent (e.g. `repository(owner, name) { someScalar }`)
+  pass static analysis. The risk is bounded by the underlying
+  credential's permissions and by GitHub's own access checks; operators
+  who need stricter enforcement should map the affected scalar in
+  `fieldScopeRequirements` or use REST scoping for the affected flow.
+- **Repository-restricted GraphQL mutations are not supported.** GitHub
+  mutation inputs identify their target by opaque global node ID
+  (`repositoryId`), which the proxy cannot statically map to a
+  repository. Use the REST API or a permission-only token instead.
+
 ## Expiration and Revocation
 
 All tokens have a configurable lifetime. The default is 24 hours, with a

--- a/docs/features/token-scoping.md
+++ b/docs/features/token-scoping.md
@@ -81,7 +81,7 @@ and `--scope` flags.
 ghp enforces token scopes on GraphQL requests for repository-restricted
 and/or permission-restricted tokens via static analysis of the incoming
 query. For those scoped-token requests the body is parsed (using
-`vektah/gqlparser`) and walked to extract three things:
+`github.com/vektah/gqlparser/v2`) and walked to extract three things:
 
 - **Required permission scopes**, derived from a curated map of
   `Mutation.<field>` and field-name → scope mappings (e.g.

--- a/docs/features/token-scoping.md
+++ b/docs/features/token-scoping.md
@@ -108,7 +108,7 @@ The proxy uses the analysis to apply a deny-by-default policy:
   does not support them over HTTP, and the proxy cannot stream-scope
   per-event payloads.
 - **Unknown object-typed fields** (fields with their own selection set that
-  do not appear in the allow-list or scope map) are rejected for any
+  do not appear in the allowlist or scope map) are rejected for any
   scoped token. Scalar leaves are permitted without a per-field mapping
   because their parent field's scope already gates them.
 

--- a/docs/features/token-scoping.md
+++ b/docs/features/token-scoping.md
@@ -119,11 +119,16 @@ The proxy uses the analysis to apply a deny-by-default policy:
   because their parent field's scope already gates them.
 
 Variable-driven repository lookups (`repository(owner: $owner, ...)`) cannot
-be statically validated; the analyzer treats them as if no repository was
-referenced, so a repository-restricted token must use literal arguments. For
-requests that go through GraphQL static analysis the request body is capped
-at 1 MiB to bound memory usage. Open-scoped tokens bypass static analysis,
-so this cap does not apply to them.
+be statically validated against a token's repository allowlist. For
+repository-restricted tokens, the proxy rejects any request that contains
+even one such variable-driven `repository(...)` selection, even if other
+literal allowlisted lookups are present in the same query — otherwise an
+attacker could mix one literal allowlisted lookup with an unbounded
+variable-driven lookup that bypasses the allowlist. Tokens with no
+repository restriction (permission-only or open-scoped) are unaffected.
+For requests that go through GraphQL static analysis the request body is
+capped at 1 MiB to bound memory usage. Open-scoped tokens bypass static
+analysis, so this cap does not apply to them.
 
 Operators reading 403 responses with a "GraphQL request references unmapped
 fields" message can use the named field as a hint for extending

--- a/docs/features/token-scoping.md
+++ b/docs/features/token-scoping.md
@@ -76,18 +76,50 @@ an agent legitimately needs broad access and scoping would be too restrictive.
 Open-scoped tokens are the default for proxy tokens created without `--repo`
 and `--scope` flags.
 
-## GraphQL Limitation
+## GraphQL Scope Enforcement
 
-Tokens that are restricted to specific repositories cannot use the GraphQL API.
-GraphQL queries can span multiple repositories in a single request, and ghp
-cannot reliably enforce repository restrictions on GraphQL without parsing
-every query. Repository-restricted tokens that attempt a GraphQL request will
-receive a `403 Forbidden` response.
+ghp enforces token scopes on GraphQL requests via static analysis of the
+incoming query. Every request body is parsed (using `vektah/gqlparser`) and
+walked to extract three things:
 
-Open-scoped and permission-only tokens (no repository restriction) can use
-GraphQL, but ghp does not currently enforce permission scopes on GraphQL
-requests; the effective permissions are those of the underlying GitHub
-credential.
+- **Required permission scopes**, derived from a curated map of
+  `Mutation.<field>` and field-name → scope mappings (e.g.
+  `Mutation.createIssue` → `issues:write`, `pullRequests` → `pull_requests:read`).
+- **Referenced repositories**, extracted from `repository(owner, name)`
+  arguments where both arguments are string literals.
+- **Cross-repository fields** (e.g. `search`, `node`, `viewer.repositories`)
+  that can return data from outside any explicit `repository(...)` selection.
+
+The proxy uses the analysis to apply a deny-by-default policy:
+
+- **Open-scoped tokens** bypass GraphQL static analysis entirely; the
+  underlying credential's permissions remain the only enforcement layer.
+- **Repository-restricted tokens** must reference at least one
+  `repository(owner, name)` with literal arguments, and every referenced
+  repository must appear in the token's allowlist. Cross-repository fields
+  are rejected outright: ghp cannot statically prove their results stay
+  inside the allowlist.
+- **Permission-restricted tokens** must grant every scope the analysis
+  identifies. Mutations whose name does not appear in the curated mutation
+  map are rejected — the proxy never grants a write scope it cannot
+  classify.
+- **Subscriptions** are rejected unconditionally: GitHub's GraphQL endpoint
+  does not support them over HTTP, and the proxy cannot stream-scope
+  per-event payloads.
+- **Unknown object-typed fields** (fields with their own selection set that
+  do not appear in the allow-list or scope map) are rejected for any
+  scoped token. Scalar leaves are permitted without a per-field mapping
+  because their parent field's scope already gates them.
+
+Variable-driven repository lookups (`repository(owner: $owner, ...)`) cannot
+be statically validated; the analyzer treats them as if no repository was
+referenced, so a repository-restricted token must use literal arguments. The
+GraphQL request body is also capped at 1 MiB to bound memory usage.
+
+Operators reading 403 responses with a "GraphQL request references unmapped
+fields" message can use the named field as a hint for extending
+`fieldScopeRequirements` or `mutationScopeRequirements` in
+`internal/proxy/graphql.go` to cover legitimate use cases.
 
 ## Expiration and Revocation
 

--- a/docs/features/token-scoping.md
+++ b/docs/features/token-scoping.md
@@ -99,7 +99,13 @@ The proxy uses the analysis to apply a deny-by-default policy:
   `repository(owner, name)` with literal arguments, and every referenced
   repository must appear in the token's allowlist. Cross-repository fields
   are rejected outright: ghp cannot statically prove their results stay
-  inside the allowlist.
+  inside the allowlist. GraphQL mutations are also rejected for
+  repository-restricted tokens — GitHub's mutation inputs identify their
+  target with an opaque global node ID (`repositoryId`) rather than
+  `owner`/`name`, which the proxy cannot statically map to the
+  allowlist. Use the REST API for repo-scoped writes, or use a
+  permission-only token if mutations across multiple repositories are
+  required.
 - **Permission-restricted tokens** must grant every scope the analysis
   identifies. Mutations whose name does not appear in the curated mutation
   map are rejected — the proxy never grants a write scope it cannot

--- a/docs/features/token-scoping.md
+++ b/docs/features/token-scoping.md
@@ -113,8 +113,10 @@ The proxy uses the analysis to apply a deny-by-default policy:
 
 Variable-driven repository lookups (`repository(owner: $owner, ...)`) cannot
 be statically validated; the analyzer treats them as if no repository was
-referenced, so a repository-restricted token must use literal arguments. The
-GraphQL request body is also capped at 1 MiB to bound memory usage.
+referenced, so a repository-restricted token must use literal arguments. For
+requests that go through GraphQL static analysis the request body is capped
+at 1 MiB to bound memory usage. Open-scoped tokens bypass static analysis,
+so this cap does not apply to them.
 
 Operators reading 403 responses with a "GraphQL request references unmapped
 fields" message can use the named field as a hint for extending

--- a/docs/features/token-scoping.md
+++ b/docs/features/token-scoping.md
@@ -78,9 +78,10 @@ and `--scope` flags.
 
 ## GraphQL Scope Enforcement
 
-ghp enforces token scopes on GraphQL requests via static analysis of the
-incoming query. Every request body is parsed (using `vektah/gqlparser`) and
-walked to extract three things:
+ghp enforces token scopes on GraphQL requests for repository-restricted
+and/or permission-restricted tokens via static analysis of the incoming
+query. For those scoped-token requests the body is parsed (using
+`vektah/gqlparser`) and walked to extract three things:
 
 - **Required permission scopes**, derived from a curated map of
   `Mutation.<field>` and field-name → scope mappings (e.g.

--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	github.com/testcontainers/testcontainers-go v0.42.0
 	github.com/testcontainers/testcontainers-go/modules/postgres v0.42.0
 	github.com/testcontainers/testcontainers-go/modules/vault v0.42.0
+	github.com/vektah/gqlparser/v2 v2.5.33
 	golang.org/x/time v0.15.0
 	gopkg.in/yaml.v3 v3.0.1
 	modernc.org/sqlite v1.50.0

--- a/go.sum
+++ b/go.sum
@@ -9,6 +9,8 @@ github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERo
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/ProtonMail/go-crypto v1.1.6 h1:ZcV+Ropw6Qn0AX9brlQLAUXfqLBc7Bl+f/DmNxpLfdw=
 github.com/ProtonMail/go-crypto v1.1.6/go.mod h1:rA3QumHc/FZ8pAHreoekgiAbzpNsfQAosU5td4SnOrE=
+github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883 h1:bvNMNQO63//z+xNgfBlViaCIJKLlCJ6/fmUseuG0wVQ=
+github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883/go.mod h1:rCTlJbsFo29Kk6CurOXKm700vrz8f0KW0JNfpkRJY/8=
 github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be h1:9AeTilPcZAjCFIImctFaOjnTIavg87rW78vTPkQqLI8=
 github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be/go.mod h1:ySMOLuWl6zY27l47sB3qLNK6tF2fkHG55UZxx8oIVo4=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
@@ -275,6 +277,8 @@ github.com/tklauser/go-sysconf v0.3.16 h1:frioLaCQSsF5Cy1jgRBrzr6t502KIIwQ0MArYI
 github.com/tklauser/go-sysconf v0.3.16/go.mod h1:/qNL9xxDhc7tx3HSRsLWNnuzbVfh3e7gh/BmM179nYI=
 github.com/tklauser/numcpus v0.11.0 h1:nSTwhKH5e1dMNsCdVBukSZrURJRoHbSEQjdEbY+9RXw=
 github.com/tklauser/numcpus v0.11.0/go.mod h1:z+LwcLq54uWZTX0u/bGobaV34u6V7KNlTZejzM6/3MQ=
+github.com/vektah/gqlparser/v2 v2.5.33 h1:lRp8aIeNUNbimf/axZd7ETg24q06hBtPaas+TcvI/7E=
+github.com/vektah/gqlparser/v2 v2.5.33/go.mod h1:c1I28gSOVNzlfc4WuDlqU7voQnsqI6OG2amkBAFmgts=
 github.com/xanzy/ssh-agent v0.3.3 h1:+/15pJfg/RsTxqYcX6fHqOXZwwMP+2VyYWJeWM2qQFM=
 github.com/xanzy/ssh-agent v0.3.3/go.mod h1:6dzNDKs0J9rVPHPhaGCukekBHKqfl+L3KghI1Bc68Uw=
 github.com/yusufpapurcu/wmi v1.2.4 h1:zFUKzehAFReQwLys1b/iSMl+JQGSCSjtVqQn9bBrPo0=
@@ -372,8 +376,6 @@ modernc.org/opt v0.1.4 h1:2kNGMRiUjrp4LcaPuLY2PzUfqM/w9N23quVwhKt5Qm8=
 modernc.org/opt v0.1.4/go.mod h1:03fq9lsNfvkYSfxrfUhZCWPk1lm4cq4N+Bh//bEtgns=
 modernc.org/sortutil v1.2.1 h1:+xyoGf15mM3NMlPDnFqrteY07klSFxLElE2PVuWIJ7w=
 modernc.org/sortutil v1.2.1/go.mod h1:7ZI3a3REbai7gzCLcotuw9AC4VZVpYMjDzETGsSMqJE=
-modernc.org/sqlite v1.49.1 h1:dYGHTKcX1sJ+EQDnUzvz4TJ5GbuvhNJa8Fg6ElGx73U=
-modernc.org/sqlite v1.49.1/go.mod h1:m0w8xhwYUVY3H6pSDwc3gkJ/irZT/0YEXwBlhaxQEew=
 modernc.org/sqlite v1.50.0 h1:eMowQSWLK0MeiQTdmz3lqoF5dqclujdlIKeJA11+7oM=
 modernc.org/sqlite v1.50.0/go.mod h1:m0w8xhwYUVY3H6pSDwc3gkJ/irZT/0YEXwBlhaxQEew=
 modernc.org/strutil v1.2.1 h1:UneZBkQA+DX2Rp35KcM69cSsNES9ly8mQWD71HKlOA0=

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -156,6 +156,7 @@ var (
 	//   github_token_resolution – loading & decrypting (or refreshing) the real GitHub credential
 	//   upstream_roundtrip     – proxying the upstream GitHub request and streaming the response (network + GitHub processing + response body transfer)
 	//   redirect_head_check   – HEAD request to the release redirect target to verify asset availability (releases handler only)
+	//   graphql_analysis      – parsing a GraphQL request body and computing the static scope/repository requirements (GraphQL handler only)
 	ProxyDecisionDuration = promauto.NewHistogramVec(prometheus.HistogramOpts{
 		Name:    "ghp_proxy_decision_duration_seconds",
 		Help:    "Duration of each stage in the proxy decision pipeline.",
@@ -271,6 +272,7 @@ const (
 	StageUpstreamRoundtrip     = "upstream_roundtrip"
 	StageRedirectHeadCheck     = "redirect_head_check"
 	StageCacheLookup           = "cache_lookup"
+	StageGraphQLAnalysis       = "graphql_analysis"
 )
 
 // ObserveDecision records the duration of a single stage in the proxy

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -161,6 +161,7 @@ func TestObserveDecision_AllStages(t *testing.T) {
 		StageUpstreamRoundtrip,
 		StageRedirectHeadCheck,
 		StageCacheLookup,
+		StageGraphQLAnalysis,
 	}
 
 	for _, stage := range stages {

--- a/internal/proxy/graphql.go
+++ b/internal/proxy/graphql.go
@@ -578,24 +578,32 @@ func (a *gqlAnalyzer) walkField(f *ast.Field, inMutation, atRoot bool) {
 	} else if req, ok := fieldScopeRequirements[name]; ok {
 		a.seenScopes[req] = struct{}{}
 	} else if len(f.SelectionSet) == 0 {
-		// Scalar leaf with no children. The parent field has already
-		// established the access context — for object-typed parents
-		// mapped to a scope (e.g. `Repository.issues`) the parent
-		// scope gates the leaf; for always-allowed metadata parents
-		// (e.g. `repository`, `user`, `viewer`) the leaf is itself
-		// metadata-style. Treating every leaf as "unknown" would force
-		// the allowlist to enumerate every scalar field name in
-		// GitHub's schema (hundreds of entries), which is impractical
-		// without schema-aware validation.
+		if atRoot {
+			// Root-level scalar leaves have no parent field to
+			// establish an access context, so they must remain
+			// deny-by-default unless explicitly allow-listed or mapped
+			// to a scope.
+			a.seenUnknown[name] = struct{}{}
+		}
+		// Otherwise: a scalar leaf nested under an object parent. The
+		// parent field has already established the access context —
+		// for object-typed parents mapped to a scope (e.g.
+		// `Repository.issues`) the parent scope gates the leaf; for
+		// always-allowed metadata parents (e.g. `repository`, `user`,
+		// `viewer`) the leaf is itself metadata-style. Treating every
+		// nested leaf as "unknown" would force the allowlist to
+		// enumerate every scalar field name in GitHub's schema
+		// (hundreds of entries), which is impractical without
+		// schema-aware validation.
 		//
 		// The known trade-off: an unmapped scalar projected directly
 		// under an always-allowed parent is not flagged, even though
 		// in principle GitHub could one day expose a sensitive scalar
 		// at that position. The risk is bounded by what the underlying
 		// credential can read; operators who want stricter enforcement
-		// must either reject GraphQL for the affected token or
-		// extend `fieldScopeRequirements` to map the offending scalar
-		// to a permission. Object-typed fields (those with their own
+		// must either reject GraphQL for the affected token or extend
+		// `fieldScopeRequirements` to map the offending scalar to a
+		// permission. Object-typed fields (those with their own
 		// selection set) remain subject to deny-by-default below.
 	} else {
 		// Object-typed field with a selection set that does not appear in

--- a/internal/proxy/graphql.go
+++ b/internal/proxy/graphql.go
@@ -45,6 +45,15 @@ type graphQLAnalysis struct {
 	// allowlist. Scoped tokens are denied if this list is non-empty
 	// (deny-by-default). Open-scoped tokens ignore it.
 	unknownFields []string
+	// hasUnpinnedRepositoryLookup is true when a `repository(...)`
+	// selection used non-literal arguments (e.g. supplied via a GraphQL
+	// variable) and could not be statically pinned to an owner/name.
+	// Repository-restricted tokens must reject such requests even if the
+	// query also references at least one literal allowlisted repo —
+	// otherwise an attacker could mix one literal allowlisted lookup
+	// with an unbounded variable-driven lookup that bypasses the
+	// allowlist.
+	hasUnpinnedRepositoryLookup bool
 }
 
 // scopeRequirement is a single (permission, level) entry.
@@ -566,9 +575,16 @@ func (a *gqlAnalyzer) walkField(f *ast.Field, inMutation, atRoot bool, depth int
 	name := f.Name
 
 	// Capture repository(owner, name) arguments wherever the field appears.
+	// When the arguments are not statically analysable as literal strings
+	// (e.g. supplied via a variable), record the lookup as "unpinned" so
+	// repo-restricted tokens fail closed: otherwise an attacker could mix
+	// one literal allowlisted lookup with a variable-driven lookup and
+	// bypass the allowlist.
 	if name == "repository" {
 		if owner, repo := repositoryArgs(f); owner != "" && repo != "" {
 			a.seenRepos[owner+"/"+repo] = struct{}{}
+		} else {
+			a.result.hasUnpinnedRepositoryLookup = true
 		}
 	}
 

--- a/internal/proxy/graphql.go
+++ b/internal/proxy/graphql.go
@@ -27,11 +27,13 @@ type graphQLAnalysis struct {
 	// referencedRepos lists every "owner/name" pair that appears as the
 	// arguments to a `repository(owner, name)` selection in the query.
 	referencedRepos []string
-	// hasMutation is true when any operation in the document is a mutation.
+	// hasMutation is true when the operation selected for analysis (per
+	// the request's `operationName`, or the sole operation when omitted)
+	// is a mutation.
 	hasMutation bool
-	// hasSubscription is true when any operation in the document is a
-	// subscription (GitHub does not support GraphQL subscriptions over HTTP;
-	// the proxy rejects them outright).
+	// hasSubscription is true when the operation selected for analysis is
+	// a subscription. GitHub does not support GraphQL subscriptions over
+	// HTTP; the proxy rejects them outright.
 	hasSubscription bool
 	// crossRepoFields lists fields that can return data from repositories
 	// other than those pinned by `repository(owner, name)` (for example

--- a/internal/proxy/graphql.go
+++ b/internal/proxy/graphql.go
@@ -1,0 +1,585 @@
+package proxy
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/goodtune/ghp/internal/database"
+	"github.com/vektah/gqlparser/v2/ast"
+	"github.com/vektah/gqlparser/v2/parser"
+)
+
+// graphQLRequestBody is the JSON envelope GitHub's GraphQL endpoint expects.
+type graphQLRequestBody struct {
+	Query         string         `json:"query"`
+	OperationName string         `json:"operationName,omitempty"`
+	Variables     map[string]any `json:"variables,omitempty"`
+}
+
+// graphQLAnalysis is the result of statically analysing a GraphQL request
+// against the proxy token's scopes.
+type graphQLAnalysis struct {
+	// requiredScopes lists the (permission, level) pairs that must be granted
+	// for this query to be permitted. A token must satisfy every entry.
+	requiredScopes []scopeRequirement
+	// referencedRepos lists every "owner/name" pair that appears as the
+	// arguments to a `repository(owner, name)` selection in the query.
+	referencedRepos []string
+	// hasMutation is true when any operation in the document is a mutation.
+	hasMutation bool
+	// hasSubscription is true when any operation in the document is a
+	// subscription (GitHub does not support GraphQL subscriptions over HTTP;
+	// the proxy rejects them outright).
+	hasSubscription bool
+	// crossRepoFields lists fields that can return data from repositories
+	// other than those pinned by `repository(owner, name)` (for example
+	// `search`, `node`, `viewer.repositories`, `organization.repositories`).
+	// A repository-restricted token cannot enforce its allowlist when these
+	// fields are present, so the request is denied.
+	crossRepoFields []string
+	// unknownFields lists every field name encountered that is not on the
+	// allowlist. Scoped tokens are denied if this list is non-empty
+	// (deny-by-default). Open-scoped tokens ignore it.
+	unknownFields []string
+}
+
+// scopeRequirement is a single (permission, level) entry.
+type scopeRequirement struct {
+	permission string
+	level      string
+}
+
+// alwaysAllowedFields names the GraphQL fields that the proxy treats as
+// metadata: they require no specific permission scope and are always
+// allowed (subject to repository scoping for repo-pinned fields).
+//
+// The list intentionally errs on the side of "no permission needed" for
+// fields that GitHub returns under metadata read access on every App
+// installation — names, ids, descriptions, URLs, timestamps, owner login,
+// etc. Anything that exposes a permission-gated resource (issues, pulls,
+// secrets, deployments, …) must be mapped via fieldScopeRequirements
+// instead.
+var alwaysAllowedFields = map[string]struct{}{
+	// Generic identity / metadata fields.
+	"__typename":   {},
+	"__schema":     {},
+	"__type":       {},
+	"id":           {},
+	"databaseId":   {},
+	"name":         {},
+	"nameWithOwner": {},
+	"login":        {},
+	"slug":         {},
+	"url":          {},
+	"resourcePath": {},
+	"avatarUrl":    {},
+	"description":  {},
+	"createdAt":    {},
+	"updatedAt":    {},
+	"pushedAt":     {},
+	"isPrivate":    {},
+	"isFork":       {},
+	"isArchived":   {},
+	"isDisabled":   {},
+	"isLocked":     {},
+	"isMirror":     {},
+	"isTemplate":   {},
+	"isInOrganization": {},
+	"visibility":   {},
+	"diskUsage":    {},
+	"forkCount":    {},
+	"stargazerCount": {},
+	"watchers":     {},
+	"languages":    {},
+	"primaryLanguage": {},
+	"defaultBranchRef": {},
+	"licenseInfo":  {},
+	"owner":        {},
+	"repositoryTopics": {},
+	"topics":       {},
+	"homepageUrl":  {},
+	"sshUrl":       {},
+	"mirrorUrl":    {},
+	"hasIssuesEnabled":     {},
+	"hasProjectsEnabled":   {},
+	"hasWikiEnabled":       {},
+	"hasDiscussionsEnabled": {},
+	"openGraphImageUrl":    {},
+	"usesCustomOpenGraphImage": {},
+	"fundingLinks": {},
+	"codeOfConduct": {},
+
+	// Pagination & connection helpers.
+	"nodes":      {},
+	"edges":      {},
+	"pageInfo":   {},
+	"totalCount": {},
+	"hasNextPage": {},
+	"hasPreviousPage": {},
+	"endCursor":   {},
+	"startCursor": {},
+	"cursor":      {},
+
+	// Root fields that are themselves harmless without further selection;
+	// the children determine the actual scope requirement.
+	"viewer":           {},
+	"repository":       {},
+	"repositoryOwner":  {},
+	"user":             {},
+	"organization":     {},
+	"rateLimit":        {},
+	"meta":             {},
+	"codeOfConducts":   {},
+	"licenses":         {},
+	"license":          {},
+	"marketplaceListing": {},
+	"marketplaceCategories": {},
+	"securityAdvisory": {},
+	"securityAdvisories": {},
+	"securityVulnerabilities": {},
+
+	// Common scalar projections on identity types.
+	"email":       {},
+	"company":     {},
+	"location":    {},
+	"bio":         {},
+	"twitterUsername": {},
+	"websiteUrl":  {},
+	"isViewer":    {},
+	"isSiteAdmin": {},
+}
+
+// fieldScopeRequirements maps GraphQL field names to the GitHub App
+// permission scope they require. The lookup is by field name only — the
+// proxy does not load GitHub's full SDL, so a field with the same name on
+// different parent types is treated identically. This is conservative for
+// security purposes: where ambiguity exists we err on the side of requiring
+// the strictest scope.
+//
+// Unknown fields in a scoped query are rejected (deny-by-default); add new
+// entries here as legitimate use cases surface.
+var fieldScopeRequirements = map[string]scopeRequirement{
+	// Issues
+	"issue":                          {"issues", "read"},
+	"issues":                         {"issues", "read"},
+	"issueOrPullRequest":             {"issues", "read"},
+	"closedByPullRequestsReferences": {"issues", "read"},
+	"timelineItems":                  {"issues", "read"},
+	"reactions":                      {"issues", "read"},
+	"reactionGroups":                 {"issues", "read"},
+
+	// Pull requests
+	"pullRequest":         {"pull_requests", "read"},
+	"pullRequests":        {"pull_requests", "read"},
+	"reviews":             {"pull_requests", "read"},
+	"reviewRequests":      {"pull_requests", "read"},
+	"reviewThreads":       {"pull_requests", "read"},
+	"latestReviews":       {"pull_requests", "read"},
+	"latestOpinionatedReviews": {"pull_requests", "read"},
+	"mergeQueue":          {"pull_requests", "read"},
+	"mergeQueueEntry":     {"pull_requests", "read"},
+
+	// Discussions
+	"discussion":         {"discussions", "read"},
+	"discussions":        {"discussions", "read"},
+	"discussionCategory": {"discussions", "read"},
+	"discussionCategories": {"discussions", "read"},
+
+	// Contents / git data
+	"object":         {"contents", "read"},
+	"ref":            {"contents", "read"},
+	"refs":           {"contents", "read"},
+	"branchProtectionRule": {"administration", "read"},
+	"branchProtectionRules": {"administration", "read"},
+	"rulesets":       {"administration", "read"},
+	"ruleset":        {"administration", "read"},
+	"release":        {"contents", "read"},
+	"releases":       {"contents", "read"},
+	"tag":            {"contents", "read"},
+	"tags":           {"contents", "read"},
+	"file":           {"contents", "read"},
+	"tree":           {"contents", "read"},
+	"blob":           {"contents", "read"},
+	"commit":         {"contents", "read"},
+	"commitComments": {"contents", "read"},
+	"history":        {"contents", "read"},
+
+	// Deployments / environments
+	"deployment":  {"deployments", "read"},
+	"deployments": {"deployments", "read"},
+	"environment": {"environments", "read"},
+	"environments": {"environments", "read"},
+
+	// Actions / workflows
+	"workflowRun":         {"actions", "read"},
+	"workflowRuns":        {"actions", "read"},
+	"actionsCacheUsage":   {"actions", "read"},
+	"workflowFile":        {"workflows", "read"},
+
+	// Statuses & checks
+	"status":       {"statuses", "read"},
+	"statuses":     {"statuses", "read"},
+	"statusCheckRollup": {"checks", "read"},
+	"checkSuite":   {"checks", "read"},
+	"checkSuites":  {"checks", "read"},
+	"checkRun":     {"checks", "read"},
+	"checkRuns":    {"checks", "read"},
+
+	// Security
+	"vulnerabilityAlerts": {"vulnerability_alerts", "read"},
+	"securityScanningAlerts": {"secret_scanning_alerts", "read"},
+
+	// Repository administration
+	"collaborators": {"administration", "read"},
+	"invitations":   {"administration", "read"},
+
+	// Organization members
+	"membersWithRole": {"members", "read"},
+	"pendingMembers":  {"members", "read"},
+	"memberStatuses":  {"members", "read"},
+
+	// Projects
+	"project":      {"projects", "read"},
+	"projects":     {"projects", "read"},
+	"projectsV2":   {"projects", "read"},
+	"projectV2":    {"projects", "read"},
+
+	// Webhooks (no GraphQL surface for webhook config today, but reserve the
+	// field name in case GitHub adds one).
+	"hooks": {"repository_hooks", "read"},
+}
+
+// crossRepoFieldNames lists fields that can leak data from repositories
+// other than those addressed by the request's `repository(owner, name)`
+// selections. Repository-scoped tokens cannot statically prove the
+// repositories returned by these fields fall inside the allowlist, so the
+// request is rejected.
+var crossRepoFieldNames = map[string]struct{}{
+	"search":            {},
+	"searchUsers":       {},
+	"node":              {},
+	"nodes":             {},
+	"resource":          {},
+	"repositories":      {},
+	"topRepositories":   {},
+	"watching":          {},
+	"starredRepositories": {},
+	"contributedRepositories": {},
+	"pinnedRepositories":      {},
+	"recentProjects":          {},
+}
+
+// mutationScopeRequirements maps GitHub GraphQL mutation field names to the
+// permission scope they require. The list covers the well-known mutations
+// agents use; unknown mutations fall through to the default-deny path.
+var mutationScopeRequirements = map[string]scopeRequirement{
+	// Issues
+	"createIssue":          {"issues", "write"},
+	"updateIssue":          {"issues", "write"},
+	"closeIssue":           {"issues", "write"},
+	"reopenIssue":          {"issues", "write"},
+	"deleteIssue":          {"issues", "write"},
+	"transferIssue":        {"issues", "write"},
+	"lockLockable":         {"issues", "write"},
+	"unlockLockable":       {"issues", "write"},
+	"pinIssue":             {"issues", "write"},
+	"unpinIssue":           {"issues", "write"},
+	"addAssigneesToAssignable":      {"issues", "write"},
+	"removeAssigneesFromAssignable": {"issues", "write"},
+	"addLabelsToLabelable":          {"issues", "write"},
+	"removeLabelsFromLabelable":     {"issues", "write"},
+	"clearLabelsFromLabelable":      {"issues", "write"},
+	"updateIssueComment":   {"issues", "write"},
+	"deleteIssueComment":   {"issues", "write"},
+	"addComment":           {"issues", "write"},
+
+	// Pull requests
+	"createPullRequest":             {"pull_requests", "write"},
+	"updatePullRequest":             {"pull_requests", "write"},
+	"closePullRequest":              {"pull_requests", "write"},
+	"reopenPullRequest":             {"pull_requests", "write"},
+	"mergePullRequest":              {"pull_requests", "write"},
+	"markPullRequestReadyForReview": {"pull_requests", "write"},
+	"convertPullRequestToDraft":     {"pull_requests", "write"},
+	"enablePullRequestAutoMerge":    {"pull_requests", "write"},
+	"disablePullRequestAutoMerge":   {"pull_requests", "write"},
+	"requestReviews":                {"pull_requests", "write"},
+	"removeRequestedReviewers":      {"pull_requests", "write"},
+	"addPullRequestReview":          {"pull_requests", "write"},
+	"updatePullRequestReview":       {"pull_requests", "write"},
+	"submitPullRequestReview":       {"pull_requests", "write"},
+	"deletePullRequestReview":       {"pull_requests", "write"},
+	"dismissPullRequestReview":      {"pull_requests", "write"},
+	"addPullRequestReviewComment":   {"pull_requests", "write"},
+	"updatePullRequestReviewComment": {"pull_requests", "write"},
+	"deletePullRequestReviewComment": {"pull_requests", "write"},
+	"addPullRequestReviewThread":    {"pull_requests", "write"},
+	"resolveReviewThread":           {"pull_requests", "write"},
+	"unresolveReviewThread":         {"pull_requests", "write"},
+	"addPullRequestReviewThreadReply": {"pull_requests", "write"},
+
+	// Contents / git data
+	"createCommitOnBranch": {"contents", "write"},
+	"createRef":            {"contents", "write"},
+	"updateRef":            {"contents", "write"},
+	"deleteRef":            {"contents", "write"},
+	"createRepository":     {"administration", "write"},
+	"updateRepository":     {"administration", "write"},
+	"createBranchProtectionRule": {"administration", "write"},
+	"updateBranchProtectionRule": {"administration", "write"},
+	"deleteBranchProtectionRule": {"administration", "write"},
+	"createTag":            {"contents", "write"},
+	"createRelease":        {"contents", "write"},
+	"updateRelease":        {"contents", "write"},
+	"deleteRelease":        {"contents", "write"},
+
+	// Discussions
+	"createDiscussion":        {"discussions", "write"},
+	"updateDiscussion":        {"discussions", "write"},
+	"deleteDiscussion":        {"discussions", "write"},
+	"addDiscussionComment":    {"discussions", "write"},
+	"updateDiscussionComment": {"discussions", "write"},
+	"deleteDiscussionComment": {"discussions", "write"},
+	"markDiscussionCommentAsAnswer":   {"discussions", "write"},
+	"unmarkDiscussionCommentAsAnswer": {"discussions", "write"},
+
+	// Reactions are scoped to the parent resource. Without schema
+	// information we cannot tell whether a reaction targets an issue,
+	// discussion, pr, or commit. Conservatively require issues:write,
+	// matching GitHub's behaviour for issue-attached reactions.
+	"addReaction":    {"issues", "write"},
+	"removeReaction": {"issues", "write"},
+
+	// Deployments
+	"createDeployment":       {"deployments", "write"},
+	"createDeploymentStatus": {"deployments", "write"},
+
+	// Projects
+	"addProjectCard":     {"projects", "write"},
+	"updateProjectCard":  {"projects", "write"},
+	"deleteProjectCard":  {"projects", "write"},
+	"createProjectV2":    {"projects", "write"},
+	"updateProjectV2":    {"projects", "write"},
+	"deleteProjectV2":    {"projects", "write"},
+	"addProjectV2ItemById": {"projects", "write"},
+	"deleteProjectV2Item":  {"projects", "write"},
+	"updateProjectV2ItemFieldValue": {"projects", "write"},
+}
+
+// analyzeGraphQLRequest parses a GraphQL request body and returns a static
+// analysis describing the required scopes, referenced repositories, and
+// any unknown fields encountered. The caller decides whether the analysis
+// satisfies the proxy token's restrictions.
+//
+// An empty or unparseable body returns an error so the caller can fail
+// closed. A request that contains no operations is treated the same way.
+func analyzeGraphQLRequest(body []byte) (graphQLAnalysis, error) {
+	var req graphQLRequestBody
+	if err := json.Unmarshal(body, &req); err != nil {
+		return graphQLAnalysis{}, fmt.Errorf("graphql: invalid JSON body: %w", err)
+	}
+	if strings.TrimSpace(req.Query) == "" {
+		return graphQLAnalysis{}, fmt.Errorf("graphql: empty query")
+	}
+	doc, err := parser.ParseQuery(&ast.Source{Input: req.Query})
+	if err != nil {
+		return graphQLAnalysis{}, fmt.Errorf("graphql: parse error: %w", err)
+	}
+	if len(doc.Operations) == 0 {
+		return graphQLAnalysis{}, fmt.Errorf("graphql: no operation in document")
+	}
+
+	// Build a fragment lookup table so we can resolve fragment spreads.
+	fragments := map[string]*ast.FragmentDefinition{}
+	for _, frag := range doc.Fragments {
+		fragments[frag.Name] = frag
+	}
+
+	a := &gqlAnalyzer{
+		fragments:       fragments,
+		visitedFragments: map[string]bool{},
+		seenScopes:      map[scopeRequirement]struct{}{},
+		seenRepos:       map[string]struct{}{},
+		seenCrossRepo:   map[string]struct{}{},
+		seenUnknown:     map[string]struct{}{},
+	}
+
+	for _, op := range doc.Operations {
+		switch op.Operation {
+		case ast.Mutation:
+			a.result.hasMutation = true
+		case ast.Subscription:
+			a.result.hasSubscription = true
+		}
+		// Walk the selection set. Top-level selections are special only in
+		// that mutations also carry a per-field scope requirement;
+		// otherwise the walk treats every selection identically.
+		a.walkSelectionSet(op.SelectionSet, op.Operation == ast.Mutation, true)
+	}
+
+	// Materialise the deduplicated maps into deterministic slices. When the
+	// query requires both read and write of the same permission, keep only
+	// the stricter (write) entry: write implies read in
+	// database.Scopes.HasPermission.
+	collapsed := map[string]string{}
+	for s := range a.seenScopes {
+		existing, ok := collapsed[s.permission]
+		if !ok || (existing == "read" && s.level == "write") {
+			collapsed[s.permission] = s.level
+		}
+	}
+	for perm, lvl := range collapsed {
+		a.result.requiredScopes = append(a.result.requiredScopes, scopeRequirement{permission: perm, level: lvl})
+	}
+	sort.Slice(a.result.requiredScopes, func(i, j int) bool {
+		if a.result.requiredScopes[i].permission != a.result.requiredScopes[j].permission {
+			return a.result.requiredScopes[i].permission < a.result.requiredScopes[j].permission
+		}
+		return a.result.requiredScopes[i].level < a.result.requiredScopes[j].level
+	})
+	for r := range a.seenRepos {
+		a.result.referencedRepos = append(a.result.referencedRepos, r)
+	}
+	sort.Strings(a.result.referencedRepos)
+	for f := range a.seenCrossRepo {
+		a.result.crossRepoFields = append(a.result.crossRepoFields, f)
+	}
+	sort.Strings(a.result.crossRepoFields)
+	for f := range a.seenUnknown {
+		a.result.unknownFields = append(a.result.unknownFields, f)
+	}
+	sort.Strings(a.result.unknownFields)
+
+	return a.result, nil
+}
+
+type gqlAnalyzer struct {
+	fragments        map[string]*ast.FragmentDefinition
+	visitedFragments map[string]bool
+	result           graphQLAnalysis
+	seenScopes       map[scopeRequirement]struct{}
+	seenRepos        map[string]struct{}
+	seenCrossRepo    map[string]struct{}
+	seenUnknown      map[string]struct{}
+}
+
+func (a *gqlAnalyzer) walkSelectionSet(set ast.SelectionSet, inMutation, atRoot bool) {
+	for _, sel := range set {
+		switch s := sel.(type) {
+		case *ast.Field:
+			a.walkField(s, inMutation, atRoot)
+		case *ast.InlineFragment:
+			a.walkSelectionSet(s.SelectionSet, inMutation, atRoot)
+		case *ast.FragmentSpread:
+			if a.visitedFragments[s.Name] {
+				continue
+			}
+			a.visitedFragments[s.Name] = true
+			frag, ok := a.fragments[s.Name]
+			if !ok {
+				continue
+			}
+			a.walkSelectionSet(frag.SelectionSet, inMutation, false)
+		}
+	}
+}
+
+func (a *gqlAnalyzer) walkField(f *ast.Field, inMutation, atRoot bool) {
+	name := f.Name
+
+	// Capture repository(owner, name) arguments wherever the field appears.
+	if name == "repository" {
+		if owner, repo := repositoryArgs(f); owner != "" && repo != "" {
+			a.seenRepos[owner+"/"+repo] = struct{}{}
+		}
+	}
+
+	// Cross-repo fields can leak data from outside the repo allowlist.
+	if _, ok := crossRepoFieldNames[name]; ok {
+		a.seenCrossRepo[name] = struct{}{}
+	}
+
+	// Mutation root fields require a write-level scope.
+	if inMutation && atRoot {
+		if req, ok := mutationScopeRequirements[name]; ok {
+			a.seenScopes[req] = struct{}{}
+		} else {
+			a.seenUnknown[name] = struct{}{}
+		}
+	} else if _, ok := alwaysAllowedFields[name]; ok {
+		// no-op — metadata field, no scope required.
+	} else if req, ok := fieldScopeRequirements[name]; ok {
+		a.seenScopes[req] = struct{}{}
+	} else if len(f.SelectionSet) == 0 {
+		// Scalar leaf with no children. The parent field has already
+		// established the access context (its required scope gates this
+		// projection), so leaves of unknown name are not themselves
+		// suspicious. Treating every leaf as "unknown" would force the
+		// allowlist to enumerate every field name in the GitHub schema,
+		// which is impractical. Object-typed fields (those with their own
+		// selection set) are still subject to deny-by-default below.
+	} else if !strings.HasPrefix(name, "__") {
+		// Introspection fields (__schema, __type, __typename) handled via
+		// alwaysAllowedFields above; anything else with its own selection
+		// set that does not match the allow/scope tables is flagged.
+		a.seenUnknown[name] = struct{}{}
+	}
+
+	// Recurse into the selection set if any. Children of a mutation root
+	// field are not themselves "root" — their permission is implied by the
+	// mutation's required scope.
+	if len(f.SelectionSet) > 0 {
+		a.walkSelectionSet(f.SelectionSet, false, false)
+	}
+}
+
+// repositoryArgs extracts the (owner, name) arguments from a
+// `repository(owner: "X", name: "Y")` field selection. Returns empty
+// strings if either argument is missing or non-literal (e.g. supplied via
+// a GraphQL variable). Variable-driven repository lookups are
+// indistinguishable from any other lookup at static analysis time, so the
+// caller treats them as cross-repo for safety.
+func repositoryArgs(f *ast.Field) (string, string) {
+	var owner, repo string
+	for _, arg := range f.Arguments {
+		if arg.Value == nil || arg.Value.Kind != ast.StringValue {
+			continue
+		}
+		switch arg.Name {
+		case "owner":
+			owner = arg.Value.Raw
+		case "name":
+			repo = arg.Value.Raw
+		}
+	}
+	return owner, repo
+}
+
+// satisfiedBy reports whether the given proxy-token scopes grant every
+// scope required by this analysis. The token is allowed when every entry
+// in requiredScopes appears in scopes at sufficient level (write implies
+// read, per database.Scopes.HasPermission).
+func (a graphQLAnalysis) satisfiedBy(scopes database.Scopes) bool {
+	for _, req := range a.requiredScopes {
+		if !scopes.HasPermission(req.permission, req.level) {
+			return false
+		}
+	}
+	return true
+}
+
+// missingScopes returns the scope requirements that are not granted by the
+// supplied token scopes, formatted as "permission:level" entries sorted
+// alphabetically. Used to build helpful 403 messages.
+func (a graphQLAnalysis) missingScopes(scopes database.Scopes) []string {
+	var missing []string
+	for _, req := range a.requiredScopes {
+		if !scopes.HasPermission(req.permission, req.level) {
+			missing = append(missing, req.permission+":"+req.level)
+		}
+	}
+	sort.Strings(missing)
+	return missing
+}

--- a/internal/proxy/graphql.go
+++ b/internal/proxy/graphql.go
@@ -579,12 +579,24 @@ func (a *gqlAnalyzer) walkField(f *ast.Field, inMutation, atRoot bool) {
 		a.seenScopes[req] = struct{}{}
 	} else if len(f.SelectionSet) == 0 {
 		// Scalar leaf with no children. The parent field has already
-		// established the access context (its required scope gates this
-		// projection), so leaves of unknown name are not themselves
-		// suspicious. Treating every leaf as "unknown" would force the
-		// allowlist to enumerate every field name in the GitHub schema,
-		// which is impractical. Object-typed fields (those with their own
-		// selection set) are still subject to deny-by-default below.
+		// established the access context — for object-typed parents
+		// mapped to a scope (e.g. `Repository.issues`) the parent
+		// scope gates the leaf; for always-allowed metadata parents
+		// (e.g. `repository`, `user`, `viewer`) the leaf is itself
+		// metadata-style. Treating every leaf as "unknown" would force
+		// the allowlist to enumerate every scalar field name in
+		// GitHub's schema (hundreds of entries), which is impractical
+		// without schema-aware validation.
+		//
+		// The known trade-off: an unmapped scalar projected directly
+		// under an always-allowed parent is not flagged, even though
+		// in principle GitHub could one day expose a sensitive scalar
+		// at that position. The risk is bounded by what the underlying
+		// credential can read; operators who want stricter enforcement
+		// must either reject GraphQL for the affected token or
+		// extend `fieldScopeRequirements` to map the offending scalar
+		// to a permission. Object-typed fields (those with their own
+		// selection set) remain subject to deny-by-default below.
 	} else {
 		// Object-typed field with a selection set that does not appear in
 		// the allow-list or scope-requirement tables. The standard
@@ -605,11 +617,14 @@ func (a *gqlAnalyzer) walkField(f *ast.Field, inMutation, atRoot bool) {
 }
 
 // repositoryArgs extracts the (owner, name) arguments from a
-// `repository(owner: "X", name: "Y")` field selection. Returns empty
-// strings if either argument is missing or non-literal (e.g. supplied via
-// a GraphQL variable). Variable-driven repository lookups are
-// indistinguishable from any other lookup at static analysis time, so the
-// caller treats them as cross-repo for safety.
+// `repository(owner: "X", name: "Y")` field selection. It returns empty
+// strings if either argument is missing or non-literal (for example
+// supplied via a GraphQL variable). In that case the helper does not
+// have a statically pinned repository to record; policy enforcement
+// then treats the lookup as having no pinned repository, which causes
+// the `len(referencedRepos) == 0` check in the caller to reject the
+// request for repository-restricted tokens. Cross-repo tracking is not
+// populated from this helper.
 func repositoryArgs(f *ast.Field) (string, string) {
 	var owner, repo string
 	for _, arg := range f.Arguments {

--- a/internal/proxy/graphql.go
+++ b/internal/proxy/graphql.go
@@ -251,17 +251,25 @@ var fieldScopeRequirements = map[string]scopeRequirement{
 	"hooks": {"repository_hooks", "read"},
 }
 
-// crossRepoFieldNames lists fields that can leak data from repositories
-// other than those addressed by the request's `repository(owner, name)`
-// selections. Repository-scoped tokens cannot statically prove the
-// repositories returned by these fields fall inside the allowlist, so the
-// request is rejected.
-var crossRepoFieldNames = map[string]struct{}{
+// crossRepoRootOnlyFields lists fields that are cross-repository when used
+// as a root selection (`{ node(id: ...) { ... } }`) but are unrelated
+// connection helpers when nested (e.g. `Connection.nodes`,
+// `Edge.node`). The analyzer only flags these when the field appears at
+// an operation's top level.
+var crossRepoRootOnlyFields = map[string]struct{}{
+	"node":     {},
+	"nodes":    {},
+	"resource": {},
+}
+
+// crossRepoAnywhereFields lists fields that can leak data from
+// repositories other than those addressed by the request's
+// `repository(owner, name)` selections. Repository-scoped tokens cannot
+// statically prove the repositories returned by these fields fall inside
+// the allowlist, so the request is rejected wherever they appear.
+var crossRepoAnywhereFields = map[string]struct{}{
 	"search":            {},
 	"searchUsers":       {},
-	"node":              {},
-	"nodes":             {},
-	"resource":          {},
 	"repositories":      {},
 	"topRepositories":   {},
 	"watching":          {},
@@ -397,27 +405,34 @@ func analyzeGraphQLRequest(body []byte) (graphQLAnalysis, error) {
 		fragments[frag.Name] = frag
 	}
 
+	// GitHub executes a single operation per request: the one named by
+	// `operationName`, or — when omitted — the sole operation in the
+	// document. Match that semantic so a multi-operation document is not
+	// punished for operations the executor would never run.
+	op, err := selectOperation(doc, req.OperationName)
+	if err != nil {
+		return graphQLAnalysis{}, err
+	}
+
 	a := &gqlAnalyzer{
 		fragments:       fragments,
-		visitedFragments: map[string]bool{},
+		fragmentStack:   map[string]bool{},
 		seenScopes:      map[scopeRequirement]struct{}{},
 		seenRepos:       map[string]struct{}{},
 		seenCrossRepo:   map[string]struct{}{},
 		seenUnknown:     map[string]struct{}{},
 	}
 
-	for _, op := range doc.Operations {
-		switch op.Operation {
-		case ast.Mutation:
-			a.result.hasMutation = true
-		case ast.Subscription:
-			a.result.hasSubscription = true
-		}
-		// Walk the selection set. Top-level selections are special only in
-		// that mutations also carry a per-field scope requirement;
-		// otherwise the walk treats every selection identically.
-		a.walkSelectionSet(op.SelectionSet, op.Operation == ast.Mutation, true)
+	switch op.Operation {
+	case ast.Mutation:
+		a.result.hasMutation = true
+	case ast.Subscription:
+		a.result.hasSubscription = true
 	}
+	// Walk the selection set. Top-level selections are special only in
+	// that mutations also carry a per-field scope requirement; otherwise
+	// the walk treats every selection identically.
+	a.walkSelectionSet(op.SelectionSet, op.Operation == ast.Mutation, true)
 
 	// Materialise the deduplicated maps into deterministic slices. When the
 	// query requires both read and write of the same permission, keep only
@@ -455,14 +470,42 @@ func analyzeGraphQLRequest(body []byte) (graphQLAnalysis, error) {
 	return a.result, nil
 }
 
+// selectOperation picks the single operation that GitHub will execute for
+// a request. When `operationName` is non-empty it must match one of the
+// operations in the document; otherwise the document must contain exactly
+// one operation. A request that supplies multiple operations without
+// naming one is ambiguous and rejected — the proxy refuses to forward
+// queries it cannot statically scope.
+func selectOperation(doc *ast.QueryDocument, operationName string) (*ast.OperationDefinition, error) {
+	if operationName != "" {
+		for _, op := range doc.Operations {
+			if op.Name == operationName {
+				return op, nil
+			}
+		}
+		return nil, fmt.Errorf("graphql: operationName %q not found in document", operationName)
+	}
+	if len(doc.Operations) > 1 {
+		return nil, fmt.Errorf("graphql: document has multiple operations; operationName is required")
+	}
+	return doc.Operations[0], nil
+}
+
 type gqlAnalyzer struct {
-	fragments        map[string]*ast.FragmentDefinition
-	visitedFragments map[string]bool
-	result           graphQLAnalysis
-	seenScopes       map[scopeRequirement]struct{}
-	seenRepos        map[string]struct{}
-	seenCrossRepo    map[string]struct{}
-	seenUnknown      map[string]struct{}
+	fragments map[string]*ast.FragmentDefinition
+	// fragmentStack holds the fragment names currently being walked, so
+	// recursive fragment spreads (which the GraphQL spec disallows) cannot
+	// drive the analyzer into infinite recursion. Unlike a flat
+	// "visited" set, the stack permits the same fragment to be analysed
+	// multiple times in unrelated contexts (e.g. once at the operation
+	// root and once again inside a nested selection), which matters because
+	// the `atRoot`/`inMutation` flags affect mutation root-field scoping.
+	fragmentStack map[string]bool
+	result        graphQLAnalysis
+	seenScopes    map[scopeRequirement]struct{}
+	seenRepos     map[string]struct{}
+	seenCrossRepo map[string]struct{}
+	seenUnknown   map[string]struct{}
 }
 
 func (a *gqlAnalyzer) walkSelectionSet(set ast.SelectionSet, inMutation, atRoot bool) {
@@ -471,17 +514,25 @@ func (a *gqlAnalyzer) walkSelectionSet(set ast.SelectionSet, inMutation, atRoot 
 		case *ast.Field:
 			a.walkField(s, inMutation, atRoot)
 		case *ast.InlineFragment:
+			// Inline fragments are an in-place type narrowing; they
+			// preserve the surrounding selection's root-ness.
 			a.walkSelectionSet(s.SelectionSet, inMutation, atRoot)
 		case *ast.FragmentSpread:
-			if a.visitedFragments[s.Name] {
+			// A fragment spread that refers to a fragment we are already
+			// inside is a recursion: skip it. Otherwise push the name on
+			// the stack, walk the fragment with the caller's atRoot
+			// preserved (so mutation root fields sourced via fragments are
+			// still treated as root fields), and pop on the way out.
+			if a.fragmentStack[s.Name] {
 				continue
 			}
-			a.visitedFragments[s.Name] = true
 			frag, ok := a.fragments[s.Name]
 			if !ok {
 				continue
 			}
-			a.walkSelectionSet(frag.SelectionSet, inMutation, false)
+			a.fragmentStack[s.Name] = true
+			a.walkSelectionSet(frag.SelectionSet, inMutation, atRoot)
+			delete(a.fragmentStack, s.Name)
 		}
 	}
 }
@@ -497,8 +548,15 @@ func (a *gqlAnalyzer) walkField(f *ast.Field, inMutation, atRoot bool) {
 	}
 
 	// Cross-repo fields can leak data from outside the repo allowlist.
-	if _, ok := crossRepoFieldNames[name]; ok {
+	// Some field names (`node`, `nodes`) are only cross-repo when used as
+	// a root selection — at non-root positions they are connection
+	// helpers and benign.
+	if _, ok := crossRepoAnywhereFields[name]; ok {
 		a.seenCrossRepo[name] = struct{}{}
+	} else if atRoot {
+		if _, ok := crossRepoRootOnlyFields[name]; ok {
+			a.seenCrossRepo[name] = struct{}{}
+		}
 	}
 
 	// Mutation root fields require a write-level scope.

--- a/internal/proxy/graphql.go
+++ b/internal/proxy/graphql.go
@@ -585,10 +585,14 @@ func (a *gqlAnalyzer) walkField(f *ast.Field, inMutation, atRoot bool) {
 		// allowlist to enumerate every field name in the GitHub schema,
 		// which is impractical. Object-typed fields (those with their own
 		// selection set) are still subject to deny-by-default below.
-	} else if !strings.HasPrefix(name, "__") {
-		// Introspection fields (__schema, __type, __typename) handled via
-		// alwaysAllowedFields above; anything else with its own selection
-		// set that does not match the allow/scope tables is flagged.
+	} else {
+		// Object-typed field with a selection set that does not appear in
+		// the allow-list or scope-requirement tables. The standard
+		// introspection fields (`__schema`, `__type`) are already
+		// allow-listed via alwaysAllowedFields, so any other `__*` field
+		// is treated like any other unknown — exempting the entire
+		// introspection namespace would let an attacker hide arbitrary
+		// selections under a `__Anything { ... }` wrapper.
 		a.seenUnknown[name] = struct{}{}
 	}
 

--- a/internal/proxy/graphql.go
+++ b/internal/proxy/graphql.go
@@ -521,15 +521,20 @@ func (a *gqlAnalyzer) walkSelectionSet(set ast.SelectionSet, inMutation, atRoot 
 			a.walkSelectionSet(s.SelectionSet, inMutation, atRoot)
 		case *ast.FragmentSpread:
 			// A fragment spread that refers to a fragment we are already
-			// inside is a recursion: skip it. Otherwise push the name on
-			// the stack, walk the fragment with the caller's atRoot
-			// preserved (so mutation root fields sourced via fragments are
-			// still treated as root fields), and pop on the way out.
+			// inside is a recursion: skip it. A spread that names a
+			// fragment the document does not define is treated as an
+			// unknown field — silently skipping would let a malformed
+			// query slip past the fail-closed posture and reach GitHub.
+			// Otherwise push the name on the stack, walk the fragment
+			// with the caller's atRoot preserved (so mutation root
+			// fields sourced via fragments are still treated as root
+			// fields), and pop on the way out.
 			if a.fragmentStack[s.Name] {
 				continue
 			}
 			frag, ok := a.fragments[s.Name]
 			if !ok {
+				a.seenUnknown["fragment:"+s.Name] = struct{}{}
 				continue
 			}
 			a.fragmentStack[s.Name] = true

--- a/internal/proxy/graphql.go
+++ b/internal/proxy/graphql.go
@@ -12,10 +12,15 @@ import (
 )
 
 // graphQLRequestBody is the JSON envelope GitHub's GraphQL endpoint expects.
+// Variables are kept as json.RawMessage rather than `map[string]any`: the
+// analyser does not look inside them (variable values cannot statically
+// pin a repository, so the analyser already treats variable-driven
+// `repository(...)` arguments as unpinned), and decoding them eagerly
+// would allocate the entire object on every analysed request.
 type graphQLRequestBody struct {
-	Query         string         `json:"query"`
-	OperationName string         `json:"operationName,omitempty"`
-	Variables     map[string]any `json:"variables,omitempty"`
+	Query         string          `json:"query"`
+	OperationName string          `json:"operationName,omitempty"`
+	Variables     json.RawMessage `json:"variables,omitempty"`
 }
 
 // graphQLAnalysis is the result of statically analysing a GraphQL request

--- a/internal/proxy/graphql.go
+++ b/internal/proxy/graphql.go
@@ -434,7 +434,10 @@ func analyzeGraphQLRequest(body []byte) (graphQLAnalysis, error) {
 	// Walk the selection set. Top-level selections are special only in
 	// that mutations also carry a per-field scope requirement; otherwise
 	// the walk treats every selection identically.
-	a.walkSelectionSet(op.SelectionSet, op.Operation == ast.Mutation, true)
+	a.walkSelectionSet(op.SelectionSet, op.Operation == ast.Mutation, true, 1)
+	if a.tooDeep {
+		return graphQLAnalysis{}, fmt.Errorf("graphql: query exceeds maximum analysis depth (%d)", maxAnalysisDepth)
+	}
 
 	// Materialise the deduplicated maps into deterministic slices. When the
 	// query requires both read and write of the same permission, keep only
@@ -508,17 +511,32 @@ type gqlAnalyzer struct {
 	seenRepos     map[string]struct{}
 	seenCrossRepo map[string]struct{}
 	seenUnknown   map[string]struct{}
+	// tooDeep is set if the walk exceeds maxAnalysisDepth; the caller
+	// surfaces this as a 400 instead of forwarding the request, since a
+	// query the analyzer cannot fully traverse cannot be safely scoped.
+	tooDeep bool
 }
 
-func (a *gqlAnalyzer) walkSelectionSet(set ast.SelectionSet, inMutation, atRoot bool) {
+// maxAnalysisDepth caps the depth of the AST walk so that a malicious
+// (but still ≤ maxGraphQLBodyBytes) query with extreme nesting cannot
+// drive the proxy into stack growth/overflow. Real GitHub queries rarely
+// exceed ~30 levels; 100 leaves comfortable headroom for nested
+// connections and fragments without enabling unbounded recursion.
+const maxAnalysisDepth = 100
+
+func (a *gqlAnalyzer) walkSelectionSet(set ast.SelectionSet, inMutation, atRoot bool, depth int) {
+	if depth > maxAnalysisDepth {
+		a.tooDeep = true
+		return
+	}
 	for _, sel := range set {
 		switch s := sel.(type) {
 		case *ast.Field:
-			a.walkField(s, inMutation, atRoot)
+			a.walkField(s, inMutation, atRoot, depth)
 		case *ast.InlineFragment:
 			// Inline fragments are an in-place type narrowing; they
 			// preserve the surrounding selection's root-ness.
-			a.walkSelectionSet(s.SelectionSet, inMutation, atRoot)
+			a.walkSelectionSet(s.SelectionSet, inMutation, atRoot, depth+1)
 		case *ast.FragmentSpread:
 			// A fragment spread that refers to a fragment we are already
 			// inside is a recursion: skip it. A spread that names a
@@ -538,13 +556,13 @@ func (a *gqlAnalyzer) walkSelectionSet(set ast.SelectionSet, inMutation, atRoot 
 				continue
 			}
 			a.fragmentStack[s.Name] = true
-			a.walkSelectionSet(frag.SelectionSet, inMutation, atRoot)
+			a.walkSelectionSet(frag.SelectionSet, inMutation, atRoot, depth+1)
 			delete(a.fragmentStack, s.Name)
 		}
 	}
 }
 
-func (a *gqlAnalyzer) walkField(f *ast.Field, inMutation, atRoot bool) {
+func (a *gqlAnalyzer) walkField(f *ast.Field, inMutation, atRoot bool, depth int) {
 	name := f.Name
 
 	// Capture repository(owner, name) arguments wherever the field appears.
@@ -620,7 +638,7 @@ func (a *gqlAnalyzer) walkField(f *ast.Field, inMutation, atRoot bool) {
 	// field are not themselves "root" — their permission is implied by the
 	// mutation's required scope.
 	if len(f.SelectionSet) > 0 {
-		a.walkSelectionSet(f.SelectionSet, false, false)
+		a.walkSelectionSet(f.SelectionSet, false, false, depth+1)
 	}
 }
 

--- a/internal/proxy/graphql.go
+++ b/internal/proxy/graphql.go
@@ -574,13 +574,17 @@ func (a *gqlAnalyzer) walkSelectionSet(set ast.SelectionSet, inMutation, atRoot 
 func (a *gqlAnalyzer) walkField(f *ast.Field, inMutation, atRoot bool, depth int) {
 	name := f.Name
 
-	// Capture repository(owner, name) arguments wherever the field appears.
-	// When the arguments are not statically analysable as literal strings
-	// (e.g. supplied via a variable), record the lookup as "unpinned" so
-	// repo-restricted tokens fail closed: otherwise an attacker could mix
-	// one literal allowlisted lookup with a variable-driven lookup and
-	// bypass the allowlist.
-	if name == "repository" {
+	// Capture repository(owner, name) arguments when the field is invoked
+	// as a lookup (i.e. has arguments). Nested `Repository` accessors with
+	// no arguments — `PullRequest.repository`, `Issue.repository`, etc. —
+	// are not lookups and must not be flagged as "unpinned". When a lookup
+	// is present but its arguments are not statically analysable as literal
+	// strings (e.g. supplied via a variable, or single-arg forms like
+	// `Organization.repository(name:)` whose owner is implied by the parent
+	// type), record it as "unpinned" so repo-restricted tokens fail closed:
+	// otherwise an attacker could mix one literal allowlisted lookup with a
+	// variable-driven lookup and bypass the allowlist.
+	if name == "repository" && len(f.Arguments) > 0 {
 		if owner, repo := repositoryArgs(f); owner != "" && repo != "" {
 			a.seenRepos[owner+"/"+repo] = struct{}{}
 		} else {

--- a/internal/proxy/graphql_test.go
+++ b/internal/proxy/graphql_test.go
@@ -536,4 +536,13 @@ func TestServeHTTP_GraphQL_RejectsOversizedBody(t *testing.T) {
 	if rr.Code != http.StatusRequestEntityTooLarge {
 		t.Fatalf("expected 413 for oversized body, got %d", rr.Code)
 	}
+	// The proxy must own the response: it returns its own JSON 413 rather
+	// than letting `http.MaxBytesReader` write a plain-text default that
+	// would race with `writeError`.
+	if ct := rr.Header().Get("Content-Type"); !strings.Contains(ct, "application/json") {
+		t.Errorf("expected JSON 413 response, got Content-Type %q", ct)
+	}
+	if body := rr.Body.String(); !strings.Contains(body, "exceeds proxy size limit") {
+		t.Errorf("expected proxy 413 message in body, got %q", body)
+	}
 }

--- a/internal/proxy/graphql_test.go
+++ b/internal/proxy/graphql_test.go
@@ -149,6 +149,21 @@ func TestAnalyzeGraphQLRequest_FragmentAtMutationRootStillScoped(t *testing.T) {
 	}
 }
 
+func TestAnalyzeGraphQLRequest_UnknownDoubleUnderscoreFieldFlagged(t *testing.T) {
+	// `__schema` and `__type` are explicitly allow-listed via
+	// alwaysAllowedFields; any other `__*` object-typed field must still
+	// be flagged so an attacker can't hide an arbitrary subtree under a
+	// `__Anything { ... }` wrapper.
+	body := []byte(`{"query":"{ __mystery { id } }"}`)
+	got, err := analyzeGraphQLRequest(body)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got.unknownFields) == 0 {
+		t.Fatalf("expected __mystery to be flagged unknown")
+	}
+}
+
 func TestAnalyzeGraphQLRequest_UndefinedFragmentSpreadFlagged(t *testing.T) {
 	// A spread that names a fragment the document does not define must
 	// surface as an unknown-field entry so scoped tokens are denied
@@ -553,6 +568,27 @@ func TestServeHTTP_GraphQL_RejectsInvalidJSON(t *testing.T) {
 
 	if rr.Code != http.StatusBadRequest {
 		t.Fatalf("expected 400 for invalid JSON body, got %d; body: %s", rr.Code, rr.Body.String())
+	}
+}
+
+func TestServeHTTP_GraphQL_RejectsNonPost(t *testing.T) {
+	// GitHub's GraphQL endpoint accepts only POST; the proxy must reject
+	// other methods with a clear 405 rather than failing JSON parse.
+	h, ghpToken := newScopeOnlyHandler(t, map[string]string{
+		"issues": "read",
+	})
+
+	req := httptest.NewRequest("GET", "http://api.github.com/graphql?query={viewer{login}}", nil)
+	req.Header.Set("Authorization", "Bearer "+ghpToken)
+	rr := httptest.NewRecorder()
+
+	h.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("expected 405 for GET, got %d; body: %s", rr.Code, rr.Body.String())
+	}
+	if got := rr.Header().Get("Allow"); got != http.MethodPost {
+		t.Errorf("expected Allow: POST, got %q", got)
 	}
 }
 

--- a/internal/proxy/graphql_test.go
+++ b/internal/proxy/graphql_test.go
@@ -1,0 +1,436 @@
+package proxy
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/goodtune/ghp/internal/database"
+)
+
+func TestAnalyzeGraphQLRequest_ViewerOnly(t *testing.T) {
+	body := []byte(`{"query":"{ viewer { login } }"}`)
+	got, err := analyzeGraphQLRequest(body)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.hasMutation || got.hasSubscription {
+		t.Errorf("expected query operation only, got mutation=%v subscription=%v", got.hasMutation, got.hasSubscription)
+	}
+	if len(got.requiredScopes) != 0 {
+		t.Errorf("expected no required scopes for { viewer { login } }, got %v", got.requiredScopes)
+	}
+	if len(got.referencedRepos) != 0 {
+		t.Errorf("expected no referenced repos, got %v", got.referencedRepos)
+	}
+	if len(got.crossRepoFields) != 0 {
+		t.Errorf("expected no cross-repo fields, got %v", got.crossRepoFields)
+	}
+	if len(got.unknownFields) != 0 {
+		t.Errorf("expected no unknown fields, got %v", got.unknownFields)
+	}
+}
+
+func TestAnalyzeGraphQLRequest_RepositoryArgsExtracted(t *testing.T) {
+	body := []byte(`{"query":"{ repository(owner: \"goodtune\", name: \"ghp\") { id name } }"}`)
+	got, err := analyzeGraphQLRequest(body)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := []string{"goodtune/ghp"}
+	if !reflect.DeepEqual(got.referencedRepos, want) {
+		t.Errorf("referencedRepos = %v, want %v", got.referencedRepos, want)
+	}
+	if len(got.unknownFields) != 0 {
+		t.Errorf("expected no unknown fields, got %v", got.unknownFields)
+	}
+}
+
+func TestAnalyzeGraphQLRequest_RepositoryArgsAreLiteralOnly(t *testing.T) {
+	// owner is a variable reference rather than a literal string. The
+	// analyzer must not trust the variable name as the repository identity.
+	body := []byte(`{"query":"query Q($owner: String!) { repository(owner: $owner, name: \"ghp\") { id } }","variables":{"owner":"goodtune"}}`)
+	got, err := analyzeGraphQLRequest(body)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got.referencedRepos) != 0 {
+		t.Errorf("variable-driven owner must not produce a referencedRepos entry, got %v", got.referencedRepos)
+	}
+}
+
+func TestAnalyzeGraphQLRequest_PullRequestRequiresScope(t *testing.T) {
+	body := []byte(`{"query":"{ repository(owner: \"goodtune\", name: \"ghp\") { pullRequests(first: 10) { nodes { number } } } }"}`)
+	got, err := analyzeGraphQLRequest(body)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := []scopeRequirement{{permission: "pull_requests", level: "read"}}
+	if !reflect.DeepEqual(got.requiredScopes, want) {
+		t.Errorf("requiredScopes = %v, want %v", got.requiredScopes, want)
+	}
+}
+
+func TestAnalyzeGraphQLRequest_MutationRequiresWriteScope(t *testing.T) {
+	body := []byte(`{"query":"mutation { createIssue(input: {repositoryId: \"abc\", title: \"hello\"}) { issue { id } } }"}`)
+	got, err := analyzeGraphQLRequest(body)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !got.hasMutation {
+		t.Fatalf("expected mutation flag")
+	}
+	want := []scopeRequirement{{permission: "issues", level: "write"}}
+	if !reflect.DeepEqual(got.requiredScopes, want) {
+		t.Errorf("requiredScopes = %v, want %v", got.requiredScopes, want)
+	}
+}
+
+func TestAnalyzeGraphQLRequest_UnknownMutationDeniedByDefault(t *testing.T) {
+	body := []byte(`{"query":"mutation { destroyTheUniverse { ok } }"}`)
+	got, err := analyzeGraphQLRequest(body)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !got.hasMutation {
+		t.Fatalf("expected mutation flag")
+	}
+	if len(got.unknownFields) == 0 {
+		t.Fatalf("expected destroyTheUniverse to be flagged as unknown")
+	}
+}
+
+func TestAnalyzeGraphQLRequest_CrossRepoFieldsFlagged(t *testing.T) {
+	body := []byte(`{"query":"{ search(query: \"x\", type: REPOSITORY, first: 5) { repositoryCount } }"}`)
+	got, err := analyzeGraphQLRequest(body)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := []string{"search"}
+	if !reflect.DeepEqual(got.crossRepoFields, want) {
+		t.Errorf("crossRepoFields = %v, want %v", got.crossRepoFields, want)
+	}
+}
+
+func TestAnalyzeGraphQLRequest_FragmentsResolved(t *testing.T) {
+	body := []byte(`{"query":"query { repository(owner: \"goodtune\", name: \"ghp\") { ...PR } } fragment PR on Repository { pullRequests(first: 1) { nodes { number } } }"}`)
+	got, err := analyzeGraphQLRequest(body)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := []scopeRequirement{{permission: "pull_requests", level: "read"}}
+	if !reflect.DeepEqual(got.requiredScopes, want) {
+		t.Errorf("requiredScopes = %v, want %v", got.requiredScopes, want)
+	}
+}
+
+func TestAnalyzeGraphQLRequest_SubscriptionFlagged(t *testing.T) {
+	body := []byte(`{"query":"subscription { whatever }"}`)
+	got, err := analyzeGraphQLRequest(body)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !got.hasSubscription {
+		t.Fatalf("expected subscription flag")
+	}
+}
+
+func TestAnalyzeGraphQLRequest_InvalidJSON(t *testing.T) {
+	if _, err := analyzeGraphQLRequest([]byte(`not json`)); err == nil {
+		t.Fatal("expected error for non-JSON body")
+	}
+}
+
+func TestAnalyzeGraphQLRequest_UnparseableQuery(t *testing.T) {
+	if _, err := analyzeGraphQLRequest([]byte(`{"query":"not a graphql query"}`)); err == nil {
+		t.Fatal("expected parse error")
+	}
+}
+
+func TestAnalyzeGraphQLRequest_EmptyQuery(t *testing.T) {
+	if _, err := analyzeGraphQLRequest([]byte(`{"query":""}`)); err == nil {
+		t.Fatal("expected error for empty query")
+	}
+}
+
+func TestAnalysisSatisfiedBy(t *testing.T) {
+	a := graphQLAnalysis{
+		requiredScopes: []scopeRequirement{
+			{permission: "issues", level: "read"},
+			{permission: "pull_requests", level: "write"},
+		},
+	}
+	tests := []struct {
+		name   string
+		scopes database.Scopes
+		want   bool
+	}{
+		{"missing both", database.Scopes{}, false},
+		{"missing one", database.Scopes{"issues": "read"}, false},
+		{"exact match", database.Scopes{"issues": "read", "pull_requests": "write"}, true},
+		{"write covers read", database.Scopes{"issues": "write", "pull_requests": "write"}, true},
+		{"read does not cover write", database.Scopes{"issues": "read", "pull_requests": "read"}, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := a.satisfiedBy(tc.scopes); got != tc.want {
+				t.Errorf("satisfiedBy(%v) = %v, want %v", tc.scopes, got, tc.want)
+			}
+		})
+	}
+}
+
+// --- handler-level integration tests ---
+
+func TestServeHTTP_GraphQL_RepoScoped_AllowsAllowlistedRepo(t *testing.T) {
+	h, ghpToken := newRepoOnlyHandler(t, "goodtune/ghp")
+
+	body := `{"query":"{ repository(owner: \"goodtune\", name: \"ghp\") { name } }"}`
+	req := httptest.NewRequest("POST", "http://api.github.com/graphql", strings.NewReader(body))
+	req.Header.Set("Authorization", "Bearer "+ghpToken)
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+
+	h.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200 for repo-scoped token referencing the allowlisted repo, got %d; body: %s", rr.Code, rr.Body.String())
+	}
+}
+
+func TestServeHTTP_GraphQL_RepoScoped_DeniesOtherRepo(t *testing.T) {
+	h, ghpToken := newRepoOnlyHandler(t, "goodtune/ghp")
+
+	body := `{"query":"{ repository(owner: \"someone\", name: \"else\") { name } }"}`
+	req := httptest.NewRequest("POST", "http://api.github.com/graphql", strings.NewReader(body))
+	req.Header.Set("Authorization", "Bearer "+ghpToken)
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+
+	h.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d; body: %s", rr.Code, rr.Body.String())
+	}
+	if !strings.Contains(rr.Body.String(), "someone/else") {
+		t.Errorf("expected error message to name the denied repo, got: %s", rr.Body.String())
+	}
+}
+
+func TestServeHTTP_GraphQL_RepoScoped_DeniesCrossRepoField(t *testing.T) {
+	h, ghpToken := newRepoOnlyHandler(t, "goodtune/ghp")
+
+	body := `{"query":"{ search(query: \"x\", type: REPOSITORY, first: 1) { repositoryCount } }"}`
+	req := httptest.NewRequest("POST", "http://api.github.com/graphql", strings.NewReader(body))
+	req.Header.Set("Authorization", "Bearer "+ghpToken)
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+
+	h.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusForbidden {
+		t.Fatalf("expected 403 for cross-repo field on repo-scoped token, got %d; body: %s", rr.Code, rr.Body.String())
+	}
+	if !strings.Contains(rr.Body.String(), "search") {
+		t.Errorf("expected error message to name the cross-repo field, got: %s", rr.Body.String())
+	}
+}
+
+func TestServeHTTP_GraphQL_RepoScoped_DeniesQueryWithoutRepoArg(t *testing.T) {
+	// A repo-scoped token with a top-level query that does not pin a repo
+	// (e.g. `{ viewer { login } }`) must be rejected: the proxy cannot prove
+	// the response stays inside the allowlist.
+	h, ghpToken := newRepoOnlyHandler(t, "goodtune/ghp")
+
+	body := `{"query":"{ viewer { login } }"}`
+	req := httptest.NewRequest("POST", "http://api.github.com/graphql", strings.NewReader(body))
+	req.Header.Set("Authorization", "Bearer "+ghpToken)
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+
+	h.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d; body: %s", rr.Code, rr.Body.String())
+	}
+	if !strings.Contains(rr.Body.String(), "repository-restricted") {
+		t.Errorf("expected error to mention repository restriction, got: %s", rr.Body.String())
+	}
+}
+
+func TestServeHTTP_GraphQL_PermissionScoped_AllowsCoveredQuery(t *testing.T) {
+	h, ghpToken := newScopeOnlyHandler(t, map[string]string{
+		"pull_requests": "read",
+	})
+
+	body := `{"query":"{ repository(owner: \"goodtune\", name: \"ghp\") { pullRequests(first: 1) { nodes { number } } } }"}`
+	req := httptest.NewRequest("POST", "http://api.github.com/graphql", strings.NewReader(body))
+	req.Header.Set("Authorization", "Bearer "+ghpToken)
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+
+	h.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200 when token's scopes cover the query, got %d; body: %s", rr.Code, rr.Body.String())
+	}
+}
+
+func TestServeHTTP_GraphQL_PermissionScoped_DeniesUncoveredQuery(t *testing.T) {
+	h, ghpToken := newScopeOnlyHandler(t, map[string]string{
+		"contents": "read",
+	})
+
+	body := `{"query":"{ repository(owner: \"goodtune\", name: \"ghp\") { issues(first: 1) { nodes { number } } } }"}`
+	req := httptest.NewRequest("POST", "http://api.github.com/graphql", strings.NewReader(body))
+	req.Header.Set("Authorization", "Bearer "+ghpToken)
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+
+	h.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusForbidden {
+		t.Fatalf("expected 403 when token lacks issues:read, got %d; body: %s", rr.Code, rr.Body.String())
+	}
+	if !strings.Contains(rr.Body.String(), "issues:read") {
+		t.Errorf("expected error to name the missing scope, got: %s", rr.Body.String())
+	}
+}
+
+func TestServeHTTP_GraphQL_PermissionScoped_DeniesMutationWithoutWriteScope(t *testing.T) {
+	h, ghpToken := newScopeOnlyHandler(t, map[string]string{
+		"issues": "read",
+	})
+
+	body := `{"query":"mutation { createIssue(input: {repositoryId: \"abc\", title: \"x\"}) { issue { id } } }"}`
+	req := httptest.NewRequest("POST", "http://api.github.com/graphql", strings.NewReader(body))
+	req.Header.Set("Authorization", "Bearer "+ghpToken)
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+
+	h.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusForbidden {
+		t.Fatalf("expected 403 for mutation without write scope, got %d; body: %s", rr.Code, rr.Body.String())
+	}
+	if !strings.Contains(rr.Body.String(), "issues:write") {
+		t.Errorf("expected error to name issues:write requirement, got: %s", rr.Body.String())
+	}
+}
+
+func TestServeHTTP_GraphQL_PermissionScoped_AllowsMutationWithWriteScope(t *testing.T) {
+	h, ghpToken := newScopeOnlyHandler(t, map[string]string{
+		"issues": "write",
+	})
+
+	body := `{"query":"mutation { createIssue(input: {repositoryId: \"abc\", title: \"x\"}) { issue { id } } }"}`
+	req := httptest.NewRequest("POST", "http://api.github.com/graphql", strings.NewReader(body))
+	req.Header.Set("Authorization", "Bearer "+ghpToken)
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+
+	h.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200 for issues:write mutation, got %d; body: %s", rr.Code, rr.Body.String())
+	}
+}
+
+func TestServeHTTP_GraphQL_PermissionScoped_DeniesUnknownMutation(t *testing.T) {
+	h, ghpToken := newScopeOnlyHandler(t, map[string]string{
+		"issues": "write",
+	})
+
+	body := `{"query":"mutation { destroyTheUniverse { ok } }"}`
+	req := httptest.NewRequest("POST", "http://api.github.com/graphql", strings.NewReader(body))
+	req.Header.Set("Authorization", "Bearer "+ghpToken)
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+
+	h.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusForbidden {
+		t.Fatalf("expected 403 (deny-by-default) for unknown mutation, got %d; body: %s", rr.Code, rr.Body.String())
+	}
+	if !strings.Contains(rr.Body.String(), "destroyTheUniverse") {
+		t.Errorf("expected error to name the unmapped field, got: %s", rr.Body.String())
+	}
+}
+
+func TestServeHTTP_GraphQL_PermissionScoped_DeniesUnknownQueryField(t *testing.T) {
+	h, ghpToken := newScopeOnlyHandler(t, map[string]string{
+		"contents": "read",
+	})
+
+	body := `{"query":"{ repository(owner: \"goodtune\", name: \"ghp\") { topSecretField { id } } }"}`
+	req := httptest.NewRequest("POST", "http://api.github.com/graphql", strings.NewReader(body))
+	req.Header.Set("Authorization", "Bearer "+ghpToken)
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+
+	h.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusForbidden {
+		t.Fatalf("expected 403 for unknown field, got %d; body: %s", rr.Code, rr.Body.String())
+	}
+	if !strings.Contains(rr.Body.String(), "topSecretField") {
+		t.Errorf("expected error to name the unmapped field, got: %s", rr.Body.String())
+	}
+}
+
+func TestServeHTTP_GraphQL_OpenScoped_BypassesAnalysis(t *testing.T) {
+	// An open-scoped token must pass even queries that would fail static
+	// analysis (e.g. unknown fields), because the underlying credential
+	// continues to gate access at GitHub's end.
+	h, ghpToken := newOpenScopedHandler(t)
+
+	body := `{"query":"{ unknownField { somethingElse } }"}`
+	req := httptest.NewRequest("POST", "http://api.github.com/graphql", strings.NewReader(body))
+	req.Header.Set("Authorization", "Bearer "+ghpToken)
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+
+	h.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200 for open-scoped token, got %d; body: %s", rr.Code, rr.Body.String())
+	}
+}
+
+func TestServeHTTP_GraphQL_RejectsInvalidJSON(t *testing.T) {
+	h, ghpToken := newScopeOnlyHandler(t, map[string]string{
+		"issues": "read",
+	})
+
+	req := httptest.NewRequest("POST", "http://api.github.com/graphql", strings.NewReader(`not json`))
+	req.Header.Set("Authorization", "Bearer "+ghpToken)
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+
+	h.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for invalid JSON body, got %d; body: %s", rr.Code, rr.Body.String())
+	}
+}
+
+func TestServeHTTP_GraphQL_RejectsOversizedBody(t *testing.T) {
+	h, ghpToken := newScopeOnlyHandler(t, map[string]string{
+		"issues": "read",
+	})
+
+	// Build a body larger than maxGraphQLBodyBytes.
+	big := strings.Repeat("a", maxGraphQLBodyBytes+1024)
+	req := httptest.NewRequest("POST", "http://api.github.com/graphql", strings.NewReader(big))
+	req.Header.Set("Authorization", "Bearer "+ghpToken)
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+
+	h.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("expected 413 for oversized body, got %d", rr.Code)
+	}
+}

--- a/internal/proxy/graphql_test.go
+++ b/internal/proxy/graphql_test.go
@@ -1,6 +1,7 @@
 package proxy
 
 import (
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
@@ -124,6 +125,108 @@ func TestAnalyzeGraphQLRequest_FragmentsResolved(t *testing.T) {
 	if !reflect.DeepEqual(got.requiredScopes, want) {
 		t.Errorf("requiredScopes = %v, want %v", got.requiredScopes, want)
 	}
+}
+
+func TestAnalyzeGraphQLRequest_FragmentAtMutationRootStillScoped(t *testing.T) {
+	// When a mutation operation pulls in its root fields via a fragment
+	// spread, those fields must still be classified as mutation root
+	// fields so mutationScopeRequirements is consulted (rather than the
+	// query field-name map).
+	body := []byte(`{"query":"mutation { ...M } fragment M on Mutation { createIssue(input: {repositoryId: \"abc\", title: \"x\"}) { issue { id } } }"}`)
+	got, err := analyzeGraphQLRequest(body)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !got.hasMutation {
+		t.Fatalf("expected mutation flag")
+	}
+	want := []scopeRequirement{{permission: "issues", level: "write"}}
+	if !reflect.DeepEqual(got.requiredScopes, want) {
+		t.Errorf("requiredScopes = %v, want %v", got.requiredScopes, want)
+	}
+	if len(got.unknownFields) != 0 {
+		t.Errorf("expected createIssue not to be flagged unknown via fragment, got %v", got.unknownFields)
+	}
+}
+
+func TestAnalyzeGraphQLRequest_RecursiveFragmentSpreadIsSafe(t *testing.T) {
+	// A self-referential fragment must not drive the analyzer into
+	// infinite recursion. (The query is technically illegal under the
+	// GraphQL spec, but the parser still produces an AST and we must not
+	// hang on it.)
+	body := []byte(`{"query":"{ repository(owner: \"goodtune\", name: \"ghp\") { ...R } } fragment R on Repository { ...R }"}`)
+	if _, err := analyzeGraphQLRequest(body); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestAnalyzeGraphQLRequest_NodesInsideConnectionIsNotCrossRepo(t *testing.T) {
+	// `nodes` is a Connection helper when nested under a connection
+	// field; it is only cross-repository when used as a root selection
+	// (`{ nodes(ids: [...]) { ... } }`). The repo-scoped analysis must
+	// not flag the inner case.
+	body := []byte(`{"query":"{ repository(owner: \"goodtune\", name: \"ghp\") { pullRequests(first: 1) { nodes { number } } } }"}`)
+	got, err := analyzeGraphQLRequest(body)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got.crossRepoFields) != 0 {
+		t.Errorf("nested `nodes` should not be flagged cross-repo, got %v", got.crossRepoFields)
+	}
+}
+
+func TestAnalyzeGraphQLRequest_RootNodesIsCrossRepo(t *testing.T) {
+	// Root-level `nodes(ids: ...)` is the cross-repository form.
+	body := []byte(`{"query":"{ nodes(ids: [\"abc\"]) { __typename } }"}`)
+	got, err := analyzeGraphQLRequest(body)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got.crossRepoFields) == 0 {
+		t.Fatalf("expected root-level `nodes` to be flagged cross-repo")
+	}
+}
+
+func TestAnalyzeGraphQLRequest_OperationNameSelectsOnlyOne(t *testing.T) {
+	// The document defines two operations; only `Wanted` should be
+	// analysed. `Unwanted` references unknown fields that would otherwise
+	// fail deny-by-default.
+	q := "query Wanted { viewer { login } } query Unwanted { mysteryRoot { id } }"
+	body := []byte(`{"query":` + jsonString(q) + `,"operationName":"Wanted"}`)
+	got, err := analyzeGraphQLRequest(body)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got.unknownFields) != 0 {
+		t.Errorf("only the named operation should be analysed; got unknown fields %v", got.unknownFields)
+	}
+}
+
+func TestAnalyzeGraphQLRequest_OperationNameMissingErrors(t *testing.T) {
+	q := "query A { viewer { login } } query B { viewer { login } }"
+	body := []byte(`{"query":` + jsonString(q) + `,"operationName":"C"}`)
+	if _, err := analyzeGraphQLRequest(body); err == nil {
+		t.Fatal("expected error when operationName does not match any operation")
+	}
+}
+
+func TestAnalyzeGraphQLRequest_MultipleOperationsRequireOperationName(t *testing.T) {
+	q := "query A { viewer { login } } query B { viewer { login } }"
+	body := []byte(`{"query":` + jsonString(q) + `}`)
+	if _, err := analyzeGraphQLRequest(body); err == nil {
+		t.Fatal("expected error when document has multiple operations and operationName is omitted")
+	}
+}
+
+// jsonString escapes s as a JSON string literal (including surrounding
+// double quotes) so it can be embedded directly into a hand-written JSON
+// fragment in tests.
+func jsonString(s string) string {
+	b, err := json.Marshal(s)
+	if err != nil {
+		panic(err)
+	}
+	return string(b)
 }
 
 func TestAnalyzeGraphQLRequest_SubscriptionFlagged(t *testing.T) {

--- a/internal/proxy/graphql_test.go
+++ b/internal/proxy/graphql_test.go
@@ -339,6 +339,31 @@ func TestAnalysisSatisfiedBy(t *testing.T) {
 
 // --- handler-level integration tests ---
 
+func TestServeHTTP_GraphQL_RepoScoped_RejectsMutationWithClearMessage(t *testing.T) {
+	// GitHub GraphQL mutations identify their target by global node ID
+	// (e.g. `repositoryId: "MDEwOlJlcG9zaXRvcnk="`) rather than by an
+	// `owner`/`name` pair, so the proxy cannot statically map them to
+	// the repo allowlist. Repo-scoped tokens must therefore be rejected
+	// with a clear, actionable error rather than the generic "must
+	// reference repository(owner, name)" message intended for queries.
+	h, ghpToken := newRepoOnlyHandler(t, "goodtune/ghp")
+
+	body := `{"query":"mutation { createIssue(input: {repositoryId: \"abc\", title: \"x\"}) { issue { id } } }"}`
+	req := httptest.NewRequest("POST", "http://api.github.com/graphql", strings.NewReader(body))
+	req.Header.Set("Authorization", "Bearer "+ghpToken)
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+
+	h.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d; body: %s", rr.Code, rr.Body.String())
+	}
+	if !strings.Contains(rr.Body.String(), "mutations are not supported") {
+		t.Errorf("expected mutation-specific error, got: %s", rr.Body.String())
+	}
+}
+
 func TestServeHTTP_GraphQL_RepoScoped_AllowsAllowlistedRepo(t *testing.T) {
 	h, ghpToken := newRepoOnlyHandler(t, "goodtune/ghp")
 

--- a/internal/proxy/graphql_test.go
+++ b/internal/proxy/graphql_test.go
@@ -211,6 +211,28 @@ func TestAnalyzeGraphQLRequest_UndefinedFragmentSpreadFlagged(t *testing.T) {
 	}
 }
 
+func TestAnalyzeGraphQLRequest_DepthLimitEnforced(t *testing.T) {
+	// A query with nesting depth far above maxAnalysisDepth must be
+	// rejected rather than driving the analyser into stack overflow.
+	var b strings.Builder
+	b.WriteString("{ ")
+	const nest = maxAnalysisDepth + 50
+	for i := 0; i < nest; i++ {
+		b.WriteString("a { ")
+	}
+	b.WriteString("__typename ")
+	for i := 0; i < nest; i++ {
+		b.WriteString("} ")
+	}
+	b.WriteString("}")
+	body := []byte(`{"query":` + jsonString(b.String()) + `}`)
+	if _, err := analyzeGraphQLRequest(body); err == nil {
+		t.Fatal("expected depth-limit error, got nil")
+	} else if !strings.Contains(err.Error(), "maximum analysis depth") {
+		t.Errorf("expected error to mention depth limit, got %v", err)
+	}
+}
+
 func TestAnalyzeGraphQLRequest_RecursiveFragmentSpreadIsSafe(t *testing.T) {
 	// A self-referential fragment must not drive the analyzer into
 	// infinite recursion. (The query is technically illegal under the

--- a/internal/proxy/graphql_test.go
+++ b/internal/proxy/graphql_test.go
@@ -60,6 +60,45 @@ func TestAnalyzeGraphQLRequest_RepositoryArgsAreLiteralOnly(t *testing.T) {
 	if len(got.referencedRepos) != 0 {
 		t.Errorf("variable-driven owner must not produce a referencedRepos entry, got %v", got.referencedRepos)
 	}
+	if !got.hasUnpinnedRepositoryLookup {
+		t.Errorf("variable-driven repository lookup must set hasUnpinnedRepositoryLookup")
+	}
+}
+
+func TestAnalyzeGraphQLRequest_LiteralRepositoryDoesNotFlagUnpinned(t *testing.T) {
+	body := []byte(`{"query":"{ repository(owner: \"goodtune\", name: \"ghp\") { id } }"}`)
+	got, err := analyzeGraphQLRequest(body)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.hasUnpinnedRepositoryLookup {
+		t.Errorf("literal repository(...) must not set hasUnpinnedRepositoryLookup")
+	}
+}
+
+func TestServeHTTP_GraphQL_RepoScoped_RejectsMixedLiteralAndVariableRepoLookups(t *testing.T) {
+	// A repo-scoped query that mixes one literal allowlisted lookup
+	// with a variable-driven `repository(...)` selection must be
+	// rejected: the proxy cannot validate the second lookup against
+	// the allowlist, so an attacker could otherwise pin one allowed
+	// repo and ride a variable-driven lookup past enforcement.
+	h, ghpToken := newRepoOnlyHandler(t, "goodtune/ghp")
+
+	q := "query Q($o: String!, $n: String!) { allowed: repository(owner: \"goodtune\", name: \"ghp\") { name } sneaky: repository(owner: $o, name: $n) { name } }"
+	body := `{"query":` + jsonString(q) + `,"variables":{"o":"someone","n":"else"}}`
+	req := httptest.NewRequest("POST", "http://api.github.com/graphql", strings.NewReader(body))
+	req.Header.Set("Authorization", "Bearer "+ghpToken)
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+
+	h.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusForbidden {
+		t.Fatalf("expected 403 for mixed literal+variable repo lookup, got %d; body: %s", rr.Code, rr.Body.String())
+	}
+	if !strings.Contains(rr.Body.String(), "literal string arguments") {
+		t.Errorf("expected error to call out non-literal repository args, got: %s", rr.Body.String())
+	}
 }
 
 func TestAnalyzeGraphQLRequest_PullRequestRequiresScope(t *testing.T) {

--- a/internal/proxy/graphql_test.go
+++ b/internal/proxy/graphql_test.go
@@ -149,6 +149,38 @@ func TestAnalyzeGraphQLRequest_FragmentAtMutationRootStillScoped(t *testing.T) {
 	}
 }
 
+func TestAnalyzeGraphQLRequest_UnknownRootScalarFlagged(t *testing.T) {
+	// A scalar leaf at the operation root has no parent to gate it, so
+	// it must remain deny-by-default. (Nested leaves are intentionally
+	// not flagged — see TestAnalyzeGraphQLRequest_PullRequestRequiresScope
+	// for an example query that projects scalars under a scoped parent
+	// without the scalar names appearing in `unknownFields`.)
+	body := []byte(`{"query":"{ totallyUnknownRootScalar }"}`)
+	got, err := analyzeGraphQLRequest(body)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := []string{"totallyUnknownRootScalar"}
+	if !reflect.DeepEqual(got.unknownFields, want) {
+		t.Errorf("unknownFields = %v, want %v", got.unknownFields, want)
+	}
+}
+
+func TestAnalyzeGraphQLRequest_NestedUnknownScalarNotFlagged(t *testing.T) {
+	// Sanity check the deliberate trade-off: an unmapped scalar nested
+	// under a known parent is permitted, since the parent's scope
+	// requirement already gates the surrounding access. Documented as a
+	// known limitation in docs/features/token-scoping.md.
+	body := []byte(`{"query":"{ repository(owner: \"goodtune\", name: \"ghp\") { someUnmappedScalar } }"}`)
+	got, err := analyzeGraphQLRequest(body)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got.unknownFields) != 0 {
+		t.Errorf("nested scalar leaf should not be flagged, got %v", got.unknownFields)
+	}
+}
+
 func TestAnalyzeGraphQLRequest_UnknownDoubleUnderscoreFieldFlagged(t *testing.T) {
 	// `__schema` and `__type` are explicitly allow-listed via
 	// alwaysAllowedFields; any other `__*` object-typed field must still

--- a/internal/proxy/graphql_test.go
+++ b/internal/proxy/graphql_test.go
@@ -648,6 +648,16 @@ func TestServeHTTP_GraphQL_RejectsInvalidJSON(t *testing.T) {
 	if rr.Code != http.StatusBadRequest {
 		t.Fatalf("expected 400 for invalid JSON body, got %d; body: %s", rr.Code, rr.Body.String())
 	}
+	// Documentation URL must point at GitHub's GraphQL reference, not REST.
+	body := rr.Body.String()
+	if !strings.Contains(body, "docs.github.com/graphql") {
+		t.Errorf("expected GraphQL docs URL in 400 body, got: %s", body)
+	}
+	// The wrapper message must not double the "graphql:" prefix coming
+	// from the analyser error.
+	if strings.Contains(body, "Invalid GraphQL request: graphql:") {
+		t.Errorf("expected single GraphQL prefix, got: %s", body)
+	}
 }
 
 func TestServeHTTP_GraphQL_RejectsNonPost(t *testing.T) {

--- a/internal/proxy/graphql_test.go
+++ b/internal/proxy/graphql_test.go
@@ -76,6 +76,26 @@ func TestAnalyzeGraphQLRequest_LiteralRepositoryDoesNotFlagUnpinned(t *testing.T
 	}
 }
 
+func TestAnalyzeGraphQLRequest_NestedRepositoryFieldDoesNotFlagUnpinned(t *testing.T) {
+	// Nested `repository` accessors (e.g. `Issue.repository`,
+	// `PullRequest.repository`) take no arguments — they are not
+	// `repository(owner, name)` lookups but plain field traversals from a
+	// parent type back to the owning Repository. They must not be flagged
+	// as "unpinned", or every repo-scoped query that uses them would be
+	// rejected.
+	body := []byte(`{"query":"{ repository(owner: \"goodtune\", name: \"ghp\") { issues(first: 1) { nodes { repository { id } } } } }"}`)
+	got, err := analyzeGraphQLRequest(body)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.hasUnpinnedRepositoryLookup {
+		t.Errorf("nested no-arg `repository` field must not set hasUnpinnedRepositoryLookup")
+	}
+	if len(got.referencedRepos) != 1 || got.referencedRepos[0] != "goodtune/ghp" {
+		t.Errorf("referencedRepos = %v, want [goodtune/ghp]", got.referencedRepos)
+	}
+}
+
 func TestServeHTTP_GraphQL_RepoScoped_RejectsMixedLiteralAndVariableRepoLookups(t *testing.T) {
 	// A repo-scoped query that mixes one literal allowlisted lookup
 	// with a variable-driven `repository(...)` selection must be

--- a/internal/proxy/graphql_test.go
+++ b/internal/proxy/graphql_test.go
@@ -149,6 +149,21 @@ func TestAnalyzeGraphQLRequest_FragmentAtMutationRootStillScoped(t *testing.T) {
 	}
 }
 
+func TestAnalyzeGraphQLRequest_UndefinedFragmentSpreadFlagged(t *testing.T) {
+	// A spread that names a fragment the document does not define must
+	// surface as an unknown-field entry so scoped tokens are denied
+	// rather than letting a malformed document slip through.
+	body := []byte(`{"query":"{ repository(owner: \"goodtune\", name: \"ghp\") { ...Missing } }"}`)
+	got, err := analyzeGraphQLRequest(body)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := []string{"fragment:Missing"}
+	if !reflect.DeepEqual(got.unknownFields, want) {
+		t.Errorf("unknownFields = %v, want %v", got.unknownFields, want)
+	}
+}
+
 func TestAnalyzeGraphQLRequest_RecursiveFragmentSpreadIsSafe(t *testing.T) {
 	// A self-referential fragment must not drive the analyzer into
 	// infinite recursion. (The query is technically illegal under the
@@ -215,6 +230,28 @@ func TestAnalyzeGraphQLRequest_MultipleOperationsRequireOperationName(t *testing
 	body := []byte(`{"query":` + jsonString(q) + `}`)
 	if _, err := analyzeGraphQLRequest(body); err == nil {
 		t.Fatal("expected error when document has multiple operations and operationName is omitted")
+	}
+}
+
+func TestSummariseFieldList(t *testing.T) {
+	tests := []struct {
+		name  string
+		in    []string
+		limit int
+		want  string
+	}{
+		{"empty", nil, 5, ""},
+		{"under limit", []string{"a", "b"}, 5, "a, b"},
+		{"at limit", []string{"a", "b", "c"}, 3, "a, b, c"},
+		{"over limit", []string{"a", "b", "c", "d", "e"}, 2, "a, b, …and 3 more"},
+		{"limit zero falls back to full join", []string{"a", "b"}, 0, "a, b"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := summariseFieldList(tc.in, tc.limit); got != tc.want {
+				t.Errorf("summariseFieldList(%v, %d) = %q, want %q", tc.in, tc.limit, got, tc.want)
+			}
+		})
 	}
 }
 

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -338,9 +338,11 @@ func (h *Handler) handleGraphQL(w http.ResponseWriter, r *http.Request, pt *data
 
 	// Open-scoped tokens skip GraphQL static analysis entirely and forward
 	// to GitHub unchanged. The underlying credential's own permissions act
-	// as the only enforcement layer. Emit a zero-duration scope-enforcement
-	// decision so the per-request stage timeline is uniform across paths.
+	// as the only enforcement layer. Emit zero-duration GraphQL-analysis
+	// and scope-enforcement decisions so the per-request stage timeline
+	// is uniform across paths.
 	if si.isOpenScoped() {
+		metrics.ObserveDecision(metrics.StageGraphQLAnalysis, tokenType, 0)
 		metrics.ObserveDecision(metrics.StageScopeEnforcement, tokenType, 0)
 		h.forwardGraphQL(w, r, pt, &si, rewriteAuth, start, nil)
 		return

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -349,26 +349,28 @@ func (h *Handler) handleGraphQL(w http.ResponseWriter, r *http.Request, pt *data
 	}
 
 	// Buffer the request body so we can both analyse the query and replay
-	// it to GitHub. MaxBytesReader caps the read so unbounded uploads are
-	// rejected before any allocation. Close the original body once it is
-	// drained so the underlying network connection can be returned to the
-	// pool while we run static analysis.
+	// it to GitHub. Read at most maxGraphQLBodyBytes+1 so oversized
+	// bodies are detected without letting `http.MaxBytesReader` write
+	// directly to the live ResponseWriter (which would race with the
+	// writeError call below and emit a mixed response). Close the
+	// original body once it is drained so the underlying network
+	// connection can be returned to the pool while we run static
+	// analysis.
 	originalBody := r.Body
-	body, err := io.ReadAll(http.MaxBytesReader(w, r.Body, maxGraphQLBodyBytes))
+	body, err := io.ReadAll(io.LimitReader(r.Body, maxGraphQLBodyBytes+1))
 	_ = originalBody.Close()
 	if err != nil {
-		var maxErr *http.MaxBytesError
-		if errors.As(err, &maxErr) {
-			metrics.ObserveDecision(metrics.StageTotal, tokenType, time.Since(start))
-			writeError(w, http.StatusRequestEntityTooLarge,
-				"GraphQL request body exceeds proxy size limit")
-			h.logRequest(pt, r, "/graphql", "", http.StatusRequestEntityTooLarge, time.Since(start), "proxy_scope_denied")
-			return
-		}
 		h.logger.Warn("graphql: failed to read request body", "error", err)
 		metrics.ObserveDecision(metrics.StageTotal, tokenType, time.Since(start))
 		writeError(w, http.StatusBadRequest, "Failed to read GraphQL request body")
 		h.logRequest(pt, r, "/graphql", "", http.StatusBadRequest, time.Since(start), "proxy_scope_denied")
+		return
+	}
+	if int64(len(body)) > maxGraphQLBodyBytes {
+		metrics.ObserveDecision(metrics.StageTotal, tokenType, time.Since(start))
+		writeError(w, http.StatusRequestEntityTooLarge,
+			"GraphQL request body exceeds proxy size limit")
+		h.logRequest(pt, r, "/graphql", "", http.StatusRequestEntityTooLarge, time.Since(start), "proxy_scope_denied")
 		return
 	}
 	r.Body = io.NopCloser(bytes.NewReader(body))

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -365,7 +365,7 @@ func (h *Handler) handleGraphQL(w http.ResponseWriter, r *http.Request, pt *data
 		w.Header().Set("Allow", http.MethodPost)
 		metrics.ObserveDecision(metrics.StageTotal, tokenType, time.Since(start))
 		writeGraphQLError(w, http.StatusMethodNotAllowed, "GraphQL endpoint only accepts POST")
-		h.logRequest(pt, r, "/graphql", "", http.StatusMethodNotAllowed, time.Since(start), "proxy_scope_denied")
+		h.logRequest(pt, r, "/graphql", "", http.StatusMethodNotAllowed, time.Since(start), "proxy_request_invalid")
 		return
 	}
 
@@ -396,14 +396,14 @@ func (h *Handler) handleGraphQL(w http.ResponseWriter, r *http.Request, pt *data
 		h.logger.Warn("graphql: failed to read request body", "error", err)
 		metrics.ObserveDecision(metrics.StageTotal, tokenType, time.Since(start))
 		writeGraphQLError(w, http.StatusBadRequest, "Failed to read GraphQL request body")
-		h.logRequest(pt, r, "/graphql", "", http.StatusBadRequest, time.Since(start), "proxy_scope_denied")
+		h.logRequest(pt, r, "/graphql", "", http.StatusBadRequest, time.Since(start), "proxy_request_invalid")
 		return
 	}
 	if int64(len(body)) > maxGraphQLBodyBytes {
 		metrics.ObserveDecision(metrics.StageTotal, tokenType, time.Since(start))
 		writeGraphQLError(w, http.StatusRequestEntityTooLarge,
 			"GraphQL request body exceeds proxy size limit")
-		h.logRequest(pt, r, "/graphql", "", http.StatusRequestEntityTooLarge, time.Since(start), "proxy_scope_denied")
+		h.logRequest(pt, r, "/graphql", "", http.StatusRequestEntityTooLarge, time.Since(start), "proxy_request_invalid")
 		return
 	}
 	r.Body = io.NopCloser(bytes.NewReader(body))
@@ -422,7 +422,7 @@ func (h *Handler) handleGraphQL(w http.ResponseWriter, r *http.Request, pt *data
 		// single sentence rather than nesting two GraphQL-specific
 		// prefixes.
 		writeGraphQLError(w, http.StatusBadRequest, fmt.Sprintf("Invalid request: %s", err.Error()))
-		h.logRequest(pt, r, "/graphql", "", http.StatusBadRequest, time.Since(start), "proxy_scope_denied")
+		h.logRequest(pt, r, "/graphql", "", http.StatusBadRequest, time.Since(start), "proxy_request_invalid")
 		return
 	}
 

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -463,6 +463,20 @@ func (h *Handler) handleGraphQL(w http.ResponseWriter, r *http.Request, pt *data
 			h.logRequest(pt, r, "/graphql", "", http.StatusForbidden, time.Since(start), "proxy_scope_denied")
 			return
 		}
+		// GraphQL mutations on GitHub take an opaque `repositoryId`
+		// (global node ID) in their input rather than `owner`/`name`,
+		// which the proxy cannot statically map to its allowlist. Reject
+		// mutations on repository-restricted tokens with a clear,
+		// actionable message rather than the generic "must reference
+		// repository(owner, name)" path below.
+		if analysis.hasMutation {
+			metrics.ObserveDecision(metrics.StageScopeEnforcement, tokenType, time.Since(scopeEnforceStart))
+			metrics.ObserveDecision(metrics.StageTotal, tokenType, time.Since(start))
+			writeError(w, http.StatusForbidden,
+				"Token is repository-restricted; GraphQL mutations are not supported for repository-scoped tokens (mutations identify their target by global node ID, which the proxy cannot statically map to a repository)")
+			h.logRequest(pt, r, "/graphql", "", http.StatusForbidden, time.Since(start), "proxy_scope_denied")
+			return
+		}
 		// Repository-restricted queries must include at least one literal
 		// repository(owner, name) reference, and every referenced
 		// repository must be in the allowlist. Selections that are not

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -481,6 +481,20 @@ func (h *Handler) handleGraphQL(w http.ResponseWriter, r *http.Request, pt *data
 			h.logRequest(pt, r, "/graphql", "", http.StatusForbidden, time.Since(start), "proxy_scope_denied")
 			return
 		}
+		// A `repository(owner, name)` selection whose arguments are not
+		// literal strings (e.g. variable-driven) cannot be statically
+		// validated against the allowlist. Reject the request even if
+		// it also contains other literal allowlisted lookups —
+		// otherwise an attacker could pin one allowlisted repo and ride
+		// a second unbounded variable lookup past the check.
+		if analysis.hasUnpinnedRepositoryLookup {
+			metrics.ObserveDecision(metrics.StageScopeEnforcement, tokenType, time.Since(scopeEnforceStart))
+			metrics.ObserveDecision(metrics.StageTotal, tokenType, time.Since(start))
+			writeGraphQLError(w, http.StatusForbidden,
+				"Token is repository-restricted; every repository(owner, name) selection must use literal string arguments (variable-driven lookups cannot be allowlist-checked)")
+			h.logRequest(pt, r, "/graphql", "", http.StatusForbidden, time.Since(start), "proxy_scope_denied")
+			return
+		}
 		// Repository-restricted queries must include at least one literal
 		// repository(owner, name) reference, and every referenced
 		// repository must be in the allowlist. Selections that are not
@@ -858,9 +872,17 @@ func (h *Handler) forwardRequest(w http.ResponseWriter, r *http.Request, path, a
 		targetURL += "?" + r.URL.RawQuery
 	}
 
+	// Use the GraphQL-flavoured error envelope (with the GraphQL docs
+	// URL) for /graphql failures so proxy-generated 5xx responses don't
+	// point clients at the REST docs.
+	errWriter := writeError
+	if path == "/graphql" {
+		errWriter = writeGraphQLError
+	}
+
 	proxyReq, err := http.NewRequestWithContext(r.Context(), r.Method, targetURL, r.Body)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, "Failed to create upstream request")
+		errWriter(w, http.StatusInternalServerError, "Failed to create upstream request")
 		return http.StatusInternalServerError
 	}
 
@@ -882,7 +904,7 @@ func (h *Handler) forwardRequest(w http.ResponseWriter, r *http.Request, path, a
 	resp, err := h.client.Do(proxyReq)
 	if err != nil {
 		h.logger.Error("upstream request failed", "error", err)
-		writeError(w, http.StatusBadGateway, "Upstream request failed")
+		errWriter(w, http.StatusBadGateway, "Upstream request failed")
 		return http.StatusBadGateway
 	}
 	defer resp.Body.Close()

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -426,9 +426,12 @@ func (h *Handler) handleGraphQL(w http.ResponseWriter, r *http.Request, pt *data
 			h.logRequest(pt, r, "/graphql", "", http.StatusForbidden, time.Since(start), "proxy_scope_denied")
 			return
 		}
-		// Every selection in the query must be pinned to at least one
-		// repository, and every referenced repository must be in the
-		// allowlist.
+		// Repository-restricted queries must include at least one literal
+		// repository(owner, name) reference, and every referenced
+		// repository must be in the allowlist. Selections that are not
+		// pinned to a repository are bounded by the cross-repository
+		// field check above, which rejects fields that could return
+		// out-of-allowlist data.
 		if len(analysis.referencedRepos) == 0 {
 			metrics.ObserveDecision(metrics.StageScopeEnforcement, tokenType, time.Since(scopeEnforceStart))
 			metrics.ObserveDecision(metrics.StageTotal, tokenType, time.Since(start))

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -364,7 +364,7 @@ func (h *Handler) handleGraphQL(w http.ResponseWriter, r *http.Request, pt *data
 	if r.Method != http.MethodPost {
 		w.Header().Set("Allow", http.MethodPost)
 		metrics.ObserveDecision(metrics.StageTotal, tokenType, time.Since(start))
-		writeError(w, http.StatusMethodNotAllowed, "GraphQL endpoint only accepts POST")
+		writeGraphQLError(w, http.StatusMethodNotAllowed, "GraphQL endpoint only accepts POST")
 		h.logRequest(pt, r, "/graphql", "", http.StatusMethodNotAllowed, time.Since(start), "proxy_scope_denied")
 		return
 	}
@@ -395,13 +395,13 @@ func (h *Handler) handleGraphQL(w http.ResponseWriter, r *http.Request, pt *data
 	if err != nil {
 		h.logger.Warn("graphql: failed to read request body", "error", err)
 		metrics.ObserveDecision(metrics.StageTotal, tokenType, time.Since(start))
-		writeError(w, http.StatusBadRequest, "Failed to read GraphQL request body")
+		writeGraphQLError(w, http.StatusBadRequest, "Failed to read GraphQL request body")
 		h.logRequest(pt, r, "/graphql", "", http.StatusBadRequest, time.Since(start), "proxy_scope_denied")
 		return
 	}
 	if int64(len(body)) > maxGraphQLBodyBytes {
 		metrics.ObserveDecision(metrics.StageTotal, tokenType, time.Since(start))
-		writeError(w, http.StatusRequestEntityTooLarge,
+		writeGraphQLError(w, http.StatusRequestEntityTooLarge,
 			"GraphQL request body exceeds proxy size limit")
 		h.logRequest(pt, r, "/graphql", "", http.StatusRequestEntityTooLarge, time.Since(start), "proxy_scope_denied")
 		return
@@ -417,7 +417,11 @@ func (h *Handler) handleGraphQL(w http.ResponseWriter, r *http.Request, pt *data
 	if err != nil {
 		// Fail closed: a query we cannot parse is a query we cannot scope.
 		metrics.ObserveDecision(metrics.StageTotal, tokenType, time.Since(start))
-		writeError(w, http.StatusBadRequest, fmt.Sprintf("Invalid GraphQL request: %s", err.Error()))
+		// `analyzeGraphQLRequest` already prefixes its error strings with
+		// "graphql:"; surface them directly so the message reads as a
+		// single sentence rather than nesting two GraphQL-specific
+		// prefixes.
+		writeGraphQLError(w, http.StatusBadRequest, fmt.Sprintf("Invalid request: %s", err.Error()))
 		h.logRequest(pt, r, "/graphql", "", http.StatusBadRequest, time.Since(start), "proxy_scope_denied")
 		return
 	}
@@ -430,7 +434,7 @@ func (h *Handler) handleGraphQL(w http.ResponseWriter, r *http.Request, pt *data
 	if analysis.hasSubscription {
 		metrics.ObserveDecision(metrics.StageScopeEnforcement, tokenType, time.Since(scopeEnforceStart))
 		metrics.ObserveDecision(metrics.StageTotal, tokenType, time.Since(start))
-		writeError(w, http.StatusForbidden, "GraphQL subscriptions are not supported")
+		writeGraphQLError(w, http.StatusForbidden, "GraphQL subscriptions are not supported")
 		h.logRequest(pt, r, "/graphql", "", http.StatusForbidden, time.Since(start), "proxy_scope_denied")
 		return
 	}
@@ -442,7 +446,7 @@ func (h *Handler) handleGraphQL(w http.ResponseWriter, r *http.Request, pt *data
 	if len(analysis.unknownFields) > 0 {
 		metrics.ObserveDecision(metrics.StageScopeEnforcement, tokenType, time.Since(scopeEnforceStart))
 		metrics.ObserveDecision(metrics.StageTotal, tokenType, time.Since(start))
-		writeError(w, http.StatusForbidden,
+		writeGraphQLError(w, http.StatusForbidden,
 			fmt.Sprintf("GraphQL request references unmapped fields: %s", summariseFieldList(analysis.unknownFields, maxRenderedFieldNames)))
 		h.logRequest(pt, r, "/graphql", "", http.StatusForbidden, time.Since(start), "proxy_scope_denied")
 		return
@@ -457,7 +461,7 @@ func (h *Handler) handleGraphQL(w http.ResponseWriter, r *http.Request, pt *data
 		if len(analysis.crossRepoFields) > 0 {
 			metrics.ObserveDecision(metrics.StageScopeEnforcement, tokenType, time.Since(scopeEnforceStart))
 			metrics.ObserveDecision(metrics.StageTotal, tokenType, time.Since(start))
-			writeError(w, http.StatusForbidden,
+			writeGraphQLError(w, http.StatusForbidden,
 				fmt.Sprintf("Token is repository-restricted; GraphQL request uses cross-repository fields: %s",
 					summariseFieldList(analysis.crossRepoFields, maxRenderedFieldNames)))
 			h.logRequest(pt, r, "/graphql", "", http.StatusForbidden, time.Since(start), "proxy_scope_denied")
@@ -472,7 +476,7 @@ func (h *Handler) handleGraphQL(w http.ResponseWriter, r *http.Request, pt *data
 		if analysis.hasMutation {
 			metrics.ObserveDecision(metrics.StageScopeEnforcement, tokenType, time.Since(scopeEnforceStart))
 			metrics.ObserveDecision(metrics.StageTotal, tokenType, time.Since(start))
-			writeError(w, http.StatusForbidden,
+			writeGraphQLError(w, http.StatusForbidden,
 				"Token is repository-restricted; GraphQL mutations are not supported for repository-scoped tokens (mutations identify their target by global node ID, which the proxy cannot statically map to a repository)")
 			h.logRequest(pt, r, "/graphql", "", http.StatusForbidden, time.Since(start), "proxy_scope_denied")
 			return
@@ -486,7 +490,7 @@ func (h *Handler) handleGraphQL(w http.ResponseWriter, r *http.Request, pt *data
 		if len(analysis.referencedRepos) == 0 {
 			metrics.ObserveDecision(metrics.StageScopeEnforcement, tokenType, time.Since(scopeEnforceStart))
 			metrics.ObserveDecision(metrics.StageTotal, tokenType, time.Since(start))
-			writeError(w, http.StatusForbidden,
+			writeGraphQLError(w, http.StatusForbidden,
 				"Token is repository-restricted; GraphQL request must reference repository(owner, name) with literal arguments")
 			h.logRequest(pt, r, "/graphql", "", http.StatusForbidden, time.Since(start), "proxy_scope_denied")
 			return
@@ -495,7 +499,7 @@ func (h *Handler) handleGraphQL(w http.ResponseWriter, r *http.Request, pt *data
 			if !si.repoAllowed(repo) {
 				metrics.ObserveDecision(metrics.StageScopeEnforcement, tokenType, time.Since(scopeEnforceStart))
 				metrics.ObserveDecision(metrics.StageTotal, tokenType, time.Since(start))
-				writeError(w, http.StatusForbidden,
+				writeGraphQLError(w, http.StatusForbidden,
 					fmt.Sprintf("Token is not scoped to %s", repo))
 				h.logRequest(pt, r, "/graphql", repo, http.StatusForbidden, time.Since(start), "proxy_scope_denied")
 				return
@@ -512,7 +516,7 @@ func (h *Handler) handleGraphQL(w http.ResponseWriter, r *http.Request, pt *data
 		if analysis.hasMutation && len(analysis.requiredScopes) == 0 {
 			metrics.ObserveDecision(metrics.StageScopeEnforcement, tokenType, time.Since(scopeEnforceStart))
 			metrics.ObserveDecision(metrics.StageTotal, tokenType, time.Since(start))
-			writeError(w, http.StatusForbidden,
+			writeGraphQLError(w, http.StatusForbidden,
 				"GraphQL mutation could not be statically scoped; rejected by deny-by-default policy")
 			h.logRequest(pt, r, "/graphql", "", http.StatusForbidden, time.Since(start), "proxy_scope_denied")
 			return
@@ -520,7 +524,7 @@ func (h *Handler) handleGraphQL(w http.ResponseWriter, r *http.Request, pt *data
 		if missing := analysis.missingScopes(si.Scopes); len(missing) > 0 {
 			metrics.ObserveDecision(metrics.StageScopeEnforcement, tokenType, time.Since(scopeEnforceStart))
 			metrics.ObserveDecision(metrics.StageTotal, tokenType, time.Since(start))
-			writeError(w, http.StatusForbidden,
+			writeGraphQLError(w, http.StatusForbidden,
 				fmt.Sprintf("Token does not grant required GraphQL scopes: %s", strings.Join(missing, ", ")))
 			h.logRequest(pt, r, "/graphql", "", http.StatusForbidden, time.Since(start), "proxy_scope_denied")
 			return
@@ -551,7 +555,7 @@ func (h *Handler) forwardGraphQL(w http.ResponseWriter, r *http.Request, pt *dat
 		h.logger.Error("failed to get GitHub token for GraphQL", "error", err)
 		status, msg := installationTokenErrorResponse(err)
 		metrics.ObserveDecision(metrics.StageTotal, tokenType, time.Since(start))
-		writeError(w, status, msg)
+		writeGraphQLError(w, status, msg)
 		return
 	}
 
@@ -1017,10 +1021,23 @@ func installationTokenErrorResponse(err error) (int, string) {
 }
 
 func writeError(w http.ResponseWriter, status int, message string) {
+	writeErrorWithDocs(w, status, message, "https://docs.github.com/rest")
+}
+
+// writeGraphQLError is the GraphQL-specific variant of writeError that
+// sets the documentation_url to GitHub's GraphQL reference. The proxy's
+// `/graphql` handler returns its own JSON error envelopes (rejections,
+// 405 method-not-allowed, oversized body, etc.) and pointing those at
+// the REST docs would mislead clients debugging GraphQL failures.
+func writeGraphQLError(w http.ResponseWriter, status int, message string) {
+	writeErrorWithDocs(w, status, message, "https://docs.github.com/graphql")
+}
+
+func writeErrorWithDocs(w http.ResponseWriter, status int, message, docsURL string) {
 	w.Header().Set("Content-Type", "application/json; charset=utf-8")
 	w.WriteHeader(status)
 	json.NewEncoder(w).Encode(map[string]string{
 		"message":           message,
-		"documentation_url": "https://docs.github.com/rest",
+		"documentation_url": docsURL,
 	})
 }

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -338,16 +338,22 @@ func (h *Handler) handleGraphQL(w http.ResponseWriter, r *http.Request, pt *data
 
 	// Open-scoped tokens skip GraphQL static analysis entirely and forward
 	// to GitHub unchanged. The underlying credential's own permissions act
-	// as the only enforcement layer.
+	// as the only enforcement layer. Emit a zero-duration scope-enforcement
+	// decision so the per-request stage timeline is uniform across paths.
 	if si.isOpenScoped() {
+		metrics.ObserveDecision(metrics.StageScopeEnforcement, tokenType, 0)
 		h.forwardGraphQL(w, r, pt, &si, rewriteAuth, start, nil)
 		return
 	}
 
 	// Buffer the request body so we can both analyse the query and replay
 	// it to GitHub. MaxBytesReader caps the read so unbounded uploads are
-	// rejected before any allocation.
+	// rejected before any allocation. Close the original body once it is
+	// drained so the underlying network connection can be returned to the
+	// pool while we run static analysis.
+	originalBody := r.Body
 	body, err := io.ReadAll(http.MaxBytesReader(w, r.Body, maxGraphQLBodyBytes))
+	_ = originalBody.Close()
 	if err != nil {
 		var maxErr *http.MaxBytesError
 		if errors.As(err, &maxErr) {

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -382,13 +382,13 @@ func (h *Handler) handleGraphQL(w http.ResponseWriter, r *http.Request, pt *data
 	}
 
 	// Buffer the request body so we can both analyse the query and replay
-	// it to GitHub. Read at most maxGraphQLBodyBytes+1 so oversized
-	// bodies are detected without letting `http.MaxBytesReader` write
-	// directly to the live ResponseWriter (which would race with the
-	// writeError call below and emit a mixed response). Close the
-	// original body once it is drained so the underlying network
-	// connection can be returned to the pool while we run static
-	// analysis.
+	// it to GitHub. Read at most maxGraphQLBodyBytes+1 via io.LimitReader,
+	// then explicitly reject oversized bodies after io.ReadAll returns so
+	// this handler — rather than an implicit reader-side write (which
+	// `http.MaxBytesReader` would do) — controls the error response
+	// emitted below. Close the original body once it is drained so the
+	// underlying network connection can be returned to the pool while we
+	// run static analysis.
 	originalBody := r.Body
 	body, err := io.ReadAll(io.LimitReader(r.Body, maxGraphQLBodyBytes+1))
 	_ = originalBody.Close()

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -21,6 +21,7 @@
 package proxy
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -42,6 +43,12 @@ import (
 	"github.com/goodtune/ghp/internal/metrics"
 	"github.com/goodtune/ghp/internal/token"
 )
+
+// maxGraphQLBodyBytes caps the size of GraphQL request bodies the proxy
+// will read into memory for static analysis. GitHub itself accepts up to
+// roughly a megabyte; rejecting anything larger keeps memory use bounded
+// for adversarial clients.
+const maxGraphQLBodyBytes = 1 << 20 // 1 MiB
 
 const (
 	githubAPIBase    = "https://api.github.com"
@@ -329,26 +336,154 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 func (h *Handler) handleGraphQL(w http.ResponseWriter, r *http.Request, pt *database.ProxyToken, si tokenScopeInfo, rewriteAuth func(string) string, start time.Time) {
 	tokenType := pt.TokenType
 
-	// Repository-restricted tokens cannot have their repo restrictions enforced
-	// on GraphQL requests because GraphQL queries can span arbitrary repositories
-	// without a parseable path structure. Block GraphQL to prevent bypassing
-	// repository scope restrictions.
+	// Open-scoped tokens skip GraphQL static analysis entirely and forward
+	// to GitHub unchanged. The underlying credential's own permissions act
+	// as the only enforcement layer.
+	if si.isOpenScoped() {
+		h.forwardGraphQL(w, r, pt, &si, rewriteAuth, start, nil)
+		return
+	}
+
+	// Buffer the request body so we can both analyse the query and replay
+	// it to GitHub. MaxBytesReader caps the read so unbounded uploads are
+	// rejected before any allocation.
+	body, err := io.ReadAll(http.MaxBytesReader(w, r.Body, maxGraphQLBodyBytes))
+	if err != nil {
+		var maxErr *http.MaxBytesError
+		if errors.As(err, &maxErr) {
+			metrics.ObserveDecision(metrics.StageTotal, tokenType, time.Since(start))
+			writeError(w, http.StatusRequestEntityTooLarge,
+				"GraphQL request body exceeds proxy size limit")
+			h.logRequest(pt, r, "/graphql", "", http.StatusRequestEntityTooLarge, time.Since(start), "proxy_scope_denied")
+			return
+		}
+		h.logger.Warn("graphql: failed to read request body", "error", err)
+		metrics.ObserveDecision(metrics.StageTotal, tokenType, time.Since(start))
+		writeError(w, http.StatusBadRequest, "Failed to read GraphQL request body")
+		h.logRequest(pt, r, "/graphql", "", http.StatusBadRequest, time.Since(start), "proxy_scope_denied")
+		return
+	}
+	r.Body = io.NopCloser(bytes.NewReader(body))
+	r.ContentLength = int64(len(body))
+
+	// Static analysis: parse the query and extract required scopes,
+	// referenced repositories, and any unknown fields encountered.
+	analysisStart := time.Now()
+	analysis, err := analyzeGraphQLRequest(body)
+	metrics.ObserveDecision(metrics.StageGraphQLAnalysis, tokenType, time.Since(analysisStart))
+	if err != nil {
+		// Fail closed: a query we cannot parse is a query we cannot scope.
+		metrics.ObserveDecision(metrics.StageTotal, tokenType, time.Since(start))
+		writeError(w, http.StatusBadRequest, fmt.Sprintf("Invalid GraphQL request: %s", err.Error()))
+		h.logRequest(pt, r, "/graphql", "", http.StatusBadRequest, time.Since(start), "proxy_scope_denied")
+		return
+	}
+
 	scopeEnforceStart := time.Now()
-	if len(si.Repos) > 0 {
+
+	// Subscriptions are never permitted: GitHub's GraphQL endpoint does not
+	// support them over HTTP, and even if it did the proxy has no way to
+	// stream-scope per-event payloads.
+	if analysis.hasSubscription {
 		metrics.ObserveDecision(metrics.StageScopeEnforcement, tokenType, time.Since(scopeEnforceStart))
 		metrics.ObserveDecision(metrics.StageTotal, tokenType, time.Since(start))
-		writeError(w, http.StatusForbidden,
-			"Token is repository-restricted; GraphQL is not supported for repository-scoped tokens")
+		writeError(w, http.StatusForbidden, "GraphQL subscriptions are not supported")
 		h.logRequest(pt, r, "/graphql", "", http.StatusForbidden, time.Since(start), "proxy_scope_denied")
 		return
 	}
+
+	// Deny-by-default: any unknown field rejects the request when the token
+	// has any restriction. Open-scoped tokens were forwarded earlier.
+	if len(analysis.unknownFields) > 0 {
+		metrics.ObserveDecision(metrics.StageScopeEnforcement, tokenType, time.Since(scopeEnforceStart))
+		metrics.ObserveDecision(metrics.StageTotal, tokenType, time.Since(start))
+		writeError(w, http.StatusForbidden,
+			fmt.Sprintf("GraphQL request references unmapped fields: %s", strings.Join(analysis.unknownFields, ", ")))
+		h.logRequest(pt, r, "/graphql", "", http.StatusForbidden, time.Since(start), "proxy_scope_denied")
+		return
+	}
+
+	// Repository-scope enforcement.
+	if len(si.Repos) > 0 {
+		// Cross-repo fields cannot be statically constrained to a repo
+		// allowlist (e.g. `search`, `node(id:)`, `viewer.repositories`).
+		// Reject these requests rather than risk leaking data outside the
+		// allowlist.
+		if len(analysis.crossRepoFields) > 0 {
+			metrics.ObserveDecision(metrics.StageScopeEnforcement, tokenType, time.Since(scopeEnforceStart))
+			metrics.ObserveDecision(metrics.StageTotal, tokenType, time.Since(start))
+			writeError(w, http.StatusForbidden,
+				fmt.Sprintf("Token is repository-restricted; GraphQL request uses cross-repository fields: %s",
+					strings.Join(analysis.crossRepoFields, ", ")))
+			h.logRequest(pt, r, "/graphql", "", http.StatusForbidden, time.Since(start), "proxy_scope_denied")
+			return
+		}
+		// Every selection in the query must be pinned to at least one
+		// repository, and every referenced repository must be in the
+		// allowlist.
+		if len(analysis.referencedRepos) == 0 {
+			metrics.ObserveDecision(metrics.StageScopeEnforcement, tokenType, time.Since(scopeEnforceStart))
+			metrics.ObserveDecision(metrics.StageTotal, tokenType, time.Since(start))
+			writeError(w, http.StatusForbidden,
+				"Token is repository-restricted; GraphQL request must reference repository(owner, name) with literal arguments")
+			h.logRequest(pt, r, "/graphql", "", http.StatusForbidden, time.Since(start), "proxy_scope_denied")
+			return
+		}
+		for _, repo := range analysis.referencedRepos {
+			if !si.repoAllowed(repo) {
+				metrics.ObserveDecision(metrics.StageScopeEnforcement, tokenType, time.Since(scopeEnforceStart))
+				metrics.ObserveDecision(metrics.StageTotal, tokenType, time.Since(start))
+				writeError(w, http.StatusForbidden,
+					fmt.Sprintf("Token is not scoped to %s", repo))
+				h.logRequest(pt, r, "/graphql", repo, http.StatusForbidden, time.Since(start), "proxy_scope_denied")
+				return
+			}
+		}
+	}
+
+	// Permission-scope enforcement.
+	if len(si.Scopes) > 0 {
+		// Mutations require at least one mapped write scope; if the
+		// analyzer didn't map any required scope from a mutation, reject
+		// (the deny-by-default unknown-fields check above usually catches
+		// this first, but we verify here too).
+		if analysis.hasMutation && len(analysis.requiredScopes) == 0 {
+			metrics.ObserveDecision(metrics.StageScopeEnforcement, tokenType, time.Since(scopeEnforceStart))
+			metrics.ObserveDecision(metrics.StageTotal, tokenType, time.Since(start))
+			writeError(w, http.StatusForbidden,
+				"GraphQL mutation could not be statically scoped; rejected by deny-by-default policy")
+			h.logRequest(pt, r, "/graphql", "", http.StatusForbidden, time.Since(start), "proxy_scope_denied")
+			return
+		}
+		if missing := analysis.missingScopes(si.Scopes); len(missing) > 0 {
+			metrics.ObserveDecision(metrics.StageScopeEnforcement, tokenType, time.Since(scopeEnforceStart))
+			metrics.ObserveDecision(metrics.StageTotal, tokenType, time.Since(start))
+			writeError(w, http.StatusForbidden,
+				fmt.Sprintf("Token does not grant required GraphQL scopes: %s", strings.Join(missing, ", ")))
+			h.logRequest(pt, r, "/graphql", "", http.StatusForbidden, time.Since(start), "proxy_scope_denied")
+			return
+		}
+	}
+
 	metrics.ObserveDecision(metrics.StageScopeEnforcement, tokenType, time.Since(scopeEnforceStart))
 
-	// For permission-scoped tokens (scopes set, no repo restrictions), we forward
-	// to GitHub. Full GraphQL query parsing to enforce per-operation permission
-	// checks is not implemented; the underlying GitHub token enforces actual access.
+	// All static checks passed — forward to GitHub.
+	repoForLog := ""
+	if len(analysis.referencedRepos) == 1 {
+		repoForLog = analysis.referencedRepos[0]
+	}
+	h.forwardGraphQL(w, r, pt, &si, rewriteAuth, start, &repoForLog)
+}
+
+// forwardGraphQL completes the GitHub-token resolution + upstream roundtrip
+// portion of a GraphQL request. It is shared by the open-scoped fast path
+// and the post-analysis path so that the metrics stages and audit log
+// emission stay consistent across both.
+func (h *Handler) forwardGraphQL(w http.ResponseWriter, r *http.Request, pt *database.ProxyToken, si *tokenScopeInfo, rewriteAuth func(string) string, start time.Time, repoForLog *string) {
+	tokenType := pt.TokenType
+
 	ghTokenStart := time.Now()
-	githubToken, err := h.getGitHubToken(r, pt, &si)
+	githubToken, err := h.getGitHubToken(r, pt, si)
 	metrics.ObserveDecision(metrics.StageGitHubTokenResolution, tokenType, time.Since(ghTokenStart))
 	if err != nil {
 		h.logger.Error("failed to get GitHub token for GraphQL", "error", err)
@@ -364,18 +499,19 @@ func (h *Handler) handleGraphQL(w http.ResponseWriter, r *http.Request, pt *data
 
 	authHeader := rewriteAuth(githubToken)
 
-	// Record total decision time (everything before forwarding to GitHub).
 	metrics.ObserveDecision(metrics.StageTotal, tokenType, time.Since(start))
 
 	upstreamStart := time.Now()
 	status := h.forwardRequest(w, r, "/graphql", authHeader)
 	metrics.ObserveDecision(metrics.StageUpstreamRoundtrip, tokenType, time.Since(upstreamStart))
 
-	// Re-check the cache after the roundtrip; the async lookup triggered
-	// by resolveTokenUsername may have completed during the upstream wait.
 	h.checkCacheAfterRoundtrip(r, githubToken, pt)
 
-	h.logRequest(pt, r, "/graphql", "", status, time.Since(start), "proxy_request")
+	repo := ""
+	if repoForLog != nil {
+		repo = *repoForLog
+	}
+	h.logRequest(pt, r, "/graphql", repo, status, time.Since(start), "proxy_request")
 }
 
 // resolveTokenUsername resolves the identity behind a GitHub token by querying

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -53,8 +53,8 @@ const maxGraphQLBodyBytes = 1 << 20 // 1 MiB
 // maxRenderedFieldNames caps how many field names are inlined into the
 // 403 messages the GraphQL handler returns when a query is rejected for
 // unmapped or cross-repository fields. Without a cap, an adversarial
-// query could inflate the response body and audit log line to be
-// proportional to the request size.
+// query could inflate the response body to be proportional to the
+// request size.
 const maxRenderedFieldNames = 10
 
 // summariseFieldList renders a comma-separated string of up to `limit`

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -356,6 +356,19 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 func (h *Handler) handleGraphQL(w http.ResponseWriter, r *http.Request, pt *database.ProxyToken, si tokenScopeInfo, rewriteAuth func(string) string, start time.Time) {
 	tokenType := pt.TokenType
 
+	// GitHub's GraphQL endpoint only accepts POST. Reject other methods
+	// up front with a clear 405 rather than parsing an empty body and
+	// returning a confusing JSON error. The check applies to scoped and
+	// open-scoped tokens alike: forwarding non-POST requests would yield
+	// the same upstream rejection at the cost of an extra roundtrip.
+	if r.Method != http.MethodPost {
+		w.Header().Set("Allow", http.MethodPost)
+		metrics.ObserveDecision(metrics.StageTotal, tokenType, time.Since(start))
+		writeError(w, http.StatusMethodNotAllowed, "GraphQL endpoint only accepts POST")
+		h.logRequest(pt, r, "/graphql", "", http.StatusMethodNotAllowed, time.Since(start), "proxy_scope_denied")
+		return
+	}
+
 	// Open-scoped tokens skip GraphQL static analysis entirely and forward
 	// to GitHub unchanged. The underlying credential's own permissions act
 	// as the only enforcement layer. Emit zero-duration GraphQL-analysis

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -50,6 +50,26 @@ import (
 // for adversarial clients.
 const maxGraphQLBodyBytes = 1 << 20 // 1 MiB
 
+// maxRenderedFieldNames caps how many field names are inlined into the
+// 403 messages the GraphQL handler returns when a query is rejected for
+// unmapped or cross-repository fields. Without a cap, an adversarial
+// query could inflate the response body and audit log line to be
+// proportional to the request size.
+const maxRenderedFieldNames = 10
+
+// summariseFieldList renders a comma-separated string of up to `limit`
+// names, appending "…and N more" when the input is longer. Returns an
+// empty string when the input is empty.
+func summariseFieldList(names []string, limit int) string {
+	if len(names) == 0 {
+		return ""
+	}
+	if limit <= 0 || len(names) <= limit {
+		return strings.Join(names, ", ")
+	}
+	return fmt.Sprintf("%s, …and %d more", strings.Join(names[:limit], ", "), len(names)-limit)
+}
+
 const (
 	githubAPIBase    = "https://api.github.com"
 	githubTokenURL   = "https://github.com/login/oauth/access_token"
@@ -403,12 +423,14 @@ func (h *Handler) handleGraphQL(w http.ResponseWriter, r *http.Request, pt *data
 	}
 
 	// Deny-by-default: any unknown field rejects the request when the token
-	// has any restriction. Open-scoped tokens were forwarded earlier.
+	// has any restriction. Open-scoped tokens were forwarded earlier. The
+	// rendered field list is capped so an adversarial query cannot
+	// inflate the response body (or audit log line) to O(request size).
 	if len(analysis.unknownFields) > 0 {
 		metrics.ObserveDecision(metrics.StageScopeEnforcement, tokenType, time.Since(scopeEnforceStart))
 		metrics.ObserveDecision(metrics.StageTotal, tokenType, time.Since(start))
 		writeError(w, http.StatusForbidden,
-			fmt.Sprintf("GraphQL request references unmapped fields: %s", strings.Join(analysis.unknownFields, ", ")))
+			fmt.Sprintf("GraphQL request references unmapped fields: %s", summariseFieldList(analysis.unknownFields, maxRenderedFieldNames)))
 		h.logRequest(pt, r, "/graphql", "", http.StatusForbidden, time.Since(start), "proxy_scope_denied")
 		return
 	}
@@ -424,7 +446,7 @@ func (h *Handler) handleGraphQL(w http.ResponseWriter, r *http.Request, pt *data
 			metrics.ObserveDecision(metrics.StageTotal, tokenType, time.Since(start))
 			writeError(w, http.StatusForbidden,
 				fmt.Sprintf("Token is repository-restricted; GraphQL request uses cross-repository fields: %s",
-					strings.Join(analysis.crossRepoFields, ", ")))
+					summariseFieldList(analysis.crossRepoFields, maxRenderedFieldNames)))
 			h.logRequest(pt, r, "/graphql", "", http.StatusForbidden, time.Since(start), "proxy_scope_denied")
 			return
 		}

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -650,8 +650,11 @@ func TestServeHTTP_OpenScopedToken_GraphQLAllowed(t *testing.T) {
 }
 
 func TestServeHTTP_RepoOnly_GraphQLDenied(t *testing.T) {
-	// A repo-restricted token must be denied on GraphQL because repo restrictions
-	// cannot be enforced on arbitrary GraphQL queries without query parsing.
+	// A repo-restricted token issued a GraphQL query that does not pin a
+	// specific repository (`{ viewer { login } }`) is rejected: the
+	// analyzer cannot prove the response stays inside the allowlist.
+	// Queries that do reference an allowlisted `repository(owner, name)`
+	// are exercised by TestServeHTTP_GraphQL_RepoScoped_AllowsAllowlistedRepo.
 	h, ghpToken := newRepoOnlyHandler(t, "goodtune/ghp")
 
 	req := httptest.NewRequest("POST", "http://api.github.com/graphql", strings.NewReader(`{"query":"{ viewer { login } }"}`))
@@ -671,9 +674,12 @@ func TestServeHTTP_RepoOnly_GraphQLDenied(t *testing.T) {
 }
 
 func TestServeHTTP_ScopeOnly_GraphQLAllowed(t *testing.T) {
-	// A scope-only token (scopes set, no repo restrictions) must be allowed to
-	// use GraphQL. Per-operation permission enforcement on GraphQL is not
-	// implemented; the underlying GitHub token enforces actual access.
+	// A scope-only token (scopes set, no repo restrictions) submitting a
+	// metadata-only GraphQL query (`{ viewer { login } }`) passes the
+	// static analysis: the analyzer infers no required scope, so the
+	// token's scopes trivially cover the request. Coverage and denial
+	// behaviour for queries that do require a scope is exercised by the
+	// TestServeHTTP_GraphQL_PermissionScoped_* tests.
 	h, ghpToken := newScopeOnlyHandler(t, map[string]string{
 		"contents": "read",
 	})
@@ -691,8 +697,10 @@ func TestServeHTTP_ScopeOnly_GraphQLAllowed(t *testing.T) {
 }
 
 func TestServeHTTP_RepoAndScopeToken_GraphQLDenied(t *testing.T) {
-	// A fully-scoped token (repos AND scopes set) must also be denied on GraphQL
-	// because repo restrictions cannot be enforced without query parsing.
+	// A fully-scoped token (repos AND scopes set) is rejected on a query
+	// that does not pin a `repository(owner, name)` selection. Repository
+	// scoping is checked first; the permission check is exercised
+	// separately by TestServeHTTP_GraphQL_PermissionScoped_*.
 	h, ghpToken := newScopedHandler(t, "goodtune/ghp", map[string]string{
 		"contents": "read",
 	})


### PR DESCRIPTION
## Summary

Adds a deny-by-default static-analysis layer in front of `/graphql` so proxy tokens are downscoped on GraphQL requests, not just REST. Previously permission-scoped tokens were forwarded to GitHub unchanged and repository-scoped tokens were rejected outright with no way to opt in.

## Approach

- New `internal/proxy/graphql.go` parses each request body with `github.com/vektah/gqlparser/v2` and walks the AST (resolving fragment spreads via a recursion stack, capped at `maxAnalysisDepth = 100` so a deeply-nested but ≤1 MiB query can't blow the stack). Only the operation named by `operationName` (or the sole operation when omitted) is analyzed — multi-operation documents that don't pin a name are rejected. The walk extracts:
  - **Required scopes** from a curated `Mutation.<field>` map and a field-name → scope map (e.g. `pullRequests` → `pull_requests:read`, `createIssue` → `issues:write`).
  - **Referenced repositories** from literal `repository(owner, name)` arguments. Any `repository(...)` selection with non-literal arguments sets `hasUnpinnedRepositoryLookup`, so a repo-scoped token is rejected even if the same query also contains literal allowlisted lookups (otherwise an attacker could mix one allowed repo with an unbounded variable-driven lookup).
  - **Cross-repository fields** (`search`, `node`, `viewer.repositories`, …) that can return data outside any explicit `repository(...)` selection.
  - **Unknown object-typed fields** — anything that does not appear in the allowlist or scope tables AND has its own selection set is flagged. Scalar leaves are permitted because their parent's scope already gates them.

- `Handler.handleGraphQL` now buffers the request body (read via `io.LimitReader` capped at 1 MiB + 1 byte, then explicitly rejected with 413 if oversized — the handler controls the error response rather than letting an implicit reader-side write race with `writeError`), runs the analysis, and applies the policy:
  - **Open-scoped tokens**: bypass analysis (unchanged).
  - **Repository-scoped tokens**: must reference at least one literal repository, every referenced repo must be in the allowlist, and any cross-repo field is rejected.
  - **Permission-scoped tokens**: every required scope must be granted; unmappable mutations are denied (deny-by-default), and unknown object-typed fields are rejected.
  - **Subscriptions**: rejected unconditionally.

- Non-POST `/graphql` requests are rejected with 405 + `Allow: POST` before any body parsing, and `/graphql` error envelopes use the GraphQL docs URL (not the REST one) via a new `writeGraphQLError` helper.

- New `graphql_analysis` decision-pipeline metric stage so operators can see the parsing cost. Open-scoped requests emit a zero-duration `graphql_analysis` and `scope_enforcement` decision so the per-request stage timeline is uniform across paths. Client-side rejections (405/413/parse 400) are audited as `proxy_request_invalid`; genuine authorization 403s remain `proxy_scope_denied`.

- Updated `docs/features/token-scoping.md` to replace the "GraphQL Limitation" section with a description of the new enforcement model and how to extend the curated tables when legitimate fields surface in 403 messages.

## Test plan

- [x] `go vet ./...`
- [x] `go test ./internal/proxy/... ./internal/metrics/...` (unit + handler integration)
- [ ] Validate analysis decisions against real agent traffic in a staging environment
- [ ] Iterate on `fieldScopeRequirements` / `mutationScopeRequirements` based on production 403 logs