### PR TITLE
feat(auth): HA-safe auth state and CLI device-authorization flow

### DIFF
--- a/cmd/ghp/auth.go
+++ b/cmd/ghp/auth.go
@@ -1,7 +1,10 @@
 package main
 
 import (
+	"bytes"
+	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -121,6 +124,162 @@ func openBrowser(rawURL string) {
 	}
 }
 
+// deviceStartResponse is the JSON returned by POST /cli/auth/device.
+type deviceStartResponse struct {
+	DeviceCode              string `json:"device_code"`
+	UserCode                string `json:"user_code"`
+	VerificationURI         string `json:"verification_uri"`
+	VerificationURIComplete string `json:"verification_uri_complete"`
+	ExpiresIn               int    `json:"expires_in"`
+	Interval                int    `json:"interval"`
+}
+
+// runDeviceLogin runs the OAuth device-authorization flow against the ghp
+// server and returns the issued session token. The returned token is a
+// long-lived `ghpr_` user session token suitable for persistence.
+func runDeviceLogin(ctx context.Context, out io.Writer, serverURL string) (string, error) {
+	startEndpoint, err := url.JoinPath(serverURL, "/cli/auth/device")
+	if err != nil {
+		return "", fmt.Errorf("building device-auth URL: %w", err)
+	}
+	startReq, err := http.NewRequestWithContext(ctx, "POST", startEndpoint, strings.NewReader(""))
+	if err != nil {
+		return "", err
+	}
+	startReq.Header.Set("Accept", "application/json")
+	startResp, err := cliHTTPClient.Do(startReq)
+	if err != nil {
+		return "", fmt.Errorf("connecting to server: %w", err)
+	}
+	defer startResp.Body.Close()
+
+	if startResp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(io.LimitReader(startResp.Body, 4096))
+		return "", fmt.Errorf("device-auth request failed (%d): %s", startResp.StatusCode, strings.TrimSpace(string(body)))
+	}
+
+	var ds deviceStartResponse
+	if err := json.NewDecoder(io.LimitReader(startResp.Body, 64*1024)).Decode(&ds); err != nil {
+		return "", fmt.Errorf("decoding device-auth response: %w", err)
+	}
+	if ds.DeviceCode == "" || ds.UserCode == "" || ds.VerificationURI == "" {
+		return "", fmt.Errorf("device-auth response missing required fields")
+	}
+
+	// The CLI may receive an interval of 0 from a misconfigured server; clamp
+	// to a sane minimum to avoid hammering the endpoint in a tight loop.
+	pollInterval := time.Duration(ds.Interval) * time.Second
+	if pollInterval < time.Second {
+		pollInterval = 5 * time.Second
+	}
+	expiresAt := time.Now().Add(time.Duration(ds.ExpiresIn) * time.Second)
+	if ds.ExpiresIn <= 0 {
+		expiresAt = time.Now().Add(10 * time.Minute)
+	}
+
+	openURL := ds.VerificationURIComplete
+	if openURL == "" {
+		openURL = ds.VerificationURI
+	}
+
+	fmt.Fprintf(out, "Open this URL in a browser to authorize the CLI:\n  %s\n\n", openURL)
+	fmt.Fprintf(out, "Confirm this code matches what the page displays:\n  %s\n\n", ds.UserCode)
+	fmt.Fprintf(out, "Waiting for approval (Ctrl-C to cancel)...\n")
+
+	if os.Getenv("GHP_NO_BROWSER") == "" {
+		openBrowser(openURL)
+	}
+
+	tokenEndpoint, err := url.JoinPath(serverURL, "/cli/auth/device/token")
+	if err != nil {
+		return "", fmt.Errorf("building token URL: %w", err)
+	}
+
+	for {
+		if time.Now().After(expiresAt) {
+			return "", fmt.Errorf("authorization request expired before approval; run 'ghp auth login' again")
+		}
+
+		token, errCode, err := pollDeviceToken(ctx, tokenEndpoint, ds.DeviceCode)
+		if err != nil {
+			return "", err
+		}
+		if token != "" {
+			return token, nil
+		}
+
+		switch errCode {
+		case "authorization_pending":
+			// continue polling at interval
+		case "slow_down":
+			pollInterval += 5 * time.Second
+		case "access_denied":
+			return "", fmt.Errorf("authorization was denied")
+		case "expired_token":
+			return "", fmt.Errorf("authorization request expired before approval; run 'ghp auth login' again")
+		case "invalid_request", "invalid_grant":
+			return "", fmt.Errorf("server rejected device code: %s", errCode)
+		default:
+			return "", fmt.Errorf("unexpected error from server: %s", errCode)
+		}
+
+		select {
+		case <-ctx.Done():
+			return "", ctx.Err()
+		case <-time.After(pollInterval):
+		}
+	}
+}
+
+// pollDeviceToken issues one POST /cli/auth/device/token. On success it
+// returns (token, "", nil). On a recognized RFC-8628 error it returns
+// ("", errorCode, nil). On a transport or unexpected response it returns an error.
+func pollDeviceToken(ctx context.Context, endpoint, deviceCode string) (string, string, error) {
+	bodyJSON, _ := json.Marshal(map[string]string{"device_code": deviceCode})
+	req, err := http.NewRequestWithContext(ctx, "POST", endpoint, bytes.NewReader(bodyJSON))
+	if err != nil {
+		return "", "", err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := cliHTTPClient.Do(req)
+	if err != nil {
+		// Treat ctx cancellation as a hard error; otherwise transient
+		// network errors are surfaced to the user.
+		if errors.Is(err, context.Canceled) {
+			return "", "", err
+		}
+		return "", "", fmt.Errorf("polling token endpoint: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, 64*1024))
+
+	if resp.StatusCode == http.StatusOK {
+		var success struct {
+			SessionToken string `json:"session_token"`
+			Username     string `json:"username"`
+		}
+		if err := json.Unmarshal(body, &success); err != nil {
+			return "", "", fmt.Errorf("decoding token response: %w", err)
+		}
+		if success.SessionToken == "" {
+			return "", "", fmt.Errorf("server returned empty session_token")
+		}
+		return success.SessionToken, "", nil
+	}
+
+	var errResp struct {
+		Error string `json:"error"`
+	}
+	_ = json.Unmarshal(body, &errResp)
+	if errResp.Error == "" {
+		return "", "", fmt.Errorf("token endpoint returned %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+	return "", errResp.Error, nil
+}
+
 func newAuthCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "auth",
@@ -129,7 +288,13 @@ func newAuthCmd() *cobra.Command {
 
 	loginCmd := &cobra.Command{
 		Use:   "login",
-		Short: "Authenticate via GitHub OAuth",
+		Short: "Authenticate to the ghp server",
+		Long: `Authenticate to the ghp server using the device-authorization flow.
+
+The CLI initiates a sign-in request, prints a URL on the ghp server itself,
+and polls until the user approves it in a browser. No GitHub OAuth round-trip
+involves the CLI directly: GitHub remains the identity provider for the ghp
+web UI, but the CLI never sees a github.com URL.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cfg, err := loadCLIConfig()
 			if err != nil {
@@ -139,59 +304,28 @@ func newAuthCmd() *cobra.Command {
 				return fmt.Errorf("server URL not configured. Set GHP_SERVER_URL or add server_url to ~/.config/ghp/config.yaml")
 			}
 
-			// Ask the server for the GitHub OAuth URL. The server generates a
-			// state token and returns the full GitHub authorization URL. Using
-			// Accept: application/json also instructs the server to append
-			// ?format=json to the OAuth callback, so the browser will display
-			// the session token as JSON after the user authenticates.
-			endpoint, err := url.JoinPath(cfg.ServerURL, "/auth/github")
-			if err != nil {
-				return fmt.Errorf("building auth URL: %w", err)
-			}
-			req, err := http.NewRequest("GET", endpoint, nil)
+			out := cmd.OutOrStdout()
+			token, err := runDeviceLogin(cmd.Context(), out, cfg.ServerURL)
 			if err != nil {
 				return err
 			}
-			req.Header.Set("Accept", "application/json")
 
-			resp, err := cliHTTPClient.Do(req)
+			// Persist the issued token. Read the file directly so a transient
+			// GHP_SERVER_URL doesn't get written back to disk.
+			fileCfg, err := loadCLIConfigFile()
 			if err != nil {
-				return fmt.Errorf("connecting to server: %w", err)
+				return err
 			}
-			defer resp.Body.Close()
-
-			if resp.StatusCode != http.StatusOK {
-				body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
-				return fmt.Errorf("server returned %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+			fileCfg.UserToken = token
+			if err := saveCLIConfig(fileCfg); err != nil {
+				return fmt.Errorf("saving config: %w", err)
 			}
-
-			var result struct {
-				URL string `json:"url"`
+			if home, err := os.UserHomeDir(); err == nil {
+				fmt.Fprintf(out, "\nToken saved to %s\n", filepath.Join(home, ".config", "ghp", "config.yaml"))
+			} else {
+				fmt.Fprintln(out, "\nToken saved.")
 			}
-			// Cap the body read so a misconfigured or malicious server can't
-			// exhaust memory. Legitimate responses are ~1KB.
-			if err := json.NewDecoder(io.LimitReader(resp.Body, 64*1024)).Decode(&result); err != nil {
-				return fmt.Errorf("decoding server response: %w", err)
-			}
-			if result.URL == "" {
-				return fmt.Errorf("server returned empty auth URL")
-			}
-
-			// GHP_NO_BROWSER lets tests and CI suppress the side-effect of
-			// spawning a browser opener while still exercising the command.
-			if os.Getenv("GHP_NO_BROWSER") == "" {
-				openBrowser(result.URL)
-			}
-
-			out := cmd.OutOrStdout()
-			fmt.Fprintf(out, "Opening browser for GitHub authentication.\n\n")
-			fmt.Fprintf(out, "If the browser did not open, visit this URL:\n  %s\n\n", result.URL)
-			fmt.Fprintf(out, "After authenticating, the page will display a JSON token.\n")
-			fmt.Fprintf(out, "Copy the value of \"session_token\" and save it:\n\n")
-			fmt.Fprintf(out, "  ghp auth set-token <session_token>\n\n")
-			fmt.Fprintf(out, "Or set the environment variable:\n\n")
-			fmt.Fprintf(out, "  export GHP_USER_TOKEN=<session_token>\n")
-
+			fmt.Fprintf(out, "Run 'ghp auth status' to verify.\n")
 			return nil
 		},
 	}

--- a/cmd/ghp/auth.go
+++ b/cmd/ghp/auth.go
@@ -13,6 +13,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 	"time"
 
@@ -200,7 +201,7 @@ func runDeviceLogin(ctx context.Context, out io.Writer, serverURL string) (strin
 			return "", fmt.Errorf("authorization request expired before approval; run 'ghp auth login' again")
 		}
 
-		token, errCode, err := pollDeviceToken(ctx, tokenEndpoint, ds.DeviceCode)
+		token, errCode, retryAfter, err := pollDeviceToken(ctx, tokenEndpoint, ds.DeviceCode)
 		if err != nil {
 			return "", err
 		}
@@ -208,17 +209,41 @@ func runDeviceLogin(ctx context.Context, out io.Writer, serverURL string) (strin
 			return token, nil
 		}
 
+		// nextSleep is the delay before the following poll. Most paths use
+		// the server-supplied poll interval; slow_down and HTTP 429 extend
+		// it dynamically.
+		nextSleep := pollInterval
+
 		switch errCode {
 		case "authorization_pending":
 			// continue polling at interval
 		case "slow_down":
 			pollInterval += 5 * time.Second
+			nextSleep = pollInterval
+		case errCodeRateLimited:
+			// Server (or upstream proxy) asked us to back off. Honour the
+			// Retry-After header when present; otherwise fall back to
+			// double the current poll interval, capped sensibly.
+			wait := parseRetryAfter(retryAfter)
+			if wait <= 0 {
+				wait = pollInterval * 2
+			}
+			if wait > 60*time.Second {
+				wait = 60 * time.Second
+			}
+			nextSleep = wait
 		case "access_denied":
 			return "", fmt.Errorf("authorization was denied")
 		case "expired_token":
 			return "", fmt.Errorf("authorization request expired before approval; run 'ghp auth login' again")
 		case "invalid_request", "invalid_grant":
 			return "", fmt.Errorf("server rejected device code: %s", errCode)
+		case "server_error":
+			// The server logged the underlying cause; the CLI cannot
+			// recover, so surface a clear instruction instead of silently
+			// retrying. Re-running 'ghp auth login' picks the issue up
+			// after the operator addresses it.
+			return "", fmt.Errorf("ghp server returned server_error; check the server logs and re-run 'ghp auth login'")
 		default:
 			return "", fmt.Errorf("unexpected error from server: %s", errCode)
 		}
@@ -226,19 +251,28 @@ func runDeviceLogin(ctx context.Context, out io.Writer, serverURL string) (strin
 		select {
 		case <-ctx.Done():
 			return "", ctx.Err()
-		case <-time.After(pollInterval):
+		case <-time.After(nextSleep):
 		}
 	}
 }
 
+// errCodeRateLimited is a synthetic error code used internally by the
+// device-flow polling loop to mean "the server's IP rate limiter rejected
+// us; honour Retry-After and try again." It is not an RFC-8628 error code
+// and never escapes pollDeviceToken's caller.
+const errCodeRateLimited = "rate_limited"
+
 // pollDeviceToken issues one POST /cli/auth/device/token. On success it
-// returns (token, "", nil). On a recognized RFC-8628 error it returns
-// ("", errorCode, nil). On a transport or unexpected response it returns an error.
-func pollDeviceToken(ctx context.Context, endpoint, deviceCode string) (string, string, error) {
+// returns (token, "", "", nil). On a recognised RFC-8628 error it returns
+// ("", errorCode, "", nil). On HTTP 429 from the per-IP rate limiter it
+// returns ("", errCodeRateLimited, retryAfter, nil) where retryAfter is the
+// raw Retry-After header value (may be empty if the server didn't set one).
+// On a transport or unexpected response it returns an error.
+func pollDeviceToken(ctx context.Context, endpoint, deviceCode string) (string, string, string, error) {
 	bodyJSON, _ := json.Marshal(map[string]string{"device_code": deviceCode})
 	req, err := http.NewRequestWithContext(ctx, "POST", endpoint, bytes.NewReader(bodyJSON))
 	if err != nil {
-		return "", "", err
+		return "", "", "", err
 	}
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Accept", "application/json")
@@ -248,9 +282,9 @@ func pollDeviceToken(ctx context.Context, endpoint, deviceCode string) (string, 
 		// Treat ctx cancellation as a hard error; otherwise transient
 		// network errors are surfaced to the user.
 		if errors.Is(err, context.Canceled) {
-			return "", "", err
+			return "", "", "", err
 		}
-		return "", "", fmt.Errorf("polling token endpoint: %w", err)
+		return "", "", "", fmt.Errorf("polling token endpoint: %w", err)
 	}
 	defer resp.Body.Close()
 
@@ -262,12 +296,20 @@ func pollDeviceToken(ctx context.Context, endpoint, deviceCode string) (string, 
 			Username     string `json:"username"`
 		}
 		if err := json.Unmarshal(body, &success); err != nil {
-			return "", "", fmt.Errorf("decoding token response: %w", err)
+			return "", "", "", fmt.Errorf("decoding token response: %w", err)
 		}
 		if success.SessionToken == "" {
-			return "", "", fmt.Errorf("server returned empty session_token")
+			return "", "", "", fmt.Errorf("server returned empty session_token")
 		}
-		return success.SessionToken, "", nil
+		return success.SessionToken, "", "", nil
+	}
+
+	if resp.StatusCode == http.StatusTooManyRequests {
+		// The server's per-IP limiter (or an upstream proxy) is asking us
+		// to back off. Hand the Retry-After header up to the polling loop
+		// so it can sleep for the right amount of time instead of treating
+		// this as a fatal error.
+		return "", errCodeRateLimited, resp.Header.Get("Retry-After"), nil
 	}
 
 	var errResp struct {
@@ -275,9 +317,29 @@ func pollDeviceToken(ctx context.Context, endpoint, deviceCode string) (string, 
 	}
 	_ = json.Unmarshal(body, &errResp)
 	if errResp.Error == "" {
-		return "", "", fmt.Errorf("token endpoint returned %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+		return "", "", "", fmt.Errorf("token endpoint returned %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
 	}
-	return "", errResp.Error, nil
+	return "", errResp.Error, "", nil
+}
+
+// parseRetryAfter interprets an HTTP Retry-After header value, which is
+// either delta-seconds (e.g. "5") or an HTTP-date. Returns 0 when the
+// header is empty or malformed; the caller should fall back to its own
+// default in that case.
+func parseRetryAfter(v string) time.Duration {
+	v = strings.TrimSpace(v)
+	if v == "" {
+		return 0
+	}
+	if secs, err := strconv.Atoi(v); err == nil && secs > 0 {
+		return time.Duration(secs) * time.Second
+	}
+	if t, err := http.ParseTime(v); err == nil {
+		if d := time.Until(t); d > 0 {
+			return d
+		}
+	}
+	return 0
 }
 
 func newAuthCmd() *cobra.Command {

--- a/cmd/ghp/auth.go
+++ b/cmd/ghp/auth.go
@@ -310,6 +310,14 @@ web UI, but the CLI never sees a github.com URL.`,
 				return err
 			}
 
+			// Defensive check before writing to disk: every legitimate ghp
+			// session token starts with "ghpr_". Refuse anything else so a
+			// misconfigured or malicious server cannot persist garbage in
+			// the user's config (matches the validation in `auth set-token`).
+			if !strings.HasPrefix(token, "ghpr_") {
+				return fmt.Errorf("server returned an invalid session token (expected 'ghpr_' prefix)")
+			}
+
 			// Persist the issued token. Read the file directly so a transient
 			// GHP_SERVER_URL doesn't get written back to disk.
 			fileCfg, err := loadCLIConfigFile()

--- a/cmd/ghp/main_test.go
+++ b/cmd/ghp/main_test.go
@@ -99,7 +99,7 @@ func TestHelpOutput_AuthLogin(t *testing.T) {
 
 	output := buf.String()
 	for _, want := range []string{
-		"GitHub OAuth",
+		"device-authorization",
 	} {
 		if !strings.Contains(output, want) {
 			t.Errorf("auth login help: expected %q to appear in output:\n%s", want, output)
@@ -243,22 +243,103 @@ func TestAuthLoginCmd_NoServerURL(t *testing.T) {
 	}
 }
 
-// TestAuthLoginCmd_WithServerURL verifies that auth login fetches the OAuth URL
-// from the server, prints it, and instructs the user how to save the token.
-func TestAuthLoginCmd_WithServerURL(t *testing.T) {
-	const fakeGitHubURL = "https://github.com/login/oauth/authorize?client_id=test&state=abc"
+// TestAuthLoginCmd_DeviceFlow verifies that "ghp auth login" runs the device
+// authorization flow against the server, displays the verification URL and
+// user code, polls until the request is approved, and saves the issued token
+// to the local config file.
+func TestAuthLoginCmd_DeviceFlow(t *testing.T) {
+	const userCode = "ABCD-EFGH"
+	const deviceCode = "device-code-xyz"
+	const issuedToken = "ghpr_devicetoken123"
 
+	pollCount := 0
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != "GET" || r.URL.Path != "/auth/github" {
+		switch {
+		case r.Method == "POST" && r.URL.Path == "/cli/auth/device":
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"device_code":               deviceCode,
+				"user_code":                 userCode,
+				"verification_uri":          "http://server.example/cli/auth",
+				"verification_uri_complete": "http://server.example/cli/auth?user_code=" + userCode,
+				"expires_in":                600,
+				"interval":                  1,
+			})
+		case r.Method == "POST" && r.URL.Path == "/cli/auth/device/token":
+			pollCount++
+			w.Header().Set("Content-Type", "application/json")
+			if pollCount < 2 {
+				w.WriteHeader(http.StatusBadRequest)
+				json.NewEncoder(w).Encode(map[string]string{"error": "authorization_pending"})
+				return
+			}
+			json.NewEncoder(w).Encode(map[string]string{
+				"session_token": issuedToken,
+				"username":      "alice",
+			})
+		default:
 			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
 			w.WriteHeader(http.StatusNotFound)
-			return
 		}
-		if !strings.Contains(r.Header.Get("Accept"), "application/json") {
-			t.Errorf("expected Accept: application/json, got %q", r.Header.Get("Accept"))
+	}))
+	defer srv.Close()
+
+	home := t.TempDir()
+	t.Setenv("GHP_SERVER_URL", srv.URL)
+	t.Setenv("GHP_USER_TOKEN", "")
+	t.Setenv("HOME", home)
+	t.Setenv("GHP_NO_BROWSER", "1")
+
+	cmd := newAuthCmd()
+	buf := &bytes.Buffer{}
+	cmd.SetOut(buf)
+	cmd.SetErr(buf)
+	cmd.SetArgs([]string{"login"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("auth login error: %v", err)
+	}
+	output := buf.String()
+	if !strings.Contains(output, userCode) {
+		t.Errorf("expected user code %q in output, got: %q", userCode, output)
+	}
+	if !strings.Contains(output, "/cli/auth?user_code="+userCode) {
+		t.Errorf("expected verification URL in output, got: %q", output)
+	}
+
+	// Token should be saved to ~/.config/ghp/config.yaml.
+	cfg, err := loadCLIConfig()
+	if err != nil {
+		t.Fatalf("loadCLIConfig: %v", err)
+	}
+	if cfg.UserToken != issuedToken {
+		t.Errorf("UserToken = %q, want %q", cfg.UserToken, issuedToken)
+	}
+
+	if pollCount < 2 {
+		t.Errorf("expected at least 2 polls, got %d", pollCount)
+	}
+}
+
+// TestAuthLoginCmd_DeviceFlowDenied verifies that the CLI surfaces an
+// access_denied response from the server as a clean error.
+func TestAuthLoginCmd_DeviceFlowDenied(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/cli/auth/device":
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"device_code":      "dc",
+				"user_code":        "AAAA-BBBB",
+				"verification_uri": "http://server.example/cli/auth",
+				"expires_in":       600,
+				"interval":         1,
+			})
+		case r.URL.Path == "/cli/auth/device/token":
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusBadRequest)
+			json.NewEncoder(w).Encode(map[string]string{"error": "access_denied"})
 		}
-		w.Header().Set("Content-Type", "application/json")
-		fmt.Fprintf(w, `{"url":%q}`, fakeGitHubURL)
 	}))
 	defer srv.Close()
 
@@ -273,20 +354,17 @@ func TestAuthLoginCmd_WithServerURL(t *testing.T) {
 	cmd.SetErr(buf)
 	cmd.SetArgs([]string{"login"})
 
-	if err := cmd.Execute(); err != nil {
-		t.Fatalf("auth login error: %v", err)
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error when device flow is denied")
 	}
-	output := buf.String()
-	if !strings.Contains(output, fakeGitHubURL) {
-		t.Errorf("expected GitHub OAuth URL %q in output, got: %q", fakeGitHubURL, output)
-	}
-	if !strings.Contains(output, "set-token") {
-		t.Errorf("expected 'set-token' instruction in output, got: %q", output)
+	if !strings.Contains(err.Error(), "denied") {
+		t.Errorf("expected 'denied' in error, got: %v", err)
 	}
 }
 
-// TestAuthLoginCmd_ServerError verifies that auth login reports an error when the server
-// returns a non-200 status for the auth URL request.
+// TestAuthLoginCmd_ServerError verifies that auth login reports an error when
+// the device-start endpoint returns a non-200 status.
 func TestAuthLoginCmd_ServerError(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)
@@ -297,6 +375,7 @@ func TestAuthLoginCmd_ServerError(t *testing.T) {
 	t.Setenv("GHP_SERVER_URL", srv.URL)
 	t.Setenv("GHP_USER_TOKEN", "")
 	t.Setenv("HOME", t.TempDir())
+	t.Setenv("GHP_NO_BROWSER", "1")
 
 	cmd := newAuthCmd()
 	buf := &bytes.Buffer{}

--- a/cmd/ghp/main_test.go
+++ b/cmd/ghp/main_test.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 // TestHelpOutput_Root verifies that the root help text mentions all subcommands and flags.
@@ -385,6 +386,145 @@ func TestAuthLoginCmd_ServerError(t *testing.T) {
 
 	if err := cmd.Execute(); err == nil {
 		t.Fatal("expected error when server returns 500")
+	}
+}
+
+// TestAuthLoginCmd_DeviceFlowServerError verifies that an RFC-8628
+// `server_error` from the polling endpoint surfaces as a clear,
+// actionable error instead of "unexpected error from server".
+func TestAuthLoginCmd_DeviceFlowServerError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/cli/auth/device":
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"device_code":      "dc",
+				"user_code":        "AAAA-BBBB",
+				"verification_uri": "http://server.example/cli/auth",
+				"expires_in":       600,
+				"interval":         1,
+			})
+		case "/cli/auth/device/token":
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusInternalServerError)
+			json.NewEncoder(w).Encode(map[string]string{"error": "server_error"})
+		}
+	}))
+	defer srv.Close()
+
+	t.Setenv("GHP_SERVER_URL", srv.URL)
+	t.Setenv("GHP_USER_TOKEN", "")
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("GHP_NO_BROWSER", "1")
+
+	cmd := newAuthCmd()
+	buf := &bytes.Buffer{}
+	cmd.SetOut(buf)
+	cmd.SetErr(buf)
+	cmd.SetArgs([]string{"login"})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error when poll returns server_error")
+	}
+	if !strings.Contains(err.Error(), "server_error") || !strings.Contains(err.Error(), "ghp server") {
+		t.Errorf("expected friendly server_error message, got: %v", err)
+	}
+}
+
+// TestAuthLoginCmd_DeviceFlowRateLimit verifies that the CLI honours an
+// HTTP 429 response with Retry-After by sleeping briefly and resuming the
+// poll instead of aborting. The rate-limit response is followed by a
+// successful approval so the test completes without timing out.
+func TestAuthLoginCmd_DeviceFlowRateLimit(t *testing.T) {
+	const issuedToken = "ghpr_ratelimit_token_aaaaaaaa"
+	pollCount := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/cli/auth/device":
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"device_code":      "dc",
+				"user_code":        "AAAA-BBBB",
+				"verification_uri": "http://server.example/cli/auth",
+				"expires_in":       600,
+				"interval":         1,
+			})
+		case "/cli/auth/device/token":
+			pollCount++
+			w.Header().Set("Content-Type", "application/json")
+			if pollCount == 1 {
+				w.Header().Set("Retry-After", "1")
+				w.WriteHeader(http.StatusTooManyRequests)
+				json.NewEncoder(w).Encode(map[string]string{"message": "Rate limit exceeded"})
+				return
+			}
+			json.NewEncoder(w).Encode(map[string]string{
+				"session_token": issuedToken,
+				"username":      "alice",
+			})
+		}
+	}))
+	defer srv.Close()
+
+	t.Setenv("GHP_SERVER_URL", srv.URL)
+	t.Setenv("GHP_USER_TOKEN", "")
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("GHP_NO_BROWSER", "1")
+
+	cmd := newAuthCmd()
+	buf := &bytes.Buffer{}
+	cmd.SetOut(buf)
+	cmd.SetErr(buf)
+	cmd.SetArgs([]string{"login"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("expected success after backing off on 429, got: %v", err)
+	}
+	if pollCount < 2 {
+		t.Errorf("expected at least 2 polls (one rate-limited + one successful), got %d", pollCount)
+	}
+	cfg, err := loadCLIConfig()
+	if err != nil {
+		t.Fatalf("loadCLIConfig: %v", err)
+	}
+	if cfg.UserToken != issuedToken {
+		t.Errorf("UserToken = %q, want %q", cfg.UserToken, issuedToken)
+	}
+}
+
+// TestParseRetryAfter covers the CLI's interpretation of the Retry-After
+// header (delta-seconds, HTTP-date, and malformed/empty cases).
+func TestParseRetryAfter(t *testing.T) {
+	now := time.Now().UTC()
+	tests := []struct {
+		in   string
+		want time.Duration
+	}{
+		{"", 0},
+		{"5", 5 * time.Second},
+		{"  10  ", 10 * time.Second},
+		{"-1", 0},
+		{"not a number", 0},
+		// HTTP-date in the future yields a positive duration; we don't
+		// pin to an exact value because parseRetryAfter computes
+		// time.Until(t), which races with wall-clock at sub-second
+		// granularity. Just assert it's roughly within a 30s window.
+		{now.Add(20 * time.Second).Format(http.TimeFormat), 20 * time.Second},
+	}
+	for _, tt := range tests {
+		got := parseRetryAfter(tt.in)
+		if tt.want == 0 {
+			if got != 0 {
+				t.Errorf("parseRetryAfter(%q) = %v, want 0", tt.in, got)
+			}
+			continue
+		}
+		// Allow ±5s slack for the HTTP-date variant.
+		diff := got - tt.want
+		if diff < -5*time.Second || diff > 5*time.Second {
+			t.Errorf("parseRetryAfter(%q) = %v, want ~%v", tt.in, got, tt.want)
+		}
 	}
 }
 

--- a/docs/admin/configuration.md
+++ b/docs/admin/configuration.md
@@ -39,6 +39,7 @@ values from the config file.
 | `GHP_SERVER_HTTP_LISTEN` | HTTP listen address for HTTPS redirects | |
 | `GHP_SERVER_MANAGEMENT_HOST` | Hostname for the management UI and API | |
 | `GHP_SERVER_BASE_URL` | Public base URL for OAuth callbacks and links | |
+| `GHP_SERVER_TRUST_PROXY_HEADERS` | Honour `Forwarded` / `X-Forwarded-Proto` / `X-Forwarded-Host` when `base_url` is unset (only enable behind a trusted reverse proxy) | `false` |
 | `GHP_SERVER_SYSTEMD_SOCKET_ACTIVATION` | Accept sockets from systemd instead of binding addresses | `false` |
 
 ### GitHub
@@ -178,6 +179,10 @@ server:
   http_listen: ":80"           # HTTP-to-HTTPS redirect server
   management_host: ""          # hostname for management UI (e.g. ghp.example.com)
   base_url: ""                 # public base URL (e.g. https://ghp.example.com)
+  # trust_proxy_headers: false # honour Forwarded / X-Forwarded-Proto / X-Forwarded-Host
+                                #   when base_url is unset. Set true only behind a trusted
+                                #   reverse proxy that strips and rewrites these headers.
+                                #   Prefer setting base_url instead.
   # systemd_socket_activation: false  # accept sockets from systemd
 
 tls:

--- a/docs/admin/monitoring.md
+++ b/docs/admin/monitoring.md
@@ -138,6 +138,8 @@ See [Git Cache](../features/git-cache.md) for configuration details.
 | `ghp_auth_rate_limit_total` | Counter | Rate limiter rejections on auth endpoints (label: `endpoint`) |
 | `ghp_block_anonymous_git_total` | Counter | Anonymous git requests blocked |
 | `ghp_block_anonymous_git_enabled` | Gauge | Whether anonymous git blocking is active (1 or 0) |
+| `ghp_cli_auth_device_started_total` | Counter | CLI device-authorization requests initiated (one per `ghp auth login` invocation) |
+| `ghp_cli_auth_device_completed_total` | Counter | CLI device-authorization requests that reached a terminal state (label: `result` — `approved`, `denied`, or `expired`) |
 
 #### Release Controls Metrics
 

--- a/docs/cli/auth.md
+++ b/docs/cli/auth.md
@@ -1,6 +1,6 @@
 # ghp auth
 
-Authenticate with the ghp server.
+Authenticate to the ghp server.
 
 ## Subcommands
 
@@ -8,33 +8,54 @@ Authenticate with the ghp server.
 
     ghp auth login
 
-Start a GitHub OAuth login flow. The command contacts the ghp server to obtain
-a GitHub authorization URL, then attempts to open it in your default browser.
+Sign in to the ghp server using a device-authorization flow. The CLI never
+contacts GitHub directly: GitHub OAuth is the identity provider for the ghp
+web UI, but `ghp auth login` only talks to your ghp server.
 
-If the browser does not open (e.g. in an SSH session or headless environment),
-copy the printed URL and open it manually. After authenticating with GitHub,
-the page will display a JSON payload containing your session token:
+The flow:
 
-```json
-{"session_token":"ghpr_...","username":"your-github-username"}
-```
+1. The CLI requests a fresh sign-in from the ghp server and prints a URL on
+   the **ghp server** (not github.com) along with a short verification code:
 
-Copy the `session_token` value and save it with:
+   ```
+   Open this URL in a browser to authorize the CLI:
+     https://your-ghp.example/cli/auth?user_code=ABCD-EFGH
 
-    ghp auth set-token <session_token>
+   Confirm this code matches what the page displays:
+     ABCD-EFGH
 
-Or export it as an environment variable:
+   Waiting for approval (Ctrl-C to cancel)...
+   ```
 
-    export GHP_USER_TOKEN=<session_token>
+2. Open the URL in a browser. If you are not already signed in to ghp, you
+   will be sent through GitHub OAuth first and returned to the verification
+   page automatically.
+
+3. Confirm that the user code shown in the browser matches the one printed
+   by your CLI, then click **Authorize** (or **Deny**).
+
+4. The CLI polls the server, picks up the issued session token, and saves
+   it to `~/.config/ghp/config.yaml`. Run `ghp auth status` to verify.
+
+The verification code is short-lived (10 minutes) and tied to a specific CLI
+sign-in attempt; if the code expires before approval, run `ghp auth login`
+again to get a new one.
+
+#### Headless / SSH usage
+
+If the browser cannot be opened automatically (for example in an SSH session
+without X forwarding), copy the URL printed by the CLI and open it on
+another machine. The verification page is served over HTTPS by your ghp
+server and works from any browser that can reach it.
 
 ### ghp auth set-token
 
     ghp auth set-token <token>
 
-Save a session token (obtained from `ghp auth login`) to the local config file
-at `~/.config/ghp/config.yaml`. The token must start with `ghpr_`.
-
-    ghp auth set-token ghpr_abc123...
+Save a session token to the local config file at `~/.config/ghp/config.yaml`.
+This is normally done automatically by `ghp auth login`; use this command
+only if you are pasting in a token obtained another way (e.g. from a teammate
+or a session created via the web UI). The token must start with `ghpr_`.
 
 After saving, verify with `ghp auth status`.
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -22,6 +22,13 @@ First, authenticate with the ghp server:
 
     ghp auth login
 
+This opens a verification URL on your **ghp server** (not github.com) showing
+a short user code. Confirm the code matches what the CLI printed and click
+**Authorize**. The CLI then saves the issued session token to
+`~/.config/ghp/config.yaml`. See [`ghp auth login`](cli/auth.md#ghp-auth-login)
+for details, including how to use the flow over SSH or in a headless
+environment.
+
 Then create a scoped proxy token:
 
     ghp token create \

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -45,6 +45,23 @@ SNI to select the correct certificate for each hostname. In plain HTTP mode
 (for development or behind a reverse proxy), routing is based on the `Host`
 header alone.
 
+## High Availability
+
+ghp can run as multiple instances behind a load balancer. All transient auth
+state — browser sessions, in-flight OAuth state tokens for the GitHub login
+redirect, OAuth broker state, and CLI device-authorization records — is
+stored in the configured database (PostgreSQL, SQLite, or Vault), not in
+process memory. A user signed in on instance A can be served their next
+request from instance B, the GitHub OAuth callback for a redirect launched
+on instance A is valid against instance B, and a CLI device flow whose
+`/cli/auth/device` and `/cli/auth/device/token` calls land on different
+instances completes correctly.
+
+A background cleanup goroutine on each instance periodically purges expired
+sessions, OAuth state rows, and device-auth records (default every 5
+minutes). For the SQLite backend this is in-process; for PostgreSQL and
+Vault it is shared by all instances and idempotent.
+
 ## Security Model
 
 - **Token isolation** — agents never see real GitHub credentials; they only hold short-lived ghp tokens

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -38,7 +38,7 @@ ghp serves four distinct roles depending on which hostname the request arrives o
 | `api.github.com` | **API proxy** — validates tokens, enforces scopes, injects credentials, logs every request |
 | `github.com` | **Git passthrough** — transparent proxy for `git clone`, `git push`, etc. with token interception |
 | `*.githubcopilot.com` | **Copilot passthrough** — forwards Copilot traffic transparently; all requests are logged |
-| Your management host | **Dashboard** — web UI, GitHub OAuth login, token management API |
+| Your management host | **Dashboard** — web UI, GitHub OAuth login (web), CLI device-authorization endpoints, token management API |
 
 In TLS mode (recommended for production), ghp terminates TLS directly and uses
 SNI to select the correct certificate for each hostname. In plain HTTP mode

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -1,19 +1,26 @@
 // Package auth handles GitHub OAuth authentication, browser session management,
 // and the optional OAuth broker feature. It provides:
 //
-//   - GitHub OAuth login flow for the web UI and CLI (code exchange, user info)
-//   - In-memory session store with LRU eviction and TTL expiry
+//   - GitHub OAuth login flow for the web UI (code exchange, user info)
+//   - Persistent (database-backed) session store
+//   - CLI device-authorization flow against ghp itself (no GitHub round-trip)
 //   - OAuth broker endpoints that allow downstream services to authenticate
 //     users via ghp without needing their own GitHub OAuth credentials
 //   - RS256 JWT signing for broker tokens, with JWKS endpoint for key discovery
 //   - Per-endpoint IP rate limiting on sensitive auth endpoints
 //   - Dev-mode test login endpoint (bypasses OAuth for development/testing)
+//
+// All transient auth state (sessions, OAuth state tokens, CLI device records)
+// is stored in the database via the Store interface so that flows that span
+// multiple HTTP round-trips remain correct in HA deployments where each
+// request may land on a different ghp instance.
 package auth
 
 import (
 	"context"
 	"crypto/rand"
 	"crypto/rsa"
+	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
@@ -25,8 +32,6 @@ import (
 	"os"
 	"strings"
 	"time"
-
-	"github.com/hashicorp/golang-lru/v2/expirable"
 
 	"github.com/goodtune/ghp/internal/config"
 	"github.com/goodtune/ghp/internal/crypto"
@@ -44,19 +49,16 @@ const (
 	// maxTokenResponseSize is the maximum number of bytes read from GitHub's
 	// OAuth token and user-info endpoints. This guards against unbounded reads.
 	maxTokenResponseSize = 64 * 1024 // 64 KB
-	// maxSessions is the maximum number of concurrent user sessions held in memory.
-	maxSessions = 10_000
-	// maxStates is the maximum number of in-flight OAuth state tokens.
-	maxStates = 1_000
 	// stateTTL is how long an OAuth state token remains valid.
 	stateTTL = 10 * time.Minute
-	// maxBrokerStates is the maximum number of in-flight broker OAuth states.
-	maxBrokerStates = 1_000
 	// brokerStateTTL is how long a broker OAuth state token remains valid.
 	brokerStateTTL = 10 * time.Minute
 	// authHTTPTimeout is the timeout for outbound HTTP requests made by the
 	// auth handler (OAuth token exchange and GitHub user-info calls).
 	authHTTPTimeout = 30 * time.Second
+	// authStateCleanupInterval is how often the cleanup goroutine sweeps
+	// expired sessions, oauth_states, and cli_device_authorizations rows.
+	authStateCleanupInterval = 5 * time.Minute
 )
 
 // Session represents an authenticated user session.
@@ -67,7 +69,9 @@ type Session struct {
 	ExpiresAt time.Time
 }
 
-// Handler manages OAuth flows and sessions.
+// Handler manages OAuth flows and sessions. All transient state (sessions,
+// in-flight OAuth state tokens, CLI device-authorization records) is held in
+// the Store, which makes the auth flows correct under HA load balancing.
 type Handler struct {
 	cfg       *config.Config
 	store     database.Store
@@ -79,25 +83,6 @@ type Handler struct {
 	// Note: this key is set once at NewHandler time; config hot-reload (SIGUSR1)
 	// does not update it — a server restart is required to change the signing key.
 	rsaPrivKey *rsa.PrivateKey
-
-	// sessions maps session tokens to active user sessions.
-	// Bounded and TTL-expired via expirable.LRU (thread-safe).
-	sessions *expirable.LRU[string, *Session]
-
-	// states holds in-flight OAuth state tokens (short-lived). The value is an
-	// optional return-to path to redirect the browser to after successful auth;
-	// empty means use the default ("/").
-	states *expirable.LRU[string, string]
-
-	// deviceRequests tracks in-flight CLI device-authorization requests.
-	// Keyed by device_code (the long-lived secret the CLI polls with).
-	deviceRequests *expirable.LRU[string, *deviceAuthRequest]
-	// deviceUserCodes maps short, human-friendly user_codes to device_codes
-	// so the verification page can look up the request from the URL param.
-	deviceUserCodes *expirable.LRU[string, string]
-
-	// brokerStates holds in-flight broker OAuth flow states (short-lived).
-	brokerStates *expirable.LRU[string, *brokerState]
 
 	// Rate limiters for sensitive endpoints (keyed by IP address).
 	loginLimiter     *IPRateLimiter // POST /auth/test-login
@@ -111,6 +96,10 @@ type Handler struct {
 	// Overridable base URLs for GitHub endpoints (used in tests).
 	githubBaseURL    string // defaults to "https://github.com"
 	githubAPIBaseURL string // defaults to "https://api.github.com"
+
+	// cleanupCancel stops the background cleanup goroutine when the handler
+	// is shut down. Set by StartCleanup; nil if no cleanup is running.
+	cleanupCancel context.CancelFunc
 }
 
 // NewHandler creates a new auth handler.
@@ -120,11 +109,6 @@ func NewHandler(cfg *config.Config, store database.Store, enc *crypto.Encryptor,
 		store:            store,
 		encryptor:        enc,
 		logger:           logger,
-		sessions:         expirable.NewLRU[string, *Session](maxSessions, nil, SessionDuration),
-		states:           expirable.NewLRU[string, string](maxStates, nil, stateTTL),
-		brokerStates:     expirable.NewLRU[string, *brokerState](maxBrokerStates, nil, brokerStateTTL),
-		deviceRequests:   expirable.NewLRU[string, *deviceAuthRequest](maxDeviceRequests, nil, deviceRequestTTL),
-		deviceUserCodes:  expirable.NewLRU[string, string](maxDeviceRequests, nil, deviceRequestTTL),
 		loginLimiter:     NewIPRateLimiter(100, time.Minute, "/auth/test-login", logger),
 		githubLimiter:    NewIPRateLimiter(10, time.Minute, "/auth/github", logger),
 		authorizeLimiter: NewIPRateLimiter(10, time.Minute, "/auth/authorize", logger),
@@ -200,13 +184,13 @@ func (h *Handler) RegisterRoutes(mux *http.ServeMux) {
 func (h *Handler) GetSession(r *http.Request) *Session {
 	// Check cookie first.
 	if cookie, err := r.Cookie(SessionCookieName); err == nil {
-		return h.lookupSession(cookie.Value)
+		return h.lookupSession(r.Context(), cookie.Value)
 	}
 
 	// Check Authorization header for service tokens (CLI usage).
 	auth := r.Header.Get("Authorization")
 	if strings.HasPrefix(auth, "Bearer ghpr_") {
-		return h.lookupSession(strings.TrimPrefix(auth, "Bearer "))
+		return h.lookupSession(r.Context(), strings.TrimPrefix(auth, "Bearer "))
 	}
 
 	return nil
@@ -251,39 +235,131 @@ func NewContextWithSession(ctx context.Context, s *Session) context.Context {
 	return context.WithValue(ctx, sessionKey{}, s)
 }
 
-func (h *Handler) lookupSession(token string) *Session {
-	s, ok := h.sessions.Get(token)
-	if !ok {
-		return nil
-	}
-	// ExpiresAt is a belt-and-suspenders check; the LRU TTL already evicts
-	// expired entries, but we keep it for defense in depth.
-	if time.Now().After(s.ExpiresAt) {
-		h.sessions.Remove(token)
-		return nil
-	}
-	return s
+// hashSessionToken returns the SHA-256 hex digest of a raw session bearer.
+// The Store keys sessions by this value so the unhashed token never lives
+// in the database.
+func hashSessionToken(token string) string {
+	sum := sha256.Sum256([]byte(token))
+	return hex.EncodeToString(sum[:])
 }
 
-func (h *Handler) createSession(userID, username, role string) string {
+func (h *Handler) lookupSession(ctx context.Context, token string) *Session {
+	if token == "" {
+		return nil
+	}
+	row, err := h.store.GetSessionByTokenHash(ctx, hashSessionToken(token))
+	if err != nil {
+		if !errors.Is(err, database.ErrNotFound) {
+			h.logger.Error("session lookup failed", "error", err)
+		}
+		return nil
+	}
+	return &Session{
+		UserID:    row.UserID,
+		Username:  row.Username,
+		Role:      row.Role,
+		ExpiresAt: row.ExpiresAt,
+	}
+}
+
+// createSession persists a new session row and returns the raw bearer token
+// to hand to the client (cookie or JSON response). The DB stores only the
+// hash of this value.
+func (h *Handler) createSession(ctx context.Context, userID, username, role string) (string, error) {
 	token := generateSessionToken()
-	h.sessions.Add(token, &Session{
+	expiresAt := time.Now().Add(SessionDuration).UTC()
+	if err := h.store.CreateSession(ctx, &database.Session{
+		TokenHash: hashSessionToken(token),
 		UserID:    userID,
 		Username:  username,
 		Role:      role,
-		ExpiresAt: time.Now().Add(SessionDuration),
-	})
-	return token
+		ExpiresAt: expiresAt,
+	}); err != nil {
+		return "", err
+	}
+	return token, nil
 }
 
 // CreateTestSession creates a session for E2E testing without OAuth.
 // Returns the session token that should be set as the ghp_session cookie.
+// Errors from the underlying store are logged and swallowed — test setup is
+// expected to be run against a healthy store, and historical callers don't
+// have an error return.
 func (h *Handler) CreateTestSession(userID, username, role string) string {
-	return h.createSession(userID, username, role)
+	tok, err := h.createSession(context.Background(), userID, username, role)
+	if err != nil {
+		h.logger.Error("CreateTestSession failed", "error", err)
+		return ""
+	}
+	return tok
 }
 
-func (h *Handler) deleteSession(token string) {
-	h.sessions.Remove(token)
+func (h *Handler) deleteSession(ctx context.Context, token string) {
+	if token == "" {
+		return
+	}
+	if err := h.store.DeleteSession(ctx, hashSessionToken(token)); err != nil {
+		h.logger.Warn("session delete failed", "error", err)
+	}
+}
+
+// StartCleanup launches a background goroutine that periodically purges
+// expired sessions, oauth_states, and cli_device_authorizations rows. It
+// returns immediately; the caller should arrange for the returned context's
+// cancellation when the server shuts down.
+//
+// Calling StartCleanup more than once on the same Handler replaces any
+// previously-running cleanup goroutine.
+func (h *Handler) StartCleanup(ctx context.Context) {
+	if h.cleanupCancel != nil {
+		h.cleanupCancel()
+	}
+	cleanupCtx, cancel := context.WithCancel(ctx)
+	h.cleanupCancel = cancel
+	go h.cleanupLoop(cleanupCtx)
+}
+
+// StopCleanup stops a previously-started cleanup goroutine. Safe to call
+// even if cleanup was never started.
+func (h *Handler) StopCleanup() {
+	if h.cleanupCancel != nil {
+		h.cleanupCancel()
+		h.cleanupCancel = nil
+	}
+}
+
+func (h *Handler) cleanupLoop(ctx context.Context) {
+	t := time.NewTicker(authStateCleanupInterval)
+	defer t.Stop()
+	// Run once immediately so a long-running prior process's leftovers are
+	// purged on startup.
+	h.runCleanup(ctx)
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+			h.runCleanup(ctx)
+		}
+	}
+}
+
+func (h *Handler) runCleanup(ctx context.Context) {
+	if n, err := h.store.DeleteExpiredSessions(ctx); err != nil {
+		h.logger.Warn("session cleanup failed", "error", err)
+	} else if n > 0 {
+		h.logger.Debug("expired sessions purged", "count", n)
+	}
+	if n, err := h.store.DeleteExpiredOAuthStates(ctx); err != nil {
+		h.logger.Warn("oauth state cleanup failed", "error", err)
+	} else if n > 0 {
+		h.logger.Debug("expired oauth states purged", "count", n)
+	}
+	if n, err := h.store.DeleteExpiredDeviceAuths(ctx); err != nil {
+		h.logger.Warn("device auth cleanup failed", "error", err)
+	} else if n > 0 {
+		h.logger.Debug("expired device auth records purged", "count", n)
+	}
 }
 
 func (h *Handler) handleGitHubLogin(w http.ResponseWriter, r *http.Request) {
@@ -292,9 +368,19 @@ func (h *Handler) handleGitHubLogin(w http.ResponseWriter, r *http.Request) {
 	// return_to lets a browser flow request that the user be sent back to a
 	// specific path after successful login (e.g. the device-authorization
 	// verification page). It is restricted to local paths to prevent open
-	// redirects. Stored alongside the state in the in-flight LRU.
+	// redirects. Stored alongside the state row so any ghp instance handling
+	// the GitHub callback can read it.
 	returnTo := sanitizeReturnTo(r.URL.Query().Get("return_to"))
-	h.states.Add(state, returnTo)
+	if err := h.store.CreateOAuthState(r.Context(), &database.OAuthState{
+		State:     state,
+		Kind:      database.OAuthStateKindLogin,
+		ReturnTo:  returnTo,
+		ExpiresAt: time.Now().Add(stateTTL).UTC(),
+	}); err != nil {
+		h.logger.Error("failed to persist oauth state", "error", err)
+		http.Error(w, "Internal error", http.StatusInternalServerError)
+		return
+	}
 
 	// CLI clients (Accept: application/json) need the callback to return JSON
 	// with the session token rather than setting a cookie and redirecting.
@@ -356,25 +442,23 @@ func (h *Handler) handleGitHubCallback(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		// Validate state. Get returns false for missing or TTL-expired entries.
-		// The stored value is an optional return-to path (set when the login
-		// was initiated by an in-app flow such as CLI device authorization).
-		var returnTo string
-		var ok bool
-		returnTo, ok = h.states.Get(state)
-		if ok {
-			h.states.Remove(state)
-		}
-		if !ok {
+		// Atomically read-and-delete the state row. Returns ErrNotFound for
+		// missing, expired, or wrong-kind entries.
+		st, err := h.store.ConsumeOAuthState(r.Context(), state, database.OAuthStateKindLogin)
+		if err != nil {
+			if !errors.Is(err, database.ErrNotFound) {
+				h.logger.Error("oauth state consume failed", "error", err)
+			}
 			http.Error(w, "Invalid or expired state", http.StatusBadRequest)
 			return
 		}
-		if returnTo != "" {
+		if st.ReturnTo != "" {
 			// Defer to the returnTo path after authentication completes.
-			// stateReturnTo is read again below by setting a request-scoped
-			// header, since handleGitHubCallback's existing redirect target
-			// is hardcoded to "/".
-			r = r.WithContext(context.WithValue(r.Context(), returnToCtxKey{}, returnTo))
+			// handleGitHubCallback's redirect target is hardcoded to "/" by
+			// default; threading the path through the request context lets
+			// the redirect at the bottom of this handler honour it without
+			// changing its signature.
+			r = r.WithContext(context.WithValue(r.Context(), returnToCtxKey{}, st.ReturnTo))
 		}
 	}
 
@@ -461,7 +545,12 @@ func (h *Handler) handleGitHubCallback(w http.ResponseWriter, r *http.Request) {
 	h.logger.Info("auth_login", "user", ghUser.Login, "github_id", ghUser.ID)
 
 	// Create session.
-	sessionToken := h.createSession(user.ID, user.GitHubUsername, user.Role)
+	sessionToken, err := h.createSession(r.Context(), user.ID, user.GitHubUsername, user.Role)
+	if err != nil {
+		h.logger.Error("failed to persist session", "error", err)
+		http.Error(w, "Internal error", http.StatusInternalServerError)
+		return
+	}
 
 	// If the request wants JSON (CLI client), return the token.
 	if r.URL.Query().Get("format") == "json" {
@@ -511,7 +600,7 @@ func sanitizeReturnTo(v string) string {
 
 func (h *Handler) handleLogout(w http.ResponseWriter, r *http.Request) {
 	if cookie, err := r.Cookie(SessionCookieName); err == nil {
-		h.deleteSession(cookie.Value)
+		h.deleteSession(r.Context(), cookie.Value)
 	}
 	http.SetCookie(w, &http.Cookie{
 		Name:     SessionCookieName,
@@ -608,7 +697,12 @@ func (h *Handler) handleTestLogin(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Create session.
-	sessionToken := h.createSession(user.ID, user.GitHubUsername, user.Role)
+	sessionToken, err := h.createSession(r.Context(), user.ID, user.GitHubUsername, user.Role)
+	if err != nil {
+		h.logger.Error("failed to persist test session", "error", err)
+		http.Error(w, "Internal error", http.StatusInternalServerError)
+		return
+	}
 
 	// Set cookie.
 	http.SetCookie(w, &http.Cookie{

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -867,16 +867,15 @@ func (h *Handler) getGitHubAPIBaseURL() string {
 	return "https://api.github.com"
 }
 
-// mainCallbackURL returns the absolute URL of the GitHub OAuth callback endpoint
-// for the main login flow. It uses the configured BaseURL if available, otherwise
-// derives the URL from the incoming request.
+// mainCallbackURL returns the absolute URL of the GitHub OAuth callback
+// endpoint for the main login flow. It uses the configured BaseURL if
+// available, otherwise derives the URL from the incoming request, honouring
+// Forwarded / X-Forwarded-* headers when ghp sits behind a TLS-terminating
+// reverse proxy. The same shared helpers (requestScheme/requestHost) are
+// used by the CLI device-flow verification URL so the two stay consistent.
 func (h *Handler) mainCallbackURL(r *http.Request) string {
 	if h.cfg.Server.BaseURL != "" {
 		return strings.TrimRight(h.cfg.Server.BaseURL, "/") + "/auth/github/callback"
 	}
-	scheme := "https"
-	if r.TLS == nil {
-		scheme = "http"
-	}
-	return fmt.Sprintf("%s://%s/auth/github/callback", scheme, r.Host)
+	return fmt.Sprintf("%s://%s/auth/github/callback", requestScheme(r), requestHost(r))
 }

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -869,13 +869,15 @@ func (h *Handler) getGitHubAPIBaseURL() string {
 
 // mainCallbackURL returns the absolute URL of the GitHub OAuth callback
 // endpoint for the main login flow. It uses the configured BaseURL if
-// available, otherwise derives the URL from the incoming request, honouring
-// Forwarded / X-Forwarded-* headers when ghp sits behind a TLS-terminating
-// reverse proxy. The same shared helpers (requestScheme/requestHost) are
-// used by the CLI device-flow verification URL so the two stay consistent.
+// available, otherwise derives the URL from the incoming request. The
+// shared requestScheme/requestHost helpers honour Forwarded / X-Forwarded-*
+// only when server.trust_proxy_headers is true (matches the device-flow
+// verification URL so the two stay consistent under both deployment
+// patterns).
 func (h *Handler) mainCallbackURL(r *http.Request) string {
 	if h.cfg.Server.BaseURL != "" {
 		return strings.TrimRight(h.cfg.Server.BaseURL, "/") + "/auth/github/callback"
 	}
-	return fmt.Sprintf("%s://%s/auth/github/callback", requestScheme(r), requestHost(r))
+	trustProxy := h.cfg.Server.TrustProxyHeaders
+	return fmt.Sprintf("%s://%s/auth/github/callback", requestScheme(r, trustProxy), requestHost(r, trustProxy))
 }

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -84,8 +84,17 @@ type Handler struct {
 	// Bounded and TTL-expired via expirable.LRU (thread-safe).
 	sessions *expirable.LRU[string, *Session]
 
-	// states holds in-flight OAuth state tokens (short-lived).
-	states *expirable.LRU[string, struct{}]
+	// states holds in-flight OAuth state tokens (short-lived). The value is an
+	// optional return-to path to redirect the browser to after successful auth;
+	// empty means use the default ("/").
+	states *expirable.LRU[string, string]
+
+	// deviceRequests tracks in-flight CLI device-authorization requests.
+	// Keyed by device_code (the long-lived secret the CLI polls with).
+	deviceRequests *expirable.LRU[string, *deviceAuthRequest]
+	// deviceUserCodes maps short, human-friendly user_codes to device_codes
+	// so the verification page can look up the request from the URL param.
+	deviceUserCodes *expirable.LRU[string, string]
 
 	// brokerStates holds in-flight broker OAuth flow states (short-lived).
 	brokerStates *expirable.LRU[string, *brokerState]
@@ -112,8 +121,10 @@ func NewHandler(cfg *config.Config, store database.Store, enc *crypto.Encryptor,
 		encryptor:        enc,
 		logger:           logger,
 		sessions:         expirable.NewLRU[string, *Session](maxSessions, nil, SessionDuration),
-		states:           expirable.NewLRU[string, struct{}](maxStates, nil, stateTTL),
+		states:           expirable.NewLRU[string, string](maxStates, nil, stateTTL),
 		brokerStates:     expirable.NewLRU[string, *brokerState](maxBrokerStates, nil, brokerStateTTL),
+		deviceRequests:   expirable.NewLRU[string, *deviceAuthRequest](maxDeviceRequests, nil, deviceRequestTTL),
+		deviceUserCodes:  expirable.NewLRU[string, string](maxDeviceRequests, nil, deviceRequestTTL),
 		loginLimiter:     NewIPRateLimiter(100, time.Minute, "/auth/test-login", logger),
 		githubLimiter:    NewIPRateLimiter(10, time.Minute, "/auth/github", logger),
 		authorizeLimiter: NewIPRateLimiter(10, time.Minute, "/auth/authorize", logger),
@@ -159,6 +170,9 @@ func (h *Handler) RegisterRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("GET /auth/github/callback", h.handleGitHubCallback)
 	mux.HandleFunc("POST /auth/logout", h.handleLogout)
 	mux.HandleFunc("GET /auth/status", h.handleStatus)
+
+	// CLI device-authorization flow (no GitHub round-trip from the CLI).
+	h.registerDeviceRoutes(mux)
 
 	// OAuth broker endpoints: delegate authentication to this proxy.
 	if h.cfg.Auth.JWTPrivateKey != "" || h.cfg.Auth.JWTPrivateKeyFile != "" {
@@ -274,7 +288,13 @@ func (h *Handler) deleteSession(token string) {
 
 func (h *Handler) handleGitHubLogin(w http.ResponseWriter, r *http.Request) {
 	state := generateState()
-	h.states.Add(state, struct{}{})
+
+	// return_to lets a browser flow request that the user be sent back to a
+	// specific path after successful login (e.g. the device-authorization
+	// verification page). It is restricted to local paths to prevent open
+	// redirects. Stored alongside the state in the in-flight LRU.
+	returnTo := sanitizeReturnTo(r.URL.Query().Get("return_to"))
+	h.states.Add(state, returnTo)
 
 	// CLI clients (Accept: application/json) need the callback to return JSON
 	// with the session token rather than setting a cookie and redirecting.
@@ -337,13 +357,24 @@ func (h *Handler) handleGitHubCallback(w http.ResponseWriter, r *http.Request) {
 		}
 
 		// Validate state. Get returns false for missing or TTL-expired entries.
-		_, ok := h.states.Get(state)
+		// The stored value is an optional return-to path (set when the login
+		// was initiated by an in-app flow such as CLI device authorization).
+		var returnTo string
+		var ok bool
+		returnTo, ok = h.states.Get(state)
 		if ok {
 			h.states.Remove(state)
 		}
 		if !ok {
 			http.Error(w, "Invalid or expired state", http.StatusBadRequest)
 			return
+		}
+		if returnTo != "" {
+			// Defer to the returnTo path after authentication completes.
+			// stateReturnTo is read again below by setting a request-scoped
+			// header, since handleGitHubCallback's existing redirect target
+			// is hardcoded to "/".
+			r = r.WithContext(context.WithValue(r.Context(), returnToCtxKey{}, returnTo))
 		}
 	}
 
@@ -453,7 +484,29 @@ func (h *Handler) handleGitHubCallback(w http.ResponseWriter, r *http.Request) {
 		MaxAge:   int(SessionDuration.Seconds()),
 	})
 
-	http.Redirect(w, r, "/", http.StatusSeeOther)
+	target := "/"
+	if v, ok := r.Context().Value(returnToCtxKey{}).(string); ok && v != "" {
+		target = v
+	}
+	http.Redirect(w, r, target, http.StatusSeeOther)
+}
+
+type returnToCtxKey struct{}
+
+// sanitizeReturnTo restricts return_to to local paths only, preventing open
+// redirects. It must begin with "/" and must not begin with "//" or "/\\"
+// (which browsers can interpret as a protocol-relative URL).
+func sanitizeReturnTo(v string) string {
+	if v == "" {
+		return ""
+	}
+	if !strings.HasPrefix(v, "/") {
+		return ""
+	}
+	if strings.HasPrefix(v, "//") || strings.HasPrefix(v, "/\\") {
+		return ""
+	}
+	return v
 }
 
 func (h *Handler) handleLogout(w http.ResponseWriter, r *http.Request) {

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -36,6 +36,7 @@ import (
 	"github.com/goodtune/ghp/internal/config"
 	"github.com/goodtune/ghp/internal/crypto"
 	"github.com/goodtune/ghp/internal/database"
+	"github.com/goodtune/ghp/internal/metrics"
 )
 
 const (
@@ -85,9 +86,11 @@ type Handler struct {
 	rsaPrivKey *rsa.PrivateKey
 
 	// Rate limiters for sensitive endpoints (keyed by IP address).
-	loginLimiter     *IPRateLimiter // POST /auth/test-login
-	githubLimiter    *IPRateLimiter // GET  /auth/github
-	authorizeLimiter *IPRateLimiter // GET  /auth/authorize
+	loginLimiter      *IPRateLimiter // POST /auth/test-login
+	githubLimiter     *IPRateLimiter // GET  /auth/github
+	authorizeLimiter  *IPRateLimiter // GET  /auth/authorize
+	deviceStartLimiter *IPRateLimiter // POST /cli/auth/device
+	devicePollLimiter  *IPRateLimiter // POST /cli/auth/device/token
 
 	// httpClient is used for all outbound OAuth and GitHub API requests.
 	// It has a finite timeout to prevent goroutine/connection leaks.
@@ -112,7 +115,14 @@ func NewHandler(cfg *config.Config, store database.Store, enc *crypto.Encryptor,
 		loginLimiter:     NewIPRateLimiter(100, time.Minute, "/auth/test-login", logger),
 		githubLimiter:    NewIPRateLimiter(10, time.Minute, "/auth/github", logger),
 		authorizeLimiter: NewIPRateLimiter(10, time.Minute, "/auth/authorize", logger),
-		httpClient:       &http.Client{Timeout: authHTTPTimeout},
+		// /cli/auth/device kicks off a flow that creates a database row, so
+		// it gets the same conservative ceiling as /auth/github. The polling
+		// endpoint is more permissive — a single CLI run polls every few
+		// seconds for up to 10 minutes, which is up to ~300 hits, and
+		// multiple CLI processes may run from the same NAT'd IP.
+		deviceStartLimiter: NewIPRateLimiter(10, time.Minute, "/cli/auth/device", logger),
+		devicePollLimiter:  NewIPRateLimiter(600, time.Minute, "/cli/auth/device/token", logger),
+		httpClient:         &http.Client{Timeout: authHTTPTimeout},
 	}
 	if cfg.Auth.JWTPrivateKey != "" || cfg.Auth.JWTPrivateKeyFile != "" {
 		var pemData string
@@ -346,20 +356,38 @@ func (h *Handler) cleanupLoop(ctx context.Context) {
 
 func (h *Handler) runCleanup(ctx context.Context) {
 	if n, err := h.store.DeleteExpiredSessions(ctx); err != nil {
-		h.logger.Warn("session cleanup failed", "error", err)
+		// context.Canceled is expected when the server is shutting down
+		// mid-sweep; demote those to Debug so shutdown logs stay quiet.
+		h.logCleanupError("session cleanup failed", err)
 	} else if n > 0 {
 		h.logger.Debug("expired sessions purged", "count", n)
 	}
 	if n, err := h.store.DeleteExpiredOAuthStates(ctx); err != nil {
-		h.logger.Warn("oauth state cleanup failed", "error", err)
+		h.logCleanupError("oauth state cleanup failed", err)
 	} else if n > 0 {
 		h.logger.Debug("expired oauth states purged", "count", n)
 	}
 	if n, err := h.store.DeleteExpiredDeviceAuths(ctx); err != nil {
-		h.logger.Warn("device auth cleanup failed", "error", err)
+		h.logCleanupError("device auth cleanup failed", err)
 	} else if n > 0 {
 		h.logger.Debug("expired device auth records purged", "count", n)
+		// Surface the count under the same metric the device-flow handlers
+		// use. This means ghp_cli_auth_device_completed_total{result="expired"}
+		// reports records that timed out before the user acted, complementing
+		// the "approved" and "denied" results emitted from the poll endpoint.
+		metrics.CLIDeviceCompletedTotal.WithLabelValues("expired").Add(float64(n))
 	}
+}
+
+// logCleanupError logs a cleanup-loop error at the appropriate level. A
+// context.Canceled error during shutdown is expected and would otherwise
+// produce a noisy Warn on every server stop, so it is logged at Debug.
+func (h *Handler) logCleanupError(msg string, err error) {
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		h.logger.Debug(msg, "error", err)
+		return
+	}
+	h.logger.Warn(msg, "error", err)
 }
 
 func (h *Handler) handleGitHubLogin(w http.ResponseWriter, r *http.Request) {

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -612,7 +612,10 @@ type returnToCtxKey struct{}
 
 // sanitizeReturnTo restricts return_to to local paths only, preventing open
 // redirects. It must begin with "/" and must not begin with "//" or "/\\"
-// (which browsers can interpret as a protocol-relative URL).
+// (which browsers can interpret as a protocol-relative URL). The value also
+// cannot contain ASCII control characters (CR/LF in particular) because the
+// final destination is the `Location:` response header — embedded CRLF
+// would split the header and risk response-splitting on lenient clients.
 func sanitizeReturnTo(v string) string {
 	if v == "" {
 		return ""
@@ -622,6 +625,15 @@ func sanitizeReturnTo(v string) string {
 	}
 	if strings.HasPrefix(v, "//") || strings.HasPrefix(v, "/\\") {
 		return ""
+	}
+	for i := 0; i < len(v); i++ {
+		c := v[i]
+		// Reject the ASCII control range (NUL..US) and DEL. A legitimate
+		// path/query never contains these — clients that need raw bytes
+		// percent-encode them.
+		if c < 0x20 || c == 0x7f {
+			return ""
+		}
 	}
 	return v
 }

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -420,11 +420,14 @@ func TestHandleGitHubLogin_IncludesRedirectURI(t *testing.T) {
 // callback URL from the configured BaseURL or from the incoming request.
 func TestMainCallbackURL(t *testing.T) {
 	tests := []struct {
-		name    string
-		baseURL string
-		reqHost string
-		tls     bool
-		want    string
+		name      string
+		baseURL   string
+		reqHost   string
+		tls       bool
+		xfProto   string
+		xfHost    string
+		forwarded string
+		want      string
 	}{
 		{
 			name:    "with base URL",
@@ -447,6 +450,25 @@ func TestMainCallbackURL(t *testing.T) {
 			reqHost: "proxy.example.com:8080",
 			want:    "http://proxy.example.com:8080/auth/github/callback",
 		},
+		{
+			name:        "no base URL, X-Forwarded-Proto = https",
+			reqHost:     "proxy.example.com",
+			xfProto:     "https",
+			want:        "https://proxy.example.com/auth/github/callback",
+		},
+		{
+			name:    "no base URL, X-Forwarded-Host overrides",
+			reqHost: "internal.local",
+			xfHost:  "ghp.example.com",
+			xfProto: "https",
+			want:    "https://ghp.example.com/auth/github/callback",
+		},
+		{
+			name:      "no base URL, RFC 7239 Forwarded header",
+			reqHost:   "internal.local",
+			forwarded: `for=10.0.0.1;proto=https;host=ghp.example.com`,
+			want:      "https://ghp.example.com/auth/github/callback",
+		},
 	}
 
 	for _, tt := range tests {
@@ -462,6 +484,15 @@ func TestMainCallbackURL(t *testing.T) {
 			}
 			if tt.tls {
 				req.TLS = &tls.ConnectionState{}
+			}
+			if tt.xfProto != "" {
+				req.Header.Set("X-Forwarded-Proto", tt.xfProto)
+			}
+			if tt.xfHost != "" {
+				req.Header.Set("X-Forwarded-Host", tt.xfHost)
+			}
+			if tt.forwarded != "" {
+				req.Header.Set("Forwarded", tt.forwarded)
 			}
 
 			got := h.mainCallbackURL(req)

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -297,7 +297,7 @@ func TestHandleGitHubCallback_JSONModeRedirectURI(t *testing.T) {
 
 	// Pre-load a state so state validation passes.
 	state := "teststate456"
-	h.states.Add(state, struct{}{})
+	h.states.Add(state, "")
 
 	req := httptest.NewRequest("GET",
 		"/auth/github/callback?code=testcode&state="+state+"&format=json", nil)

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -1,6 +1,7 @@
 package auth
 
 import (
+	"context"
 	"crypto/tls"
 	"encoding/json"
 	"io"
@@ -10,9 +11,28 @@ import (
 	"net/url"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/goodtune/ghp/internal/config"
+	"github.com/goodtune/ghp/internal/database"
 )
+
+// newTestStore returns an in-memory SQLite store with migrations applied.
+// Used by handler tests that need real session/oauth_state/device_auth
+// persistence (which is now everything that touches a Handler).
+func newTestStore(t *testing.T) database.Store {
+	t.Helper()
+	store, err := database.NewSQLiteStore(":memory:")
+	if err != nil {
+		t.Fatalf("create sqlite store: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	mig := database.NewMigrator(store, "sqlite")
+	if err := mig.Migrate(context.Background()); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	return store
+}
 
 func TestSecureCookies(t *testing.T) {
 	tests := []struct {
@@ -66,7 +86,7 @@ func TestSecureCookies(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			h := NewHandler(tt.cfg, nil, nil, slog.Default())
+			h := NewHandler(tt.cfg, newTestStore(t), nil, slog.Default())
 			got := h.secureCookies()
 			if got != tt.want {
 				t.Errorf("secureCookies() = %v, want %v", got, tt.want)
@@ -77,7 +97,7 @@ func TestSecureCookies(t *testing.T) {
 
 func TestHandleTestLogin_BodyTooLarge(t *testing.T) {
 	cfg := &config.Config{DevMode: true}
-	h := NewHandler(cfg, nil, nil, slog.Default())
+	h := NewHandler(cfg, newTestStore(t), nil, slog.Default())
 
 	// Body must be valid-looking JSON so the decoder reads past the 1 MB limit.
 	body := strings.NewReader(`{"username":"` + strings.Repeat("x", maxRequestBodySize) + `"}`)
@@ -92,7 +112,7 @@ func TestHandleTestLogin_BodyTooLarge(t *testing.T) {
 
 func TestHandleTestLogin_InvalidJSON(t *testing.T) {
 	cfg := &config.Config{DevMode: true}
-	h := NewHandler(cfg, nil, nil, slog.Default())
+	h := NewHandler(cfg, newTestStore(t), nil, slog.Default())
 
 	req := httptest.NewRequest("POST", "/auth/test-login", strings.NewReader("not valid json"))
 	w := httptest.NewRecorder()
@@ -161,7 +181,7 @@ func TestExchangeCode_URLEncoding(t *testing.T) {
 					ClientSecret: tt.clientSecret,
 				},
 			}
-			h := NewHandler(cfg, nil, nil, slog.Default())
+			h := NewHandler(cfg, newTestStore(t), nil, slog.Default())
 			h.githubBaseURL = ghServer.URL
 
 			_, _, _, err := h.exchangeCode(tt.code, tt.redirectURI)
@@ -208,7 +228,7 @@ func TestExchangeCode_HTTPError(t *testing.T) {
 	cfg := &config.Config{
 		GitHub: config.GitHubConfig{ClientID: "id", ClientSecret: "secret"},
 	}
-	h := NewHandler(cfg, nil, nil, slog.Default())
+	h := NewHandler(cfg, newTestStore(t), nil, slog.Default())
 	h.githubBaseURL = ghServer.URL
 
 	_, _, _, err := h.exchangeCode("bad-code", "")
@@ -232,7 +252,7 @@ func TestExchangeCode_EmptyAccessToken(t *testing.T) {
 	cfg := &config.Config{
 		GitHub: config.GitHubConfig{ClientID: "id", ClientSecret: "secret"},
 	}
-	h := NewHandler(cfg, nil, nil, slog.Default())
+	h := NewHandler(cfg, newTestStore(t), nil, slog.Default())
 	h.githubBaseURL = ghServer.URL
 
 	_, _, _, err := h.exchangeCode("code", "")
@@ -256,7 +276,7 @@ func TestExchangeCode_ErrorDescription(t *testing.T) {
 	cfg := &config.Config{
 		GitHub: config.GitHubConfig{ClientID: "id", ClientSecret: "secret"},
 	}
-	h := NewHandler(cfg, nil, nil, slog.Default())
+	h := NewHandler(cfg, newTestStore(t), nil, slog.Default())
 	h.githubBaseURL = ghServer.URL
 
 	_, _, _, err := h.exchangeCode("expired-code", "")
@@ -292,12 +312,18 @@ func TestHandleGitHubCallback_JSONModeRedirectURI(t *testing.T) {
 		GitHub: config.GitHubConfig{ClientID: "id", ClientSecret: "secret"},
 		Server: config.ServerConfig{BaseURL: "https://proxy.example.com"},
 	}
-	h := NewHandler(cfg, nil, nil, slog.Default())
+	h := NewHandler(cfg, newTestStore(t), nil, slog.Default())
 	h.githubBaseURL = ghServer.URL
 
 	// Pre-load a state so state validation passes.
 	state := "teststate456"
-	h.states.Add(state, "")
+	if err := h.store.CreateOAuthState(context.Background(), &database.OAuthState{
+		State:     state,
+		Kind:      database.OAuthStateKindLogin,
+		ExpiresAt: time.Now().Add(time.Hour),
+	}); err != nil {
+		t.Fatalf("seed state: %v", err)
+	}
 
 	req := httptest.NewRequest("GET",
 		"/auth/github/callback?code=testcode&state="+state+"&format=json", nil)
@@ -321,7 +347,7 @@ func TestHandleGitHubLogin_JSONResponse(t *testing.T) {
 		GitHub: config.GitHubConfig{ClientID: "test-client-id"},
 		Server: config.ServerConfig{BaseURL: "https://proxy.example.com"},
 	}
-	h := NewHandler(cfg, nil, nil, slog.Default())
+	h := NewHandler(cfg, newTestStore(t), nil, slog.Default())
 
 	req := httptest.NewRequest("GET", "/auth/github", nil)
 	req.Header.Set("Accept", "application/json")
@@ -365,7 +391,7 @@ func TestHandleGitHubLogin_IncludesRedirectURI(t *testing.T) {
 		GitHub: config.GitHubConfig{ClientID: "test-client-id"},
 		Server: config.ServerConfig{BaseURL: "https://proxy.example.com"},
 	}
-	h := NewHandler(cfg, nil, nil, slog.Default())
+	h := NewHandler(cfg, newTestStore(t), nil, slog.Default())
 
 	req := httptest.NewRequest("GET", "/auth/github", nil)
 	w := httptest.NewRecorder()
@@ -428,7 +454,7 @@ func TestMainCallbackURL(t *testing.T) {
 			cfg := &config.Config{
 				Server: config.ServerConfig{BaseURL: tt.baseURL},
 			}
-			h := NewHandler(cfg, nil, nil, slog.Default())
+			h := NewHandler(cfg, newTestStore(t), nil, slog.Default())
 
 			req := httptest.NewRequest("GET", "/", nil)
 			if tt.reqHost != "" {

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -420,14 +420,15 @@ func TestHandleGitHubLogin_IncludesRedirectURI(t *testing.T) {
 // callback URL from the configured BaseURL or from the incoming request.
 func TestMainCallbackURL(t *testing.T) {
 	tests := []struct {
-		name      string
-		baseURL   string
-		reqHost   string
-		tls       bool
-		xfProto   string
-		xfHost    string
-		forwarded string
-		want      string
+		name       string
+		baseURL    string
+		trustProxy bool
+		reqHost    string
+		tls        bool
+		xfProto    string
+		xfHost     string
+		forwarded  string
+		want       string
 	}{
 		{
 			name:    "with base URL",
@@ -451,30 +452,42 @@ func TestMainCallbackURL(t *testing.T) {
 			want:    "http://proxy.example.com:8080/auth/github/callback",
 		},
 		{
-			name:        "no base URL, X-Forwarded-Proto = https",
-			reqHost:     "proxy.example.com",
-			xfProto:     "https",
-			want:        "https://proxy.example.com/auth/github/callback",
-		},
-		{
-			name:    "no base URL, X-Forwarded-Host overrides",
+			// Without trust_proxy_headers an internet-reachable instance must
+			// not honour client-spoofable headers; r.Host wins.
+			name:    "no base URL, X-Forwarded-Proto ignored when trust_proxy_headers=false",
 			reqHost: "internal.local",
-			xfHost:  "ghp.example.com",
 			xfProto: "https",
-			want:    "https://ghp.example.com/auth/github/callback",
+			xfHost:  "attacker.example.com",
+			want:    "http://internal.local/auth/github/callback",
 		},
 		{
-			name:      "no base URL, RFC 7239 Forwarded header",
-			reqHost:   "internal.local",
-			forwarded: `for=10.0.0.1;proto=https;host=ghp.example.com`,
-			want:      "https://ghp.example.com/auth/github/callback",
+			name:       "no base URL, X-Forwarded-Proto trusted when trust_proxy_headers=true",
+			reqHost:    "proxy.example.com",
+			trustProxy: true,
+			xfProto:    "https",
+			want:       "https://proxy.example.com/auth/github/callback",
+		},
+		{
+			name:       "no base URL, X-Forwarded-Host trusted when trust_proxy_headers=true",
+			reqHost:    "internal.local",
+			trustProxy: true,
+			xfHost:     "ghp.example.com",
+			xfProto:    "https",
+			want:       "https://ghp.example.com/auth/github/callback",
+		},
+		{
+			name:       "no base URL, RFC 7239 Forwarded trusted when trust_proxy_headers=true",
+			reqHost:    "internal.local",
+			trustProxy: true,
+			forwarded:  `for=10.0.0.1;proto=https;host=ghp.example.com`,
+			want:       "https://ghp.example.com/auth/github/callback",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cfg := &config.Config{
-				Server: config.ServerConfig{BaseURL: tt.baseURL},
+				Server: config.ServerConfig{BaseURL: tt.baseURL, TrustProxyHeaders: tt.trustProxy},
 			}
 			h := NewHandler(cfg, newTestStore(t), nil, slog.Default())
 

--- a/internal/auth/broker.go
+++ b/internal/auth/broker.go
@@ -4,6 +4,7 @@ import (
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net"
 	"net/http"
@@ -12,13 +13,9 @@ import (
 	"time"
 
 	"github.com/golang-jwt/jwt/v5"
-)
 
-// brokerState holds the pending state for an in-progress OAuth broker flow.
-type brokerState struct {
-	RedirectURI     string
-	DownstreamState string
-}
+	"github.com/goodtune/ghp/internal/database"
+)
 
 // BrokerClaims are the JWT claims minted by the OAuth broker.
 type BrokerClaims struct {
@@ -44,10 +41,17 @@ func (h *Handler) handleBrokerAuthorize(w http.ResponseWriter, r *http.Request) 
 	downstreamState := r.URL.Query().Get("state")
 
 	state := generateState()
-	h.brokerStates.Add(state, &brokerState{
-		RedirectURI:     redirectURI,
-		DownstreamState: downstreamState,
-	})
+	if err := h.store.CreateOAuthState(r.Context(), &database.OAuthState{
+		State:                 state,
+		Kind:                  database.OAuthStateKindBroker,
+		BrokerRedirectURI:     redirectURI,
+		BrokerDownstreamState: downstreamState,
+		ExpiresAt:             time.Now().Add(brokerStateTTL).UTC(),
+	}); err != nil {
+		h.logger.Error("failed to persist broker oauth state", "error", err)
+		http.Error(w, "Internal error", http.StatusInternalServerError)
+		return
+	}
 
 	callbackURL := h.brokerCallbackURL(r)
 	params := url.Values{}
@@ -75,11 +79,11 @@ func (h *Handler) handleBrokerCallback(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	bs, ok := h.brokerStates.Get(state)
-	if ok {
-		h.brokerStates.Remove(state)
-	}
-	if !ok {
+	bs, err := h.store.ConsumeOAuthState(r.Context(), state, database.OAuthStateKindBroker)
+	if err != nil {
+		if !errors.Is(err, database.ErrNotFound) {
+			h.logger.Error("broker oauth state consume failed", "error", err)
+		}
 		http.Error(w, "Invalid or expired state", http.StatusBadRequest)
 		return
 	}
@@ -87,9 +91,9 @@ func (h *Handler) handleBrokerCallback(w http.ResponseWriter, r *http.Request) {
 	// Exchange code for access token, including the redirect_uri that was
 	// sent in the authorize request (GitHub requires it to match).
 	callbackURL := h.brokerCallbackURL(r)
-	accessToken, _, _, err := h.exchangeCode(code, callbackURL)
-	if err != nil {
-		h.logger.Error("broker: OAuth code exchange failed", "error", err)
+	accessToken, _, _, exErr := h.exchangeCode(code, callbackURL)
+	if exErr != nil {
+		h.logger.Error("broker: OAuth code exchange failed", "error", exErr)
 		http.Error(w, "Authentication failed", http.StatusInternalServerError)
 		return
 	}
@@ -110,7 +114,7 @@ func (h *Handler) handleBrokerCallback(w http.ResponseWriter, r *http.Request) {
 		RegisteredClaims: jwt.RegisteredClaims{
 			Issuer:    h.brokerIssuer(),
 			Subject:   user.Login,
-			Audience:  jwt.ClaimStrings{bs.RedirectURI},
+			Audience:  jwt.ClaimStrings{bs.BrokerRedirectURI},
 			ExpiresAt: jwt.NewNumericDate(now.Add(60 * time.Second)),
 			IssuedAt:  jwt.NewNumericDate(now),
 		},
@@ -125,19 +129,19 @@ func (h *Handler) handleBrokerCallback(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Redirect to the downstream service with the signed token.
-	redirectURL, err := url.Parse(bs.RedirectURI)
+	redirectURL, err := url.Parse(bs.BrokerRedirectURI)
 	if err != nil {
 		http.Error(w, "Invalid redirect_uri", http.StatusInternalServerError)
 		return
 	}
 	q := redirectURL.Query()
 	q.Set("token", signed)
-	if bs.DownstreamState != "" {
-		q.Set("state", bs.DownstreamState)
+	if bs.BrokerDownstreamState != "" {
+		q.Set("state", bs.BrokerDownstreamState)
 	}
 	redirectURL.RawQuery = q.Encode()
 
-	h.logger.Info("broker_auth_complete", "user", user.Login, "redirect_uri", bs.RedirectURI)
+	h.logger.Info("broker_auth_complete", "user", user.Login, "redirect_uri", bs.BrokerRedirectURI)
 	http.Redirect(w, r, redirectURL.String(), http.StatusTemporaryRedirect)
 }
 

--- a/internal/auth/broker_test.go
+++ b/internal/auth/broker_test.go
@@ -218,8 +218,10 @@ func TestBrokerAuthorize(t *testing.T) {
 		t.Fatal("expected state parameter")
 	}
 
-	// Verify broker state was stored. Use the underlying store directly
-	// to peek without consuming.
+	// Verify broker state was stored by reading it back. Note that
+	// ConsumeOAuthState atomically reads-and-deletes — the test does not
+	// need to inspect the row again afterwards, so this is fine; if a true
+	// non-destructive peek is ever needed, add a separate Get method.
 	bs, err := h.store.ConsumeOAuthState(context.Background(), state, database.OAuthStateKindBroker)
 	if err != nil {
 		t.Fatalf("broker state not stored: %v", err)

--- a/internal/auth/broker_test.go
+++ b/internal/auth/broker_test.go
@@ -1,6 +1,7 @@
 package auth
 
 import (
+	"context"
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/tls"
@@ -16,7 +17,9 @@ import (
 	"time"
 
 	"github.com/golang-jwt/jwt/v5"
+
 	"github.com/goodtune/ghp/internal/config"
+	"github.com/goodtune/ghp/internal/database"
 )
 func TestValidateRedirectURI(t *testing.T) {
 	cfg := &config.Config{
@@ -27,7 +30,7 @@ func TestValidateRedirectURI(t *testing.T) {
 			},
 		},
 	}
-	h := NewHandler(cfg, nil, nil, slog.Default())
+	h := NewHandler(cfg, newTestStore(t), nil, slog.Default())
 
 	tests := []struct {
 		name string
@@ -65,7 +68,7 @@ func TestValidateRedirectURI_PathScopedWildcard(t *testing.T) {
 			},
 		},
 	}
-	h := NewHandler(cfg, nil, nil, slog.Default())
+	h := NewHandler(cfg, newTestStore(t), nil, slog.Default())
 
 	tests := []struct {
 		name string
@@ -98,7 +101,7 @@ func TestValidateRedirectURI_DevMode(t *testing.T) {
 			},
 		},
 	}
-	h := NewHandler(cfg, nil, nil, slog.Default())
+	h := NewHandler(cfg, newTestStore(t), nil, slog.Default())
 
 	if !h.validateRedirectURI("http://localhost:3000/auth/callback") {
 		t.Error("dev mode should allow HTTP localhost")
@@ -185,7 +188,7 @@ func TestBrokerAuthorize(t *testing.T) {
 			AllowedRedirects: []string{"https://app.example.com/auth/callback"},
 		},
 	}
-	h := NewHandler(cfg, nil, nil, slog.Default())
+	h := NewHandler(cfg, newTestStore(t), nil, slog.Default())
 
 	req := httptest.NewRequest("GET",
 		"/auth/authorize?redirect_uri=https://app.example.com/auth/callback&state=csrf123", nil)
@@ -215,22 +218,23 @@ func TestBrokerAuthorize(t *testing.T) {
 		t.Fatal("expected state parameter")
 	}
 
-	// Verify broker state was stored.
-	bs, ok := h.brokerStates.Get(state)
-	if !ok {
-		t.Fatal("broker state not stored")
+	// Verify broker state was stored. Use the underlying store directly
+	// to peek without consuming.
+	bs, err := h.store.ConsumeOAuthState(context.Background(), state, database.OAuthStateKindBroker)
+	if err != nil {
+		t.Fatalf("broker state not stored: %v", err)
 	}
-	if bs.RedirectURI != "https://app.example.com/auth/callback" {
-		t.Errorf("wrong redirect_uri in state: %s", bs.RedirectURI)
+	if bs.BrokerRedirectURI != "https://app.example.com/auth/callback" {
+		t.Errorf("wrong redirect_uri in state: %s", bs.BrokerRedirectURI)
 	}
-	if bs.DownstreamState != "csrf123" {
-		t.Errorf("wrong downstream state: %s", bs.DownstreamState)
+	if bs.BrokerDownstreamState != "csrf123" {
+		t.Errorf("wrong downstream state: %s", bs.BrokerDownstreamState)
 	}
 }
 
 func TestBrokerAuthorize_MissingRedirectURI(t *testing.T) {
 	cfg := &config.Config{}
-	h := NewHandler(cfg, nil, nil, slog.Default())
+	h := NewHandler(cfg, newTestStore(t), nil, slog.Default())
 
 	req := httptest.NewRequest("GET", "/auth/authorize", nil)
 	w := httptest.NewRecorder()
@@ -247,7 +251,7 @@ func TestBrokerAuthorize_DisallowedRedirectURI(t *testing.T) {
 			AllowedRedirects: []string{"https://allowed.example.com/cb"},
 		},
 	}
-	h := NewHandler(cfg, nil, nil, slog.Default())
+	h := NewHandler(cfg, newTestStore(t), nil, slog.Default())
 
 	req := httptest.NewRequest("GET",
 		"/auth/authorize?redirect_uri=https://evil.com/cb", nil)
@@ -299,16 +303,21 @@ func TestBrokerCallback(t *testing.T) {
 			AllowedRedirects: []string{"https://app.example.com/auth/callback"},
 		},
 	}
-	h := NewHandler(cfg, nil, nil, slog.Default())
+	h := NewHandler(cfg, newTestStore(t), nil, slog.Default())
 	h.githubBaseURL = ghServer.URL
 	h.githubAPIBaseURL = ghServer.URL
 
 	// Pre-populate broker state as if /auth/authorize had run.
 	stateToken := "test-state-token"
-	h.brokerStates.Add(stateToken, &brokerState{
-		RedirectURI:     "https://app.example.com/auth/callback",
-		DownstreamState: "csrf123",
-	})
+	if err := h.store.CreateOAuthState(context.Background(), &database.OAuthState{
+		State:                 stateToken,
+		Kind:                  database.OAuthStateKindBroker,
+		BrokerRedirectURI:     "https://app.example.com/auth/callback",
+		BrokerDownstreamState: "csrf123",
+		ExpiresAt:             time.Now().Add(time.Hour),
+	}); err != nil {
+		t.Fatalf("seed broker state: %v", err)
+	}
 
 	req := httptest.NewRequest("GET",
 		"/auth/callback?code=test-code&state="+stateToken, nil)
@@ -388,7 +397,7 @@ func TestBrokerCallback_NoState(t *testing.T) {
 	cfg := &config.Config{
 		Auth: config.AuthConfig{JWTPrivateKey: privPEM},
 	}
-	h := NewHandler(cfg, nil, nil, slog.Default())
+	h := NewHandler(cfg, newTestStore(t), nil, slog.Default())
 
 	// Without downstream state, the redirect should not include a state param.
 	ghServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -414,10 +423,15 @@ func TestBrokerCallback_NoState(t *testing.T) {
 	h.githubAPIBaseURL = ghServer.URL
 
 	stateToken := "no-downstream-state"
-	h.brokerStates.Add(stateToken, &brokerState{
-		RedirectURI:     "https://app.example.com/cb",
-		DownstreamState: "", // no downstream state
-	})
+	if err := h.store.CreateOAuthState(context.Background(), &database.OAuthState{
+		State:                 stateToken,
+		Kind:                  database.OAuthStateKindBroker,
+		BrokerRedirectURI:     "https://app.example.com/cb",
+		BrokerDownstreamState: "", // no downstream state
+		ExpiresAt:             time.Now().Add(time.Hour),
+	}); err != nil {
+		t.Fatalf("seed broker state: %v", err)
+	}
 
 	req := httptest.NewRequest("GET",
 		"/auth/callback?code=test-code&state="+stateToken, nil)
@@ -439,7 +453,7 @@ func TestBrokerCallback_NoState(t *testing.T) {
 
 func TestBrokerCallback_InvalidState(t *testing.T) {
 	cfg := &config.Config{}
-	h := NewHandler(cfg, nil, nil, slog.Default())
+	h := NewHandler(cfg, newTestStore(t), nil, slog.Default())
 
 	req := httptest.NewRequest("GET",
 		"/auth/callback?code=test-code&state=nonexistent", nil)
@@ -453,7 +467,7 @@ func TestBrokerCallback_InvalidState(t *testing.T) {
 
 func TestBrokerCallback_MissingCode(t *testing.T) {
 	cfg := &config.Config{}
-	h := NewHandler(cfg, nil, nil, slog.Default())
+	h := NewHandler(cfg, newTestStore(t), nil, slog.Default())
 
 	req := httptest.NewRequest("GET", "/auth/callback?state=test-state", nil)
 	w := httptest.NewRecorder()
@@ -466,7 +480,7 @@ func TestBrokerCallback_MissingCode(t *testing.T) {
 
 func TestBrokerCallback_MissingState(t *testing.T) {
 	cfg := &config.Config{}
-	h := NewHandler(cfg, nil, nil, slog.Default())
+	h := NewHandler(cfg, newTestStore(t), nil, slog.Default())
 
 	req := httptest.NewRequest("GET", "/auth/callback?code=test-code", nil)
 	w := httptest.NewRecorder()
@@ -513,7 +527,7 @@ func TestBrokerCallbackURL(t *testing.T) {
 			cfg := &config.Config{
 				Server: config.ServerConfig{BaseURL: tt.baseURL},
 			}
-			h := NewHandler(cfg, nil, nil, slog.Default())
+			h := NewHandler(cfg, newTestStore(t), nil, slog.Default())
 
 			req := httptest.NewRequest("GET", "/", nil)
 			if tt.reqHost != "" {
@@ -556,7 +570,7 @@ func TestHandleJWKS(t *testing.T) {
 			AllowedRedirects: []string{"https://app.example.com/auth/callback"},
 		},
 	}
-	h := NewHandler(cfg, nil, nil, slog.Default())
+	h := NewHandler(cfg, newTestStore(t), nil, slog.Default())
 
 	req := httptest.NewRequest("GET", "/.well-known/jwks.json", nil)
 	w := httptest.NewRecorder()
@@ -602,7 +616,7 @@ func TestHandleJWKS(t *testing.T) {
 
 func TestHandleJWKS_NoKey(t *testing.T) {
 	cfg := &config.Config{}
-	h := NewHandler(cfg, nil, nil, slog.Default())
+	h := NewHandler(cfg, newTestStore(t), nil, slog.Default())
 
 	req := httptest.NewRequest("GET", "/.well-known/jwks.json", nil)
 	w := httptest.NewRecorder()

--- a/internal/auth/device.go
+++ b/internal/auth/device.go
@@ -74,10 +74,13 @@ const (
 )
 
 // registerDeviceRoutes adds the CLI device-authorization endpoints to the mux.
-// Called from RegisterRoutes.
+// Called from RegisterRoutes. The two anonymous endpoints (/cli/auth/device
+// for flow initiation and /cli/auth/device/token for polling) are wrapped in
+// per-IP rate limiters so a hostile client cannot churn the database with
+// device-auth rows or hammer the polling endpoint with non-existent codes.
 func (h *Handler) registerDeviceRoutes(mux *http.ServeMux) {
-	mux.HandleFunc("POST /cli/auth/device", h.handleDeviceStart)
-	mux.HandleFunc("POST /cli/auth/device/token", h.handleDevicePoll)
+	mux.Handle("POST /cli/auth/device", h.deviceStartLimiter.Middleware(http.HandlerFunc(h.handleDeviceStart)))
+	mux.Handle("POST /cli/auth/device/token", h.devicePollLimiter.Middleware(http.HandlerFunc(h.handleDevicePoll)))
 	mux.HandleFunc("GET /cli/auth", h.handleDeviceVerify)
 	mux.HandleFunc("POST /cli/auth/decision", h.handleDeviceDecision)
 }
@@ -88,18 +91,24 @@ func (h *Handler) registerDeviceRoutes(mux *http.ServeMux) {
 //
 // Response is RFC-8628-shaped JSON.
 func (h *Handler) handleDeviceStart(w http.ResponseWriter, r *http.Request) {
-	deviceCode, err := generateDeviceCode()
-	if err != nil {
-		h.logger.Error("failed to generate device_code", "error", err)
-		writeDeviceError(w, "server_error", http.StatusInternalServerError)
-		return
-	}
-
 	// user_code collisions are extremely unlikely (≈40 bits of entropy with
-	// at most ~1k records active in a 10-minute window) but possible. Retry
-	// a small number of times if Create reports a unique-constraint error.
-	var userCode string
-	for attempt := 0; attempt < 5; attempt++ {
+	// at most ~1k records active in a 10-minute window) but possible. We
+	// regenerate both codes on each attempt: a duplicate user_code is the
+	// expected retriable failure, but if some other transient DB issue
+	// happens to be tied to a particular row (e.g. a primary-key collision
+	// on device_code, however vanishingly improbable), keeping the same
+	// device_code across attempts would just spin uselessly. Fresh codes
+	// each iteration also remove any need to introspect driver-specific
+	// constraint error messages.
+	var deviceCode, userCode string
+	const maxAttempts = 5
+	for attempt := 0; attempt < maxAttempts; attempt++ {
+		dc, err := generateDeviceCode()
+		if err != nil {
+			h.logger.Error("failed to generate device_code", "error", err)
+			writeDeviceError(w, "server_error", http.StatusInternalServerError)
+			return
+		}
 		uc, err := generateUserCode()
 		if err != nil {
 			h.logger.Error("failed to generate user_code", "error", err)
@@ -107,21 +116,19 @@ func (h *Handler) handleDeviceStart(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		if err := h.store.CreateDeviceAuth(r.Context(), &database.DeviceAuth{
-			DeviceCode: deviceCode,
+			DeviceCode: dc,
 			UserCode:   uc,
 			Status:     database.DeviceAuthStatusPending,
 			ExpiresAt:  time.Now().Add(deviceRequestTTL).UTC(),
 		}); err != nil {
-			// A duplicate user_code is the only retriable error we expect;
-			// retry on any error here is cheap and safer than parsing
-			// driver-specific constraint messages.
-			if attempt == 4 {
-				h.logger.Error("failed to persist device_auth", "error", err)
+			if attempt == maxAttempts-1 {
+				h.logger.Error("failed to persist device_auth", "error", err, "attempts", maxAttempts)
 				writeDeviceError(w, "server_error", http.StatusInternalServerError)
 				return
 			}
 			continue
 		}
+		deviceCode = dc
 		userCode = uc
 		break
 	}
@@ -286,7 +293,16 @@ func (h *Handler) handleDeviceDecision(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Bound the body size before ParseForm reads it. The form has two
+	// short fields (user_code, action); 1 MB is the same ceiling we apply
+	// elsewhere and is far more than the legitimate flow needs.
+	r.Body = http.MaxBytesReader(w, r.Body, maxRequestBodySize)
 	if err := r.ParseForm(); err != nil {
+		var maxErr *http.MaxBytesError
+		if errors.As(err, &maxErr) {
+			http.Error(w, "Request body too large", http.StatusRequestEntityTooLarge)
+			return
+		}
 		http.Error(w, "Invalid form", http.StatusBadRequest)
 		return
 	}

--- a/internal/auth/device.go
+++ b/internal/auth/device.go
@@ -35,7 +35,6 @@ package auth
 // the CLI bootstrap — the CLI never sees a github.com URL.
 
 import (
-	"context"
 	"crypto/rand"
 	"encoding/hex"
 	"encoding/json"
@@ -633,7 +632,3 @@ func renderDeviceVerify(w http.ResponseWriter, logger interface{ Error(msg strin
 		http.Error(w, "Internal error", http.StatusInternalServerError)
 	}
 }
-
-// Compile-time check that handlers don't accidentally rely on background
-// context for store operations.
-var _ context.Context = context.Background()

--- a/internal/auth/device.go
+++ b/internal/auth/device.go
@@ -461,34 +461,36 @@ func normaliseUserCode(s string) string {
 }
 
 // absoluteURL constructs an absolute URL for path on this server, preferring
-// the configured server.base_url and falling back to a scheme/host derived
-// from the incoming request (with X-Forwarded-* headers honoured for
-// reverse-proxy deployments).
+// the configured server.base_url. When base_url is unset it falls back to a
+// scheme/host derived from the incoming request, optionally honouring
+// reverse-proxy headers when server.trust_proxy_headers is true.
 func (h *Handler) absoluteURL(r *http.Request, path string) string {
 	if h.cfg.Server.BaseURL != "" {
 		return strings.TrimRight(h.cfg.Server.BaseURL, "/") + path
 	}
-	return fmt.Sprintf("%s://%s%s", requestScheme(r), requestHost(r), path)
+	return fmt.Sprintf("%s://%s%s", requestScheme(r, h.cfg.Server.TrustProxyHeaders), requestHost(r, h.cfg.Server.TrustProxyHeaders), path)
 }
 
-// requestScheme reports the externally-visible scheme for r. It checks the
-// standardised Forwarded header first, then X-Forwarded-Proto (for the
-// common case of an L7 proxy), and finally falls back to whether the
-// connection itself is TLS. This matters because in a typical deployment
-// TLS terminates at the proxy and ghp receives plain HTTP — without the
-// header check we'd hand back http:// verification URLs that don't match
-// the user's externally reachable address.
-func requestScheme(r *http.Request) string {
-	if v := forwardedField(r.Header.Get("Forwarded"), "proto"); v != "" {
-		return v
-	}
-	if v := r.Header.Get("X-Forwarded-Proto"); v != "" {
-		// Multiple proxies may chain values ("https, http"); take the
-		// first, which represents the originating client edge.
-		if i := strings.Index(v, ","); i >= 0 {
-			v = v[:i]
+// requestScheme reports the externally-visible scheme for r. When trustProxy
+// is true it consults the standardised Forwarded header first, then
+// X-Forwarded-Proto, before falling back to whether the connection itself is
+// TLS — this matters when TLS terminates at a reverse proxy and ghp
+// receives plain HTTP. When trustProxy is false the headers are ignored, so
+// an internet-reachable instance cannot be tricked into emitting attacker-
+// controlled scheme values via header spoofing.
+func requestScheme(r *http.Request, trustProxy bool) string {
+	if trustProxy {
+		if v := forwardedField(r.Header.Get("Forwarded"), "proto"); v != "" {
+			return v
 		}
-		return strings.TrimSpace(v)
+		if v := r.Header.Get("X-Forwarded-Proto"); v != "" {
+			// Multiple proxies may chain values ("https, http"); take the
+			// first, which represents the originating client edge.
+			if i := strings.Index(v, ","); i >= 0 {
+				v = v[:i]
+			}
+			return strings.TrimSpace(v)
+		}
 	}
 	if r.TLS != nil {
 		return "https"
@@ -496,17 +498,21 @@ func requestScheme(r *http.Request) string {
 	return "http"
 }
 
-// requestHost reports the externally-visible host for r, honouring
-// X-Forwarded-Host before the request's own Host header.
-func requestHost(r *http.Request) string {
-	if v := forwardedField(r.Header.Get("Forwarded"), "host"); v != "" {
-		return v
-	}
-	if v := r.Header.Get("X-Forwarded-Host"); v != "" {
-		if i := strings.Index(v, ","); i >= 0 {
-			v = v[:i]
+// requestHost reports the externally-visible host for r. Behaves the same as
+// requestScheme: forwarded host headers are only honoured when trustProxy is
+// true. Otherwise we use r.Host, which Go has already validated for HTTP
+// host-header injection.
+func requestHost(r *http.Request, trustProxy bool) string {
+	if trustProxy {
+		if v := forwardedField(r.Header.Get("Forwarded"), "host"); v != "" {
+			return v
 		}
-		return strings.TrimSpace(v)
+		if v := r.Header.Get("X-Forwarded-Host"); v != "" {
+			if i := strings.Index(v, ","); i >= 0 {
+				v = v[:i]
+			}
+			return strings.TrimSpace(v)
+		}
 	}
 	return r.Host
 }

--- a/internal/auth/device.go
+++ b/internal/auth/device.go
@@ -1,0 +1,568 @@
+package auth
+
+// CLI device-authorization flow.
+//
+// The CLI authenticates against ghp itself, not GitHub. The flow mirrors RFC
+// 8628 (OAuth 2.0 Device Authorization Grant) but the authorizing party is
+// the ghp server, not GitHub:
+//
+//	  CLI                                 ghp server                       user (browser)
+//	   |---- POST /cli/auth/device ------->|                                    |
+//	   |<---- {device_code, user_code,     |                                    |
+//	          verification_uri,            |                                    |
+//	          verification_uri_complete} --|                                    |
+//	   |                                   |                                    |
+//	   |     (user opens verification_uri_complete in browser)                  |
+//	   |                                   |<--- GET /cli/auth?user_code=X ---- |
+//	   |                                   |                                    |
+//	   |                                   |   (if not signed in to ghp,        |
+//	   |                                   |    user goes through               |
+//	   |                                   |    /auth/github first, then        |
+//	   |                                   |    returns here)                   |
+//	   |                                   |                                    |
+//	   |                                   |<-- POST /cli/auth/decision ------- |
+//	   |                                   |    (Approve or Deny)               |
+//	   |                                   |---- HTML "approved" page --------->|
+//	   |                                   |                                    |
+//	   |- POST /cli/auth/device/token ---->|                                    |
+//	   |  (polling every interval seconds) |                                    |
+//	   |<--- {session_token, username} ----|                                    |
+//
+// Design notes:
+//   - Device records are kept in-memory (expirable.LRU), since they are
+//     short-lived and small in number; persisting them in the database would
+//     require migrations across all three backends (Postgres, SQLite, Vault)
+//     for no real benefit.
+//   - GitHub OAuth is still the identity provider for the ghp web UI, but it
+//     is no longer involved in the CLI bootstrap. The CLI never sees a
+//     github.com URL.
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"html/template"
+	"math/big"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/goodtune/ghp/internal/metrics"
+)
+
+const (
+	// deviceRequestTTL is how long a device-authorization request remains
+	// valid. After this window the user_code becomes invalid and the CLI
+	// poll receives "expired_token".
+	deviceRequestTTL = 10 * time.Minute
+	// maxDeviceRequests caps the number of in-flight device requests held
+	// in memory. The LRU evicts oldest entries past this size.
+	maxDeviceRequests = 1_000
+	// devicePollMinInterval is the minimum permitted interval between
+	// polls for a single device_code. Polling faster receives "slow_down".
+	devicePollMinInterval = 2 * time.Second
+	// deviceUserCodeAlphabet is the set of characters used in user_codes.
+	// Restricted to a 32-character set that avoids visually-confusable
+	// glyphs (no 0/O, 1/I/L) so users can read and re-type codes reliably
+	// from a small printout.
+	deviceUserCodeAlphabet = "ABCDEFGHJKMNPQRSTUVWXYZ23456789"
+	// deviceUserCodeBlockSize is the length of each block in the user code.
+	deviceUserCodeBlockSize = 4
+	// deviceUserCodeBlocks is the number of dash-separated blocks. Total
+	// entropy is blocks * blockSize * log2(alphabet) ≈ 8 * log2(31) ≈ 39.6
+	// bits, sufficient for the 10-minute window.
+	deviceUserCodeBlocks = 2
+)
+
+// DeviceAuthStatus is the lifecycle state of a device-authorization request.
+type DeviceAuthStatus string
+
+const (
+	deviceStatusPending  DeviceAuthStatus = "pending"
+	deviceStatusApproved DeviceAuthStatus = "approved"
+	deviceStatusDenied   DeviceAuthStatus = "denied"
+)
+
+// deviceAuthRequest is the in-memory record for a CLI device-authorization
+// request. The device_code is the long-lived secret the CLI polls with;
+// the user_code is the short, human-readable code displayed in both the
+// CLI output and the browser approval page.
+type deviceAuthRequest struct {
+	mu sync.Mutex
+
+	DeviceCode string
+	UserCode   string
+
+	Status DeviceAuthStatus
+
+	// SessionToken and Username are populated when Status transitions to
+	// approved. They are returned to the CLI on its next poll (after which
+	// the device record is removed from the LRU to prevent token re-use).
+	SessionToken string
+	Username     string
+
+	// LastPolledAt is updated by the polling endpoint to enforce the
+	// minimum poll interval.
+	LastPolledAt time.Time
+
+	CreatedAt time.Time
+}
+
+// RegisterDeviceRoutes adds the CLI device-authorization endpoints to the mux.
+// Called from RegisterRoutes.
+func (h *Handler) registerDeviceRoutes(mux *http.ServeMux) {
+	mux.HandleFunc("POST /cli/auth/device", h.handleDeviceStart)
+	mux.HandleFunc("POST /cli/auth/device/token", h.handleDevicePoll)
+	mux.HandleFunc("GET /cli/auth", h.handleDeviceVerify)
+	mux.HandleFunc("POST /cli/auth/decision", h.handleDeviceDecision)
+}
+
+// handleDeviceStart creates a new device-authorization request. The CLI
+// hits this endpoint anonymously; no user identity is associated with the
+// record until the verification page is approved.
+//
+// Response is RFC-8628-shaped JSON:
+//
+//	{
+//	  "device_code": "...",
+//	  "user_code": "ABCD-EFGH",
+//	  "verification_uri": "https://server/cli/auth",
+//	  "verification_uri_complete": "https://server/cli/auth?user_code=ABCD-EFGH",
+//	  "expires_in": 600,
+//	  "interval": 5
+//	}
+func (h *Handler) handleDeviceStart(w http.ResponseWriter, r *http.Request) {
+	deviceCode, err := generateDeviceCode()
+	if err != nil {
+		h.logger.Error("failed to generate device_code", "error", err)
+		http.Error(w, `{"error":"server_error"}`, http.StatusInternalServerError)
+		return
+	}
+	userCode, err := generateUserCode()
+	if err != nil {
+		h.logger.Error("failed to generate user_code", "error", err)
+		http.Error(w, `{"error":"server_error"}`, http.StatusInternalServerError)
+		return
+	}
+
+	req := &deviceAuthRequest{
+		DeviceCode: deviceCode,
+		UserCode:   userCode,
+		Status:     deviceStatusPending,
+		CreatedAt:  time.Now(),
+	}
+	h.deviceRequests.Add(deviceCode, req)
+	h.deviceUserCodes.Add(userCode, deviceCode)
+
+	verifyURI := h.absoluteURL(r, "/cli/auth")
+	verifyComplete := verifyURI + "?user_code=" + url.QueryEscape(userCode)
+
+	metrics.CLIDeviceStartedTotal.Inc()
+
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Cache-Control", "no-store")
+	_ = json.NewEncoder(w).Encode(map[string]interface{}{
+		"device_code":               deviceCode,
+		"user_code":                 userCode,
+		"verification_uri":          verifyURI,
+		"verification_uri_complete": verifyComplete,
+		"expires_in":                int(deviceRequestTTL.Seconds()),
+		"interval":                  int(devicePollMinInterval.Seconds()),
+	})
+}
+
+// handleDevicePoll returns the issued session token once the device request
+// has been approved by an authenticated browser session. Until then it
+// returns RFC-8628-style error codes.
+//
+// Request body: {"device_code": "..."}
+//
+// Responses:
+//   - 200 {"session_token": "ghpr_...", "username": "..."}                approved
+//   - 400 {"error": "authorization_pending"}                              still waiting
+//   - 400 {"error": "slow_down"}                                          polled too fast
+//   - 400 {"error": "expired_token"}                                      record TTL'd
+//   - 400 {"error": "access_denied"}                                      user denied
+//   - 400 {"error": "invalid_grant"}                                      device_code unknown
+func (h *Handler) handleDevicePoll(w http.ResponseWriter, r *http.Request) {
+	r.Body = http.MaxBytesReader(w, r.Body, maxRequestBodySize)
+
+	var body struct {
+		DeviceCode string `json:"device_code"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		var maxErr *http.MaxBytesError
+		if errors.As(err, &maxErr) {
+			http.Error(w, `{"error":"invalid_request"}`, http.StatusRequestEntityTooLarge)
+			return
+		}
+		writeDeviceError(w, "invalid_request", http.StatusBadRequest)
+		return
+	}
+	if body.DeviceCode == "" {
+		writeDeviceError(w, "invalid_request", http.StatusBadRequest)
+		return
+	}
+
+	req, ok := h.deviceRequests.Get(body.DeviceCode)
+	if !ok {
+		// Either the device_code was never issued, or it has expired and
+		// been evicted. RFC 8628 distinguishes these but we do not — both
+		// outcomes mean the CLI must restart from the beginning.
+		writeDeviceError(w, "expired_token", http.StatusBadRequest)
+		return
+	}
+
+	req.mu.Lock()
+	defer req.mu.Unlock()
+
+	now := time.Now()
+	if !req.LastPolledAt.IsZero() && now.Sub(req.LastPolledAt) < devicePollMinInterval {
+		writeDeviceError(w, "slow_down", http.StatusBadRequest)
+		return
+	}
+	req.LastPolledAt = now
+
+	switch req.Status {
+	case deviceStatusPending:
+		writeDeviceError(w, "authorization_pending", http.StatusBadRequest)
+		return
+	case deviceStatusDenied:
+		// Remove the record so a denied code can't be re-polled.
+		h.deviceRequests.Remove(req.DeviceCode)
+		h.deviceUserCodes.Remove(req.UserCode)
+		metrics.CLIDeviceCompletedTotal.WithLabelValues("denied").Inc()
+		writeDeviceError(w, "access_denied", http.StatusBadRequest)
+		return
+	case deviceStatusApproved:
+		// Hand the token to the CLI exactly once and discard the record.
+		token := req.SessionToken
+		username := req.Username
+		h.deviceRequests.Remove(req.DeviceCode)
+		h.deviceUserCodes.Remove(req.UserCode)
+		metrics.CLIDeviceCompletedTotal.WithLabelValues("approved").Inc()
+
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Cache-Control", "no-store")
+		_ = json.NewEncoder(w).Encode(map[string]string{
+			"session_token": token,
+			"username":      username,
+		})
+		return
+	}
+
+	writeDeviceError(w, "server_error", http.StatusInternalServerError)
+}
+
+// handleDeviceVerify renders the "approve this CLI sign-in" page. The user
+// must be signed in to ghp; if not, they are redirected through the existing
+// GitHub OAuth flow with a return_to back to this page.
+func (h *Handler) handleDeviceVerify(w http.ResponseWriter, r *http.Request) {
+	userCode := normaliseUserCode(r.URL.Query().Get("user_code"))
+
+	session := h.GetSession(r)
+	if session == nil {
+		// Send the user through GitHub login, then back to this page with
+		// the user_code preserved.
+		ret := "/cli/auth"
+		if userCode != "" {
+			ret += "?user_code=" + url.QueryEscape(userCode)
+		}
+		loginURL := "/auth/github?return_to=" + url.QueryEscape(ret)
+		http.Redirect(w, r, loginURL, http.StatusSeeOther)
+		return
+	}
+
+	data := deviceVerifyData{
+		Username: session.Username,
+		UserCode: userCode,
+	}
+
+	if userCode == "" {
+		data.NeedsCode = true
+		renderDeviceVerify(w, h.logger, data)
+		return
+	}
+
+	deviceCode, ok := h.deviceUserCodes.Get(userCode)
+	if !ok {
+		data.Error = "That code is invalid or has expired. Run `ghp auth login` again to get a new one."
+		renderDeviceVerify(w, h.logger, data)
+		return
+	}
+	req, ok := h.deviceRequests.Get(deviceCode)
+	if !ok {
+		data.Error = "That code is invalid or has expired. Run `ghp auth login` again to get a new one."
+		renderDeviceVerify(w, h.logger, data)
+		return
+	}
+	req.mu.Lock()
+	status := req.Status
+	req.mu.Unlock()
+
+	switch status {
+	case deviceStatusApproved:
+		data.AlreadyApproved = true
+	case deviceStatusDenied:
+		data.AlreadyDenied = true
+	}
+
+	renderDeviceVerify(w, h.logger, data)
+}
+
+// handleDeviceDecision processes the approve/deny form submission. Same-Origin
+// is enforced by the SameSite=Lax session cookie (the cookie is not sent on
+// cross-site POSTs), and the user_code itself is a short-lived secret known
+// only to the CLI and the user.
+func (h *Handler) handleDeviceDecision(w http.ResponseWriter, r *http.Request) {
+	session := h.GetSession(r)
+	if session == nil {
+		http.Error(w, "Authentication required", http.StatusUnauthorized)
+		return
+	}
+
+	if err := r.ParseForm(); err != nil {
+		http.Error(w, "Invalid form", http.StatusBadRequest)
+		return
+	}
+
+	userCode := normaliseUserCode(r.FormValue("user_code"))
+	action := r.FormValue("action")
+
+	if userCode == "" || (action != "approve" && action != "deny") {
+		http.Error(w, "Missing or invalid form fields", http.StatusBadRequest)
+		return
+	}
+
+	deviceCode, ok := h.deviceUserCodes.Get(userCode)
+	if !ok {
+		renderDeviceVerify(w, h.logger, deviceVerifyData{
+			Username: session.Username,
+			UserCode: userCode,
+			Error:    "That code is invalid or has expired. Run `ghp auth login` again to get a new one.",
+		})
+		return
+	}
+	req, ok := h.deviceRequests.Get(deviceCode)
+	if !ok {
+		renderDeviceVerify(w, h.logger, deviceVerifyData{
+			Username: session.Username,
+			UserCode: userCode,
+			Error:    "That code is invalid or has expired. Run `ghp auth login` again to get a new one.",
+		})
+		return
+	}
+
+	req.mu.Lock()
+	defer req.mu.Unlock()
+
+	if req.Status != deviceStatusPending {
+		// Already decided. Render an idempotent response.
+		data := deviceVerifyData{
+			Username: session.Username,
+			UserCode: userCode,
+		}
+		switch req.Status {
+		case deviceStatusApproved:
+			data.AlreadyApproved = true
+		case deviceStatusDenied:
+			data.AlreadyDenied = true
+		}
+		renderDeviceVerify(w, h.logger, data)
+		return
+	}
+
+	if action == "deny" {
+		req.Status = deviceStatusDenied
+		h.logger.Info("cli_auth_denied", "user", session.Username)
+		renderDeviceVerify(w, h.logger, deviceVerifyData{
+			Username:      session.Username,
+			UserCode:      userCode,
+			JustDenied:    true,
+		})
+		return
+	}
+
+	// Approve: mint a fresh session for the CLI tied to this user. The CLI
+	// session is independent of the browser session — revoking the browser
+	// session via /auth/logout does not revoke CLI sessions.
+	cliToken := h.createSession(session.UserID, session.Username, session.Role)
+	req.Status = deviceStatusApproved
+	req.SessionToken = cliToken
+	req.Username = session.Username
+
+	h.logger.Info("cli_auth_approved", "user", session.Username)
+
+	renderDeviceVerify(w, h.logger, deviceVerifyData{
+		Username:     session.Username,
+		UserCode:     userCode,
+		JustApproved: true,
+	})
+}
+
+// writeDeviceError emits an RFC-8628-style {"error":"..."} JSON body.
+func writeDeviceError(w http.ResponseWriter, code string, status int) {
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Cache-Control", "no-store")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(map[string]string{"error": code})
+}
+
+// generateDeviceCode returns a 32-byte hex-encoded random token. This is the
+// long-lived secret the CLI polls with; it must be high-entropy.
+func generateDeviceCode() (string, error) {
+	b := make([]byte, 32)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(b), nil
+}
+
+// generateUserCode returns a short, human-typeable code such as "ABCD-EFGH".
+// Each character is uniformly drawn from deviceUserCodeAlphabet using
+// crypto/rand.
+func generateUserCode() (string, error) {
+	alphabetLen := big.NewInt(int64(len(deviceUserCodeAlphabet)))
+	blocks := make([]string, deviceUserCodeBlocks)
+	for b := 0; b < deviceUserCodeBlocks; b++ {
+		var sb strings.Builder
+		sb.Grow(deviceUserCodeBlockSize)
+		for i := 0; i < deviceUserCodeBlockSize; i++ {
+			n, err := rand.Int(rand.Reader, alphabetLen)
+			if err != nil {
+				return "", err
+			}
+			sb.WriteByte(deviceUserCodeAlphabet[n.Int64()])
+		}
+		blocks[b] = sb.String()
+	}
+	return strings.Join(blocks, "-"), nil
+}
+
+// normaliseUserCode upper-cases and strips whitespace from a user-supplied
+// code so we accept "abcd-efgh" and "ABCD EFGH" the same way.
+func normaliseUserCode(s string) string {
+	s = strings.ToUpper(strings.TrimSpace(s))
+	s = strings.ReplaceAll(s, " ", "")
+	// Ensure the code contains the dash separator. If the user typed it
+	// without dashes ("ABCDEFGH"), reinsert them every blockSize chars.
+	if !strings.Contains(s, "-") && len(s) == deviceUserCodeBlocks*deviceUserCodeBlockSize {
+		var b strings.Builder
+		for i := 0; i < deviceUserCodeBlocks; i++ {
+			if i > 0 {
+				b.WriteByte('-')
+			}
+			b.WriteString(s[i*deviceUserCodeBlockSize : (i+1)*deviceUserCodeBlockSize])
+		}
+		s = b.String()
+	}
+	return s
+}
+
+// absoluteURL constructs an absolute URL for path on this server, preferring
+// the configured server.base_url and falling back to the request's host.
+func (h *Handler) absoluteURL(r *http.Request, path string) string {
+	if h.cfg.Server.BaseURL != "" {
+		return strings.TrimRight(h.cfg.Server.BaseURL, "/") + path
+	}
+	scheme := "https"
+	if r.TLS == nil {
+		scheme = "http"
+	}
+	return fmt.Sprintf("%s://%s%s", scheme, r.Host, path)
+}
+
+// deviceVerifyData drives the verification template. Exactly one of NeedsCode,
+// Error, AlreadyApproved, AlreadyDenied, JustApproved, or JustDenied is set;
+// otherwise the page renders the approve/deny form for UserCode.
+type deviceVerifyData struct {
+	Username        string
+	UserCode        string
+	NeedsCode       bool
+	Error           string
+	AlreadyApproved bool
+	AlreadyDenied   bool
+	JustApproved    bool
+	JustDenied      bool
+}
+
+var deviceVerifyTmpl = template.Must(template.New("device_verify").Parse(`<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>ghp — Authorize CLI sign-in</title>
+<style>
+* { margin: 0; padding: 0; box-sizing: border-box; }
+body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; background: #0d1117; color: #c9d1d9; display: flex; align-items: center; justify-content: center; min-height: 100vh; padding: 1rem; }
+.card { background: #161b22; border: 1px solid #30363d; border-radius: 6px; padding: 2rem; max-width: 480px; width: 100%; }
+h1 { font-size: 1.4rem; margin-bottom: 0.75rem; color: #f0f6fc; }
+p { color: #8b949e; margin-bottom: 1rem; font-size: 0.95rem; line-height: 1.5; }
+.user-code { display: block; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 1.6rem; letter-spacing: 0.15em; text-align: center; padding: 0.9rem 1rem; background: #0d1117; border: 1px solid #30363d; border-radius: 6px; color: #f0f6fc; margin: 1rem 0 1.5rem; }
+.actions { display: flex; gap: 0.75rem; margin-top: 1.5rem; }
+.btn { flex: 1; display: inline-block; padding: 0.75rem 1rem; border-radius: 6px; border: 0; font-weight: 600; font-size: 0.95rem; cursor: pointer; text-align: center; text-decoration: none; }
+.btn-approve { background: #238636; color: #fff; }
+.btn-approve:hover { background: #2ea043; }
+.btn-deny { background: #21262d; color: #f0f6fc; border: 1px solid #30363d; }
+.btn-deny:hover { background: #30363d; }
+.notice { padding: 0.75rem 1rem; border-radius: 6px; margin-bottom: 1rem; }
+.notice-error { background: #4c1d1d; color: #ffa198; border: 1px solid #6e2222; }
+.notice-success { background: #1a3a1f; color: #7ee787; border: 1px solid #2ea04340; }
+.notice-info { background: #1f2a44; color: #79c0ff; border: 1px solid #1f6feb40; }
+input[type=text] { width: 100%; padding: 0.6rem 0.75rem; background: #0d1117; border: 1px solid #30363d; border-radius: 6px; color: #f0f6fc; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 1rem; letter-spacing: 0.1em; margin-bottom: 1rem; }
+.muted { color: #6e7681; font-size: 0.8rem; }
+form { margin: 0; }
+</style>
+</head>
+<body>
+<div class="card">
+<h1>Authorize CLI sign-in</h1>
+{{if .JustApproved}}
+<div class="notice notice-success">Approved. You can return to your terminal — the CLI will pick up the new credentials within a few seconds. You can close this tab.</div>
+{{else if .JustDenied}}
+<div class="notice notice-info">Denied. The CLI session has not been authorized.</div>
+{{else if .AlreadyApproved}}
+<div class="notice notice-info">This code has already been approved.</div>
+{{else if .AlreadyDenied}}
+<div class="notice notice-info">This code was denied.</div>
+{{else if .Error}}
+<div class="notice notice-error">{{.Error}}</div>
+{{else if .NeedsCode}}
+<p>Enter the user code shown by your <code>ghp</code> CLI to authorize a new sign-in:</p>
+<form method="POST" action="/cli/auth/decision">
+<input type="text" name="user_code" autocomplete="off" autocapitalize="characters" spellcheck="false" placeholder="ABCD-EFGH" required>
+<input type="hidden" name="action" value="approve">
+<div class="actions">
+<button class="btn btn-approve" type="submit">Authorize</button>
+</div>
+</form>
+{{else}}
+<p>A <code>ghp</code> CLI is requesting permission to sign in as <strong>{{.Username}}</strong>.</p>
+<p>Confirm the code below matches what your CLI displayed:</p>
+<span class="user-code">{{.UserCode}}</span>
+<p class="muted">If you did not start a sign-in just now, click Deny.</p>
+<form method="POST" action="/cli/auth/decision">
+<input type="hidden" name="user_code" value="{{.UserCode}}">
+<div class="actions">
+<button class="btn btn-deny" type="submit" name="action" value="deny">Deny</button>
+<button class="btn btn-approve" type="submit" name="action" value="approve">Authorize</button>
+</div>
+</form>
+{{end}}
+</div>
+</body>
+</html>
+`))
+
+func renderDeviceVerify(w http.ResponseWriter, logger interface{ Error(msg string, args ...any) }, data deviceVerifyData) {
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	w.Header().Set("Cache-Control", "no-store")
+	if err := deviceVerifyTmpl.Execute(w, data); err != nil {
+		logger.Error("device verify template execution failed", "error", err)
+		http.Error(w, "Internal error", http.StatusInternalServerError)
+	}
+}

--- a/internal/auth/device.go
+++ b/internal/auth/device.go
@@ -28,16 +28,14 @@ package auth
 //	   |  (polling every interval seconds) |                                    |
 //	   |<--- {session_token, username} ----|                                    |
 //
-// Design notes:
-//   - Device records are kept in-memory (expirable.LRU), since they are
-//     short-lived and small in number; persisting them in the database would
-//     require migrations across all three backends (Postgres, SQLite, Vault)
-//     for no real benefit.
-//   - GitHub OAuth is still the identity provider for the ghp web UI, but it
-//     is no longer involved in the CLI bootstrap. The CLI never sees a
-//     github.com URL.
+// State is held in the database (cli_device_authorizations table) rather
+// than an in-process LRU so that the four round-trips above remain correct
+// when load-balanced across multiple ghp instances. GitHub OAuth is still
+// the identity provider for the ghp web UI, but it is no longer involved in
+// the CLI bootstrap — the CLI never sees a github.com URL.
 
 import (
+	"context"
 	"crypto/rand"
 	"encoding/hex"
 	"encoding/json"
@@ -48,9 +46,9 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
-	"sync"
 	"time"
 
+	"github.com/goodtune/ghp/internal/database"
 	"github.com/goodtune/ghp/internal/metrics"
 )
 
@@ -59,14 +57,11 @@ const (
 	// valid. After this window the user_code becomes invalid and the CLI
 	// poll receives "expired_token".
 	deviceRequestTTL = 10 * time.Minute
-	// maxDeviceRequests caps the number of in-flight device requests held
-	// in memory. The LRU evicts oldest entries past this size.
-	maxDeviceRequests = 1_000
 	// devicePollMinInterval is the minimum permitted interval between
 	// polls for a single device_code. Polling faster receives "slow_down".
 	devicePollMinInterval = 2 * time.Second
 	// deviceUserCodeAlphabet is the set of characters used in user_codes.
-	// Restricted to a 32-character set that avoids visually-confusable
+	// Restricted to a 31-character set that avoids visually-confusable
 	// glyphs (no 0/O, 1/I/L) so users can read and re-type codes reliably
 	// from a small printout.
 	deviceUserCodeAlphabet = "ABCDEFGHJKMNPQRSTUVWXYZ23456789"
@@ -78,41 +73,7 @@ const (
 	deviceUserCodeBlocks = 2
 )
 
-// DeviceAuthStatus is the lifecycle state of a device-authorization request.
-type DeviceAuthStatus string
-
-const (
-	deviceStatusPending  DeviceAuthStatus = "pending"
-	deviceStatusApproved DeviceAuthStatus = "approved"
-	deviceStatusDenied   DeviceAuthStatus = "denied"
-)
-
-// deviceAuthRequest is the in-memory record for a CLI device-authorization
-// request. The device_code is the long-lived secret the CLI polls with;
-// the user_code is the short, human-readable code displayed in both the
-// CLI output and the browser approval page.
-type deviceAuthRequest struct {
-	mu sync.Mutex
-
-	DeviceCode string
-	UserCode   string
-
-	Status DeviceAuthStatus
-
-	// SessionToken and Username are populated when Status transitions to
-	// approved. They are returned to the CLI on its next poll (after which
-	// the device record is removed from the LRU to prevent token re-use).
-	SessionToken string
-	Username     string
-
-	// LastPolledAt is updated by the polling endpoint to enforce the
-	// minimum poll interval.
-	LastPolledAt time.Time
-
-	CreatedAt time.Time
-}
-
-// RegisterDeviceRoutes adds the CLI device-authorization endpoints to the mux.
+// registerDeviceRoutes adds the CLI device-authorization endpoints to the mux.
 // Called from RegisterRoutes.
 func (h *Handler) registerDeviceRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("POST /cli/auth/device", h.handleDeviceStart)
@@ -121,42 +82,49 @@ func (h *Handler) registerDeviceRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("POST /cli/auth/decision", h.handleDeviceDecision)
 }
 
-// handleDeviceStart creates a new device-authorization request. The CLI
-// hits this endpoint anonymously; no user identity is associated with the
-// record until the verification page is approved.
+// handleDeviceStart creates a new device-authorization request. The CLI hits
+// this endpoint anonymously; no user identity is associated with the record
+// until the verification page is approved.
 //
-// Response is RFC-8628-shaped JSON:
-//
-//	{
-//	  "device_code": "...",
-//	  "user_code": "ABCD-EFGH",
-//	  "verification_uri": "https://server/cli/auth",
-//	  "verification_uri_complete": "https://server/cli/auth?user_code=ABCD-EFGH",
-//	  "expires_in": 600,
-//	  "interval": 5
-//	}
+// Response is RFC-8628-shaped JSON.
 func (h *Handler) handleDeviceStart(w http.ResponseWriter, r *http.Request) {
 	deviceCode, err := generateDeviceCode()
 	if err != nil {
 		h.logger.Error("failed to generate device_code", "error", err)
-		http.Error(w, `{"error":"server_error"}`, http.StatusInternalServerError)
-		return
-	}
-	userCode, err := generateUserCode()
-	if err != nil {
-		h.logger.Error("failed to generate user_code", "error", err)
-		http.Error(w, `{"error":"server_error"}`, http.StatusInternalServerError)
+		writeDeviceError(w, "server_error", http.StatusInternalServerError)
 		return
 	}
 
-	req := &deviceAuthRequest{
-		DeviceCode: deviceCode,
-		UserCode:   userCode,
-		Status:     deviceStatusPending,
-		CreatedAt:  time.Now(),
+	// user_code collisions are extremely unlikely (≈40 bits of entropy with
+	// at most ~1k records active in a 10-minute window) but possible. Retry
+	// a small number of times if Create reports a unique-constraint error.
+	var userCode string
+	for attempt := 0; attempt < 5; attempt++ {
+		uc, err := generateUserCode()
+		if err != nil {
+			h.logger.Error("failed to generate user_code", "error", err)
+			writeDeviceError(w, "server_error", http.StatusInternalServerError)
+			return
+		}
+		if err := h.store.CreateDeviceAuth(r.Context(), &database.DeviceAuth{
+			DeviceCode: deviceCode,
+			UserCode:   uc,
+			Status:     database.DeviceAuthStatusPending,
+			ExpiresAt:  time.Now().Add(deviceRequestTTL).UTC(),
+		}); err != nil {
+			// A duplicate user_code is the only retriable error we expect;
+			// retry on any error here is cheap and safer than parsing
+			// driver-specific constraint messages.
+			if attempt == 4 {
+				h.logger.Error("failed to persist device_auth", "error", err)
+				writeDeviceError(w, "server_error", http.StatusInternalServerError)
+				return
+			}
+			continue
+		}
+		userCode = uc
+		break
 	}
-	h.deviceRequests.Add(deviceCode, req)
-	h.deviceUserCodes.Add(userCode, deviceCode)
 
 	verifyURI := h.absoluteURL(r, "/cli/auth")
 	verifyComplete := verifyURI + "?user_code=" + url.QueryEscape(userCode)
@@ -178,16 +146,6 @@ func (h *Handler) handleDeviceStart(w http.ResponseWriter, r *http.Request) {
 // handleDevicePoll returns the issued session token once the device request
 // has been approved by an authenticated browser session. Until then it
 // returns RFC-8628-style error codes.
-//
-// Request body: {"device_code": "..."}
-//
-// Responses:
-//   - 200 {"session_token": "ghpr_...", "username": "..."}                approved
-//   - 400 {"error": "authorization_pending"}                              still waiting
-//   - 400 {"error": "slow_down"}                                          polled too fast
-//   - 400 {"error": "expired_token"}                                      record TTL'd
-//   - 400 {"error": "access_denied"}                                      user denied
-//   - 400 {"error": "invalid_grant"}                                      device_code unknown
 func (h *Handler) handleDevicePoll(w http.ResponseWriter, r *http.Request) {
 	r.Body = http.MaxBytesReader(w, r.Body, maxRequestBodySize)
 
@@ -197,7 +155,7 @@ func (h *Handler) handleDevicePoll(w http.ResponseWriter, r *http.Request) {
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 		var maxErr *http.MaxBytesError
 		if errors.As(err, &maxErr) {
-			http.Error(w, `{"error":"invalid_request"}`, http.StatusRequestEntityTooLarge)
+			writeDeviceError(w, "invalid_request", http.StatusRequestEntityTooLarge)
 			return
 		}
 		writeDeviceError(w, "invalid_request", http.StatusBadRequest)
@@ -208,42 +166,53 @@ func (h *Handler) handleDevicePoll(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	req, ok := h.deviceRequests.Get(body.DeviceCode)
-	if !ok {
-		// Either the device_code was never issued, or it has expired and
-		// been evicted. RFC 8628 distinguishes these but we do not — both
-		// outcomes mean the CLI must restart from the beginning.
-		writeDeviceError(w, "expired_token", http.StatusBadRequest)
+	da, err := h.store.GetDeviceAuthByDeviceCode(r.Context(), body.DeviceCode)
+	if err != nil {
+		// Either the device_code was never issued, or the record has expired
+		// and been pruned. RFC 8628 distinguishes these but we conflate
+		// them — both outcomes mean the CLI must restart from the beginning.
+		if errors.Is(err, database.ErrNotFound) {
+			writeDeviceError(w, "expired_token", http.StatusBadRequest)
+			return
+		}
+		h.logger.Error("device_auth lookup failed", "error", err)
+		writeDeviceError(w, "server_error", http.StatusInternalServerError)
 		return
 	}
 
-	req.mu.Lock()
-	defer req.mu.Unlock()
-
-	now := time.Now()
-	if !req.LastPolledAt.IsZero() && now.Sub(req.LastPolledAt) < devicePollMinInterval {
+	now := time.Now().UTC()
+	if da.LastPolledAt != nil && now.Sub(*da.LastPolledAt) < devicePollMinInterval {
 		writeDeviceError(w, "slow_down", http.StatusBadRequest)
 		return
 	}
-	req.LastPolledAt = now
 
-	switch req.Status {
-	case deviceStatusPending:
+	switch da.Status {
+	case database.DeviceAuthStatusPending:
+		// Persist the new last_polled_at so subsequent pollers from any
+		// instance see the same rate-limit window.
+		da.LastPolledAt = &now
+		if err := h.store.UpdateDeviceAuth(r.Context(), da); err != nil {
+			h.logger.Warn("device_auth poll-time update failed", "error", err)
+			// Continue — failing to record the poll time is non-fatal
+			// (the rate limit just won't trip on this poll).
+		}
 		writeDeviceError(w, "authorization_pending", http.StatusBadRequest)
 		return
-	case deviceStatusDenied:
-		// Remove the record so a denied code can't be re-polled.
-		h.deviceRequests.Remove(req.DeviceCode)
-		h.deviceUserCodes.Remove(req.UserCode)
+	case database.DeviceAuthStatusDenied:
+		// Remove the record so a denied code cannot be re-polled.
+		if err := h.store.DeleteDeviceAuth(r.Context(), da.DeviceCode); err != nil {
+			h.logger.Warn("device_auth delete failed", "error", err)
+		}
 		metrics.CLIDeviceCompletedTotal.WithLabelValues("denied").Inc()
 		writeDeviceError(w, "access_denied", http.StatusBadRequest)
 		return
-	case deviceStatusApproved:
+	case database.DeviceAuthStatusApproved:
 		// Hand the token to the CLI exactly once and discard the record.
-		token := req.SessionToken
-		username := req.Username
-		h.deviceRequests.Remove(req.DeviceCode)
-		h.deviceUserCodes.Remove(req.UserCode)
+		token := da.SessionToken
+		username := da.Username
+		if err := h.store.DeleteDeviceAuth(r.Context(), da.DeviceCode); err != nil {
+			h.logger.Warn("device_auth delete failed", "error", err)
+		}
 		metrics.CLIDeviceCompletedTotal.WithLabelValues("approved").Inc()
 
 		w.Header().Set("Content-Type", "application/json")
@@ -266,14 +235,11 @@ func (h *Handler) handleDeviceVerify(w http.ResponseWriter, r *http.Request) {
 
 	session := h.GetSession(r)
 	if session == nil {
-		// Send the user through GitHub login, then back to this page with
-		// the user_code preserved.
 		ret := "/cli/auth"
 		if userCode != "" {
 			ret += "?user_code=" + url.QueryEscape(userCode)
 		}
-		loginURL := "/auth/github?return_to=" + url.QueryEscape(ret)
-		http.Redirect(w, r, loginURL, http.StatusSeeOther)
+		http.Redirect(w, r, "/auth/github?return_to="+url.QueryEscape(ret), http.StatusSeeOther)
 		return
 	}
 
@@ -288,36 +254,31 @@ func (h *Handler) handleDeviceVerify(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	deviceCode, ok := h.deviceUserCodes.Get(userCode)
-	if !ok {
-		data.Error = "That code is invalid or has expired. Run `ghp auth login` again to get a new one."
+	da, err := h.store.GetDeviceAuthByUserCode(r.Context(), userCode)
+	if err != nil {
+		if errors.Is(err, database.ErrNotFound) {
+			data.Error = "That code is invalid or has expired. Run `ghp auth login` again to get a new one."
+		} else {
+			h.logger.Error("device_auth lookup failed", "error", err)
+			data.Error = "Internal error looking up that code."
+		}
 		renderDeviceVerify(w, h.logger, data)
 		return
 	}
-	req, ok := h.deviceRequests.Get(deviceCode)
-	if !ok {
-		data.Error = "That code is invalid or has expired. Run `ghp auth login` again to get a new one."
-		renderDeviceVerify(w, h.logger, data)
-		return
-	}
-	req.mu.Lock()
-	status := req.Status
-	req.mu.Unlock()
 
-	switch status {
-	case deviceStatusApproved:
+	switch da.Status {
+	case database.DeviceAuthStatusApproved:
 		data.AlreadyApproved = true
-	case deviceStatusDenied:
+	case database.DeviceAuthStatusDenied:
 		data.AlreadyDenied = true
 	}
-
 	renderDeviceVerify(w, h.logger, data)
 }
 
-// handleDeviceDecision processes the approve/deny form submission. Same-Origin
-// is enforced by the SameSite=Lax session cookie (the cookie is not sent on
-// cross-site POSTs), and the user_code itself is a short-lived secret known
-// only to the CLI and the user.
+// handleDeviceDecision processes the approve/deny form submission. Same-
+// origin protection is provided by the SameSite=Lax session cookie (the
+// cookie is not sent on cross-site POSTs), and the user_code itself is a
+// short-lived secret known only to the CLI and the user.
 func (h *Handler) handleDeviceDecision(w http.ResponseWriter, r *http.Request) {
 	session := h.GetSession(r)
 	if session == nil {
@@ -338,17 +299,11 @@ func (h *Handler) handleDeviceDecision(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	deviceCode, ok := h.deviceUserCodes.Get(userCode)
-	if !ok {
-		renderDeviceVerify(w, h.logger, deviceVerifyData{
-			Username: session.Username,
-			UserCode: userCode,
-			Error:    "That code is invalid or has expired. Run `ghp auth login` again to get a new one.",
-		})
-		return
-	}
-	req, ok := h.deviceRequests.Get(deviceCode)
-	if !ok {
+	da, err := h.store.GetDeviceAuthByUserCode(r.Context(), userCode)
+	if err != nil {
+		if !errors.Is(err, database.ErrNotFound) {
+			h.logger.Error("device_auth lookup failed", "error", err)
+		}
 		renderDeviceVerify(w, h.logger, deviceVerifyData{
 			Username: session.Username,
 			UserCode: userCode,
@@ -357,19 +312,16 @@ func (h *Handler) handleDeviceDecision(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	req.mu.Lock()
-	defer req.mu.Unlock()
-
-	if req.Status != deviceStatusPending {
+	if da.Status != database.DeviceAuthStatusPending {
 		// Already decided. Render an idempotent response.
 		data := deviceVerifyData{
 			Username: session.Username,
 			UserCode: userCode,
 		}
-		switch req.Status {
-		case deviceStatusApproved:
+		switch da.Status {
+		case database.DeviceAuthStatusApproved:
 			data.AlreadyApproved = true
-		case deviceStatusDenied:
+		case database.DeviceAuthStatusDenied:
 			data.AlreadyDenied = true
 		}
 		renderDeviceVerify(w, h.logger, data)
@@ -377,12 +329,17 @@ func (h *Handler) handleDeviceDecision(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if action == "deny" {
-		req.Status = deviceStatusDenied
+		da.Status = database.DeviceAuthStatusDenied
+		if err := h.store.UpdateDeviceAuth(r.Context(), da); err != nil {
+			h.logger.Error("device_auth deny update failed", "error", err)
+			http.Error(w, "Internal error", http.StatusInternalServerError)
+			return
+		}
 		h.logger.Info("cli_auth_denied", "user", session.Username)
 		renderDeviceVerify(w, h.logger, deviceVerifyData{
-			Username:      session.Username,
-			UserCode:      userCode,
-			JustDenied:    true,
+			Username:   session.Username,
+			UserCode:   userCode,
+			JustDenied: true,
 		})
 		return
 	}
@@ -390,10 +347,24 @@ func (h *Handler) handleDeviceDecision(w http.ResponseWriter, r *http.Request) {
 	// Approve: mint a fresh session for the CLI tied to this user. The CLI
 	// session is independent of the browser session — revoking the browser
 	// session via /auth/logout does not revoke CLI sessions.
-	cliToken := h.createSession(session.UserID, session.Username, session.Role)
-	req.Status = deviceStatusApproved
-	req.SessionToken = cliToken
-	req.Username = session.Username
+	cliToken, err := h.createSession(r.Context(), session.UserID, session.Username, session.Role)
+	if err != nil {
+		h.logger.Error("CLI session creation failed", "error", err)
+		http.Error(w, "Internal error", http.StatusInternalServerError)
+		return
+	}
+
+	da.Status = database.DeviceAuthStatusApproved
+	da.SessionToken = cliToken
+	da.Username = session.Username
+	if err := h.store.UpdateDeviceAuth(r.Context(), da); err != nil {
+		// Best-effort: clean up the session we just created so it isn't
+		// orphaned in the sessions table.
+		h.deleteSession(r.Context(), cliToken)
+		h.logger.Error("device_auth approve update failed", "error", err)
+		http.Error(w, "Internal error", http.StatusInternalServerError)
+		return
+	}
 
 	h.logger.Info("cli_auth_approved", "user", session.Username)
 
@@ -448,8 +419,6 @@ func generateUserCode() (string, error) {
 func normaliseUserCode(s string) string {
 	s = strings.ToUpper(strings.TrimSpace(s))
 	s = strings.ReplaceAll(s, " ", "")
-	// Ensure the code contains the dash separator. If the user typed it
-	// without dashes ("ABCDEFGH"), reinsert them every blockSize chars.
 	if !strings.Contains(s, "-") && len(s) == deviceUserCodeBlocks*deviceUserCodeBlockSize {
 		var b strings.Builder
 		for i := 0; i < deviceUserCodeBlocks; i++ {
@@ -566,3 +535,7 @@ func renderDeviceVerify(w http.ResponseWriter, logger interface{ Error(msg strin
 		http.Error(w, "Internal error", http.StatusInternalServerError)
 	}
 }
+
+// Compile-time check that handlers don't accidentally rely on background
+// context for store operations.
+var _ context.Context = context.Background()

--- a/internal/auth/device.go
+++ b/internal/auth/device.go
@@ -189,6 +189,19 @@ func (h *Handler) handleDevicePoll(w http.ResponseWriter, r *http.Request) {
 
 	now := time.Now().UTC()
 	if da.LastPolledAt != nil && now.Sub(*da.LastPolledAt) < devicePollMinInterval {
+		// Bump LastPolledAt forward even on rejection so a misbehaving
+		// client polling in a tight loop keeps pushing its own rate-limit
+		// window out instead of repeatedly hitting only the in-memory
+		// timestamp comparison. Without this the next poll from any
+		// instance sees the same stale LastPolledAt and the offender pays
+		// only the cost of the DB lookup, never advancing past slow_down.
+		da.LastPolledAt = &now
+		if err := h.store.UpdateDeviceAuth(r.Context(), da); err != nil {
+			// Non-fatal: the rate-limit window just won't tighten further
+			// for this client across this poll. The IP-level limiter still
+			// applies as a backstop.
+			h.logger.Warn("device_auth slow-down update failed", "error", err)
+		}
 		writeDeviceError(w, "slow_down", http.StatusBadRequest)
 		return
 	}
@@ -449,16 +462,85 @@ func normaliseUserCode(s string) string {
 }
 
 // absoluteURL constructs an absolute URL for path on this server, preferring
-// the configured server.base_url and falling back to the request's host.
+// the configured server.base_url and falling back to a scheme/host derived
+// from the incoming request (with X-Forwarded-* headers honoured for
+// reverse-proxy deployments).
 func (h *Handler) absoluteURL(r *http.Request, path string) string {
 	if h.cfg.Server.BaseURL != "" {
 		return strings.TrimRight(h.cfg.Server.BaseURL, "/") + path
 	}
-	scheme := "https"
-	if r.TLS == nil {
-		scheme = "http"
+	return fmt.Sprintf("%s://%s%s", requestScheme(r), requestHost(r), path)
+}
+
+// requestScheme reports the externally-visible scheme for r. It checks the
+// standardised Forwarded header first, then X-Forwarded-Proto (for the
+// common case of an L7 proxy), and finally falls back to whether the
+// connection itself is TLS. This matters because in a typical deployment
+// TLS terminates at the proxy and ghp receives plain HTTP — without the
+// header check we'd hand back http:// verification URLs that don't match
+// the user's externally reachable address.
+func requestScheme(r *http.Request) string {
+	if v := forwardedField(r.Header.Get("Forwarded"), "proto"); v != "" {
+		return v
 	}
-	return fmt.Sprintf("%s://%s%s", scheme, r.Host, path)
+	if v := r.Header.Get("X-Forwarded-Proto"); v != "" {
+		// Multiple proxies may chain values ("https, http"); take the
+		// first, which represents the originating client edge.
+		if i := strings.Index(v, ","); i >= 0 {
+			v = v[:i]
+		}
+		return strings.TrimSpace(v)
+	}
+	if r.TLS != nil {
+		return "https"
+	}
+	return "http"
+}
+
+// requestHost reports the externally-visible host for r, honouring
+// X-Forwarded-Host before the request's own Host header.
+func requestHost(r *http.Request) string {
+	if v := forwardedField(r.Header.Get("Forwarded"), "host"); v != "" {
+		return v
+	}
+	if v := r.Header.Get("X-Forwarded-Host"); v != "" {
+		if i := strings.Index(v, ","); i >= 0 {
+			v = v[:i]
+		}
+		return strings.TrimSpace(v)
+	}
+	return r.Host
+}
+
+// forwardedField extracts a single field (e.g. "proto" or "host") from an
+// RFC 7239 Forwarded header value. Returns "" when the header is empty or
+// the field is absent. Only the first forwarded element is consulted (the
+// originating client's view of the request); chained proxies after that
+// are ignored, matching the X-Forwarded-* convention above.
+func forwardedField(header, name string) string {
+	if header == "" {
+		return ""
+	}
+	// Forwarded: by=...;for=...;host=...;proto=...
+	first := header
+	if i := strings.Index(first, ","); i >= 0 {
+		first = first[:i]
+	}
+	for _, part := range strings.Split(first, ";") {
+		part = strings.TrimSpace(part)
+		eq := strings.IndexByte(part, '=')
+		if eq < 0 {
+			continue
+		}
+		if !strings.EqualFold(part[:eq], name) {
+			continue
+		}
+		v := strings.TrimSpace(part[eq+1:])
+		// Values may be quoted per the spec.
+		v = strings.Trim(v, `"`)
+		return v
+	}
+	return ""
 }
 
 // deviceVerifyData drives the verification template. Exactly one of NeedsCode,

--- a/internal/auth/device_test.go
+++ b/internal/auth/device_test.go
@@ -1,0 +1,445 @@
+package auth
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/goodtune/ghp/internal/config"
+)
+
+// TestDeviceStart_ReturnsCodes verifies POST /cli/auth/device returns the
+// device_code, user_code and verification URLs.
+func TestDeviceStart_ReturnsCodes(t *testing.T) {
+	cfg := &config.Config{
+		Server: config.ServerConfig{BaseURL: "https://proxy.example.com"},
+	}
+	h := NewHandler(cfg, nil, nil, slog.Default())
+
+	req := httptest.NewRequest("POST", "/cli/auth/device", nil)
+	w := httptest.NewRecorder()
+	h.handleDeviceStart(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp deviceStartTestResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decoding: %v", err)
+	}
+	if resp.DeviceCode == "" {
+		t.Error("device_code missing")
+	}
+	if resp.UserCode == "" {
+		t.Error("user_code missing")
+	}
+	if !strings.HasSuffix(resp.VerificationURI, "/cli/auth") {
+		t.Errorf("verification_uri = %q", resp.VerificationURI)
+	}
+	if !strings.Contains(resp.VerificationURIComplete, url.QueryEscape(resp.UserCode)) {
+		t.Errorf("verification_uri_complete missing user_code: %q", resp.VerificationURIComplete)
+	}
+	if resp.ExpiresIn <= 0 {
+		t.Errorf("expires_in = %d, want > 0", resp.ExpiresIn)
+	}
+	if resp.Interval <= 0 {
+		t.Errorf("interval = %d, want > 0", resp.Interval)
+	}
+}
+
+type deviceStartTestResponse struct {
+	DeviceCode              string `json:"device_code"`
+	UserCode                string `json:"user_code"`
+	VerificationURI         string `json:"verification_uri"`
+	VerificationURIComplete string `json:"verification_uri_complete"`
+	ExpiresIn               int    `json:"expires_in"`
+	Interval                int    `json:"interval"`
+}
+
+// TestDevicePoll_PendingThenApproved walks the full happy-path: start,
+// poll-pending, decision=approve, poll-success.
+func TestDevicePoll_PendingThenApproved(t *testing.T) {
+	cfg := &config.Config{}
+	h := NewHandler(cfg, nil, nil, slog.Default())
+
+	// Start.
+	startReq := httptest.NewRequest("POST", "/cli/auth/device", nil)
+	startW := httptest.NewRecorder()
+	h.handleDeviceStart(startW, startReq)
+	var ds deviceStartTestResponse
+	if err := json.NewDecoder(startW.Body).Decode(&ds); err != nil {
+		t.Fatalf("decode start: %v", err)
+	}
+
+	// Poll while pending → 400 authorization_pending.
+	if got := pollDeviceTokenAndExpect(t, h, ds.DeviceCode); got != "authorization_pending" {
+		t.Fatalf("first poll: got %q, want authorization_pending", got)
+	}
+
+	// Now simulate the user approving via the verification page. We need a
+	// session for the decision handler.
+	sessToken := h.createSession("user-1", "alice", "user")
+	form := url.Values{}
+	form.Set("user_code", ds.UserCode)
+	form.Set("action", "approve")
+	decisionReq := httptest.NewRequest("POST", "/cli/auth/decision", strings.NewReader(form.Encode()))
+	decisionReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	decisionReq.AddCookie(&http.Cookie{Name: SessionCookieName, Value: sessToken})
+	decisionW := httptest.NewRecorder()
+	h.handleDeviceDecision(decisionW, decisionReq)
+	if decisionW.Code != http.StatusOK {
+		t.Fatalf("decision: status %d, body %s", decisionW.Code, decisionW.Body.String())
+	}
+	if !strings.Contains(decisionW.Body.String(), "Approved") {
+		t.Errorf("expected approval HTML, got: %s", decisionW.Body.String())
+	}
+
+	// Wait long enough that the poll-rate limit doesn't trigger.
+	time.Sleep(devicePollMinInterval + 100*time.Millisecond)
+
+	// Poll → 200 with token.
+	pollReq := httptest.NewRequest("POST", "/cli/auth/device/token",
+		bytes.NewReader([]byte(`{"device_code":"`+ds.DeviceCode+`"}`)))
+	pollReq.Header.Set("Content-Type", "application/json")
+	pollW := httptest.NewRecorder()
+	h.handleDevicePoll(pollW, pollReq)
+	if pollW.Code != http.StatusOK {
+		t.Fatalf("approved poll: status %d, body %s", pollW.Code, pollW.Body.String())
+	}
+
+	var success struct {
+		SessionToken string `json:"session_token"`
+		Username     string `json:"username"`
+	}
+	if err := json.NewDecoder(pollW.Body).Decode(&success); err != nil {
+		t.Fatalf("decoding success: %v", err)
+	}
+	if !strings.HasPrefix(success.SessionToken, "ghpr_") {
+		t.Errorf("session_token = %q, want ghpr_ prefix", success.SessionToken)
+	}
+	if success.Username != "alice" {
+		t.Errorf("username = %q, want alice", success.Username)
+	}
+
+	// Token can be used to look up a session.
+	if h.lookupSession(success.SessionToken) == nil {
+		t.Error("issued token did not resolve to an active session")
+	}
+
+	// Polling again must fail (record consumed).
+	time.Sleep(devicePollMinInterval + 100*time.Millisecond)
+	pollReq2 := httptest.NewRequest("POST", "/cli/auth/device/token",
+		bytes.NewReader([]byte(`{"device_code":"`+ds.DeviceCode+`"}`)))
+	pollReq2.Header.Set("Content-Type", "application/json")
+	pollW2 := httptest.NewRecorder()
+	h.handleDevicePoll(pollW2, pollReq2)
+	if pollW2.Code != http.StatusBadRequest {
+		t.Errorf("re-poll after approval: got %d, want 400", pollW2.Code)
+	}
+}
+
+// TestDevicePoll_Denied verifies that a denied decision is reported as
+// access_denied to the CLI.
+func TestDevicePoll_Denied(t *testing.T) {
+	cfg := &config.Config{}
+	h := NewHandler(cfg, nil, nil, slog.Default())
+
+	startW := httptest.NewRecorder()
+	h.handleDeviceStart(startW, httptest.NewRequest("POST", "/cli/auth/device", nil))
+	var ds deviceStartTestResponse
+	json.NewDecoder(startW.Body).Decode(&ds)
+
+	sessToken := h.createSession("user-1", "alice", "user")
+	form := url.Values{}
+	form.Set("user_code", ds.UserCode)
+	form.Set("action", "deny")
+	dr := httptest.NewRequest("POST", "/cli/auth/decision", strings.NewReader(form.Encode()))
+	dr.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	dr.AddCookie(&http.Cookie{Name: SessionCookieName, Value: sessToken})
+	h.handleDeviceDecision(httptest.NewRecorder(), dr)
+
+	time.Sleep(devicePollMinInterval + 100*time.Millisecond)
+	if got := pollDeviceTokenAndExpect(t, h, ds.DeviceCode); got != "access_denied" {
+		t.Errorf("got %q, want access_denied", got)
+	}
+}
+
+// TestDevicePoll_SlowDown verifies that polling faster than the minimum
+// interval returns slow_down.
+func TestDevicePoll_SlowDown(t *testing.T) {
+	cfg := &config.Config{}
+	h := NewHandler(cfg, nil, nil, slog.Default())
+
+	startW := httptest.NewRecorder()
+	h.handleDeviceStart(startW, httptest.NewRequest("POST", "/cli/auth/device", nil))
+	var ds deviceStartTestResponse
+	json.NewDecoder(startW.Body).Decode(&ds)
+
+	// First poll → authorization_pending.
+	if got := pollDeviceTokenAndExpect(t, h, ds.DeviceCode); got != "authorization_pending" {
+		t.Fatalf("first poll: got %q", got)
+	}
+	// Immediate second poll → slow_down.
+	if got := pollDeviceTokenAndExpect(t, h, ds.DeviceCode); got != "slow_down" {
+		t.Errorf("rapid second poll: got %q, want slow_down", got)
+	}
+}
+
+// TestDevicePoll_UnknownCode verifies that polling with a never-issued
+// device_code returns expired_token (we deliberately conflate "expired" and
+// "never existed" — see handler comment).
+func TestDevicePoll_UnknownCode(t *testing.T) {
+	cfg := &config.Config{}
+	h := NewHandler(cfg, nil, nil, slog.Default())
+	if got := pollDeviceTokenAndExpect(t, h, "deadbeef-not-a-real-code"); got != "expired_token" {
+		t.Errorf("got %q, want expired_token", got)
+	}
+}
+
+// TestDevicePoll_InvalidRequest verifies that a malformed body returns
+// invalid_request.
+func TestDevicePoll_InvalidRequest(t *testing.T) {
+	cfg := &config.Config{}
+	h := NewHandler(cfg, nil, nil, slog.Default())
+
+	req := httptest.NewRequest("POST", "/cli/auth/device/token", strings.NewReader("not json"))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	h.handleDevicePoll(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status %d", w.Code)
+	}
+	var er struct {
+		Error string `json:"error"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &er); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if er.Error != "invalid_request" {
+		t.Errorf("error = %q, want invalid_request", er.Error)
+	}
+}
+
+// TestDeviceVerify_RedirectsWhenLoggedOut ensures the verification page sends
+// unauthenticated browsers to GitHub login with a return_to back to here.
+func TestDeviceVerify_RedirectsWhenLoggedOut(t *testing.T) {
+	cfg := &config.Config{}
+	h := NewHandler(cfg, nil, nil, slog.Default())
+
+	req := httptest.NewRequest("GET", "/cli/auth?user_code=ABCD-EFGH", nil)
+	w := httptest.NewRecorder()
+	h.handleDeviceVerify(w, req)
+	if w.Code != http.StatusSeeOther {
+		t.Fatalf("expected 303 redirect, got %d", w.Code)
+	}
+	loc := w.Header().Get("Location")
+	if !strings.HasPrefix(loc, "/auth/github?return_to=") {
+		t.Errorf("Location = %q", loc)
+	}
+	// The return_to must round-trip the user_code.
+	u, err := url.Parse(loc)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rt := u.Query().Get("return_to")
+	if !strings.Contains(rt, "user_code=ABCD-EFGH") {
+		t.Errorf("return_to = %q, want to include user_code", rt)
+	}
+}
+
+// TestDeviceVerify_RendersFormForKnownCode verifies the approve/deny page is
+// rendered when a logged-in user visits with a valid user_code.
+func TestDeviceVerify_RendersFormForKnownCode(t *testing.T) {
+	cfg := &config.Config{}
+	h := NewHandler(cfg, nil, nil, slog.Default())
+
+	startW := httptest.NewRecorder()
+	h.handleDeviceStart(startW, httptest.NewRequest("POST", "/cli/auth/device", nil))
+	var ds deviceStartTestResponse
+	json.NewDecoder(startW.Body).Decode(&ds)
+
+	sessToken := h.createSession("user-1", "alice", "user")
+	req := httptest.NewRequest("GET", "/cli/auth?user_code="+url.QueryEscape(ds.UserCode), nil)
+	req.AddCookie(&http.Cookie{Name: SessionCookieName, Value: sessToken})
+	w := httptest.NewRecorder()
+	h.handleDeviceVerify(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status %d", w.Code)
+	}
+	body := w.Body.String()
+	if !strings.Contains(body, ds.UserCode) {
+		t.Errorf("page should display user_code")
+	}
+	if !strings.Contains(body, "Authorize") || !strings.Contains(body, "Deny") {
+		t.Errorf("page should have Authorize/Deny buttons; body: %s", body)
+	}
+	if !strings.Contains(body, "alice") {
+		t.Errorf("page should mention the user; body: %s", body)
+	}
+}
+
+// TestDeviceVerify_UnknownCode shows an error message when the user_code is
+// invalid or expired (rather than redirecting back to login).
+func TestDeviceVerify_UnknownCode(t *testing.T) {
+	cfg := &config.Config{}
+	h := NewHandler(cfg, nil, nil, slog.Default())
+
+	sessToken := h.createSession("user-1", "alice", "user")
+	req := httptest.NewRequest("GET", "/cli/auth?user_code=ZZZZ-ZZZZ", nil)
+	req.AddCookie(&http.Cookie{Name: SessionCookieName, Value: sessToken})
+	w := httptest.NewRecorder()
+	h.handleDeviceVerify(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status %d", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "invalid or has expired") {
+		t.Errorf("expected error message in body, got: %s", w.Body.String())
+	}
+}
+
+// TestDeviceDecision_RequiresSession ensures the approval endpoint refuses
+// unauthenticated POSTs.
+func TestDeviceDecision_RequiresSession(t *testing.T) {
+	cfg := &config.Config{}
+	h := NewHandler(cfg, nil, nil, slog.Default())
+
+	form := url.Values{}
+	form.Set("user_code", "ABCD-EFGH")
+	form.Set("action", "approve")
+	req := httptest.NewRequest("POST", "/cli/auth/decision", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	w := httptest.NewRecorder()
+	h.handleDeviceDecision(w, req)
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("expected 401, got %d", w.Code)
+	}
+}
+
+// TestSanitizeReturnTo blocks non-local and protocol-relative return_to values.
+func TestSanitizeReturnTo(t *testing.T) {
+	tests := []struct {
+		in, want string
+	}{
+		{"", ""},
+		{"/cli/auth", "/cli/auth"},
+		{"/cli/auth?user_code=X", "/cli/auth?user_code=X"},
+		{"https://evil.example.com/", ""},
+		{"//evil.example.com", ""},
+		{"/\\evil.example.com", ""},
+		{"javascript:alert(1)", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.in, func(t *testing.T) {
+			if got := sanitizeReturnTo(tt.in); got != tt.want {
+				t.Errorf("sanitizeReturnTo(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestNormaliseUserCode handles a few common user-input variants.
+func TestNormaliseUserCode(t *testing.T) {
+	tests := []struct {
+		in, want string
+	}{
+		{"abcd-efgh", "ABCD-EFGH"},
+		{"  ABCD-EFGH  ", "ABCD-EFGH"},
+		{"ABCDEFGH", "ABCD-EFGH"},
+		{"abcd efgh", "ABCD-EFGH"},
+		{"", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.in, func(t *testing.T) {
+			if got := normaliseUserCode(tt.in); got != tt.want {
+				t.Errorf("normaliseUserCode(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestGitHubLogin_HonoursReturnTo verifies that ?return_to=<path> on
+// /auth/github causes the post-callback redirect to land on that path
+// instead of "/".
+func TestGitHubLogin_HonoursReturnTo(t *testing.T) {
+	cfg := &config.Config{
+		GitHub: config.GitHubConfig{ClientID: "id"},
+		Server: config.ServerConfig{BaseURL: "https://proxy.example.com"},
+	}
+	h := NewHandler(cfg, nil, nil, slog.Default())
+
+	req := httptest.NewRequest("GET", "/auth/github?return_to=/cli/auth?user_code=ABCD-EFGH", nil)
+	w := httptest.NewRecorder()
+	h.handleGitHubLogin(w, req)
+
+	if w.Code != http.StatusTemporaryRedirect {
+		t.Fatalf("expected 307, got %d", w.Code)
+	}
+	loc, _ := url.Parse(w.Header().Get("Location"))
+	state := loc.Query().Get("state")
+	if state == "" {
+		t.Fatal("missing state")
+	}
+
+	// The states LRU should now hold the return_to value.
+	got, ok := h.states.Get(state)
+	if !ok {
+		t.Fatal("state not stored")
+	}
+	if got != "/cli/auth?user_code=ABCD-EFGH" {
+		t.Errorf("stored return_to = %q", got)
+	}
+}
+
+// TestGitHubLogin_ReturnToIsValidated verifies that a hostile return_to is
+// dropped (sanitizeReturnTo returns "") and the LRU stores empty.
+func TestGitHubLogin_ReturnToIsValidated(t *testing.T) {
+	cfg := &config.Config{
+		GitHub: config.GitHubConfig{ClientID: "id"},
+		Server: config.ServerConfig{BaseURL: "https://proxy.example.com"},
+	}
+	h := NewHandler(cfg, nil, nil, slog.Default())
+
+	req := httptest.NewRequest("GET", "/auth/github?return_to=https://evil.example.com/x", nil)
+	w := httptest.NewRecorder()
+	h.handleGitHubLogin(w, req)
+
+	loc, _ := url.Parse(w.Header().Get("Location"))
+	state := loc.Query().Get("state")
+	got, _ := h.states.Get(state)
+	if got != "" {
+		t.Errorf("stored return_to = %q, want empty", got)
+	}
+}
+
+// pollDeviceTokenAndExpect makes a single POST /cli/auth/device/token call
+// and returns the "error" field from the response body. It fails the test
+// on transport-level errors.
+func pollDeviceTokenAndExpect(t *testing.T, h *Handler, deviceCode string) string {
+	t.Helper()
+	body, _ := json.Marshal(map[string]string{"device_code": deviceCode})
+	req := httptest.NewRequest("POST", "/cli/auth/device/token", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	h.handleDevicePoll(w, req)
+
+	if w.Code == http.StatusOK {
+		t.Fatalf("expected error response, got 200: %s", w.Body.String())
+	}
+	var er struct {
+		Error string `json:"error"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &er); err != nil {
+		raw, _ := io.ReadAll(w.Body)
+		t.Fatalf("decoding error response: %v (body: %s)", err, raw)
+	}
+	return er.Error
+}

--- a/internal/auth/device_test.go
+++ b/internal/auth/device_test.go
@@ -181,7 +181,8 @@ func TestDevicePoll_Denied(t *testing.T) {
 }
 
 // TestDevicePoll_SlowDown verifies that polling faster than the minimum
-// interval returns slow_down.
+// interval returns slow_down, and that each rejected poll bumps the
+// rate-limit window forward so a tight loop keeps being slow_down'd.
 func TestDevicePoll_SlowDown(t *testing.T) {
 	cfg := &config.Config{}
 	h := NewHandler(cfg, newTestStore(t), nil, slog.Default())
@@ -198,6 +199,25 @@ func TestDevicePoll_SlowDown(t *testing.T) {
 	// Immediate second poll → slow_down.
 	if got := pollDeviceTokenAndExpect(t, h, ds.DeviceCode); got != "slow_down" {
 		t.Errorf("rapid second poll: got %q, want slow_down", got)
+	}
+	// The slow_down response must itself update LastPolledAt; otherwise a
+	// misbehaving client could spam the endpoint without ever advancing
+	// the rate-limit window. Verify by reading the row directly.
+	da, err := h.store.GetDeviceAuthByDeviceCode(context.Background(), ds.DeviceCode)
+	if err != nil {
+		t.Fatalf("GetDeviceAuthByDeviceCode: %v", err)
+	}
+	if da.LastPolledAt == nil {
+		t.Fatal("expected LastPolledAt to be set after slow_down")
+	}
+	prev := *da.LastPolledAt
+	// Third poll: still slow_down, LastPolledAt must move forward.
+	if got := pollDeviceTokenAndExpect(t, h, ds.DeviceCode); got != "slow_down" {
+		t.Errorf("third poll: got %q, want slow_down", got)
+	}
+	da2, _ := h.store.GetDeviceAuthByDeviceCode(context.Background(), ds.DeviceCode)
+	if da2.LastPolledAt == nil || !da2.LastPolledAt.After(prev) {
+		t.Errorf("LastPolledAt should advance on every slow_down: prev=%v new=%v", prev, da2.LastPolledAt)
 	}
 }
 
@@ -351,6 +371,32 @@ func TestSanitizeReturnTo(t *testing.T) {
 				t.Errorf("sanitizeReturnTo(%q) = %q, want %q", tt.in, got, tt.want)
 			}
 		})
+	}
+}
+
+// TestForwardedField parses RFC 7239 Forwarded header values for the
+// scheme/host fallback used when server.base_url is not configured.
+func TestForwardedField(t *testing.T) {
+	tests := []struct {
+		header, name, want string
+	}{
+		{"", "proto", ""},
+		{"proto=https", "proto", "https"},
+		{"for=10.0.0.1;proto=https;host=ghp.example.com", "host", "ghp.example.com"},
+		{"for=10.0.0.1;proto=https;host=ghp.example.com", "proto", "https"},
+		{`proto="https"`, "proto", "https"},
+		// Only the first forwarded element is used.
+		{"proto=https, proto=http", "proto", "https"},
+		// Case-insensitive field name matching.
+		{"Proto=https", "proto", "https"},
+		// Missing field returns empty.
+		{"for=10.0.0.1", "proto", ""},
+	}
+	for _, tt := range tests {
+		got := forwardedField(tt.header, tt.name)
+		if got != tt.want {
+			t.Errorf("forwardedField(%q, %q) = %q, want %q", tt.header, tt.name, got, tt.want)
+		}
 	}
 }
 

--- a/internal/auth/device_test.go
+++ b/internal/auth/device_test.go
@@ -347,21 +347,31 @@ func TestDeviceDecision_RequiresSession(t *testing.T) {
 	}
 }
 
-// TestSanitizeReturnTo blocks non-local and protocol-relative return_to values.
+// TestSanitizeReturnTo blocks non-local, protocol-relative, and
+// control-character-bearing return_to values.
 func TestSanitizeReturnTo(t *testing.T) {
 	tests := []struct {
-		in, want string
+		name, in, want string
 	}{
-		{"", ""},
-		{"/cli/auth", "/cli/auth"},
-		{"/cli/auth?user_code=X", "/cli/auth?user_code=X"},
-		{"https://evil.example.com/", ""},
-		{"//evil.example.com", ""},
-		{"/\\evil.example.com", ""},
-		{"javascript:alert(1)", ""},
+		{"empty", "", ""},
+		{"local path", "/cli/auth", "/cli/auth"},
+		{"local path with query", "/cli/auth?user_code=X", "/cli/auth?user_code=X"},
+		{"absolute https url", "https://evil.example.com/", ""},
+		{"protocol-relative", "//evil.example.com", ""},
+		{"path-with-backslash", "/\\evil.example.com", ""},
+		{"javascript scheme", "javascript:alert(1)", ""},
+		// Control characters in the path/query would otherwise reach the
+		// Location header verbatim and risk response-splitting on lenient
+		// clients/proxies.
+		{"crlf injection", "/cli/auth\r\nSet-Cookie: x=y", ""},
+		{"bare lf", "/cli/auth\nfoo", ""},
+		{"bare cr", "/cli/auth\rfoo", ""},
+		{"null byte", "/cli/auth\x00", ""},
+		{"tab", "/cli/auth\t", ""},
+		{"del", "/cli/auth\x7f", ""},
 	}
 	for _, tt := range tests {
-		t.Run(tt.in, func(t *testing.T) {
+		t.Run(tt.name, func(t *testing.T) {
 			if got := sanitizeReturnTo(tt.in); got != tt.want {
 				t.Errorf("sanitizeReturnTo(%q) = %q, want %q", tt.in, got, tt.want)
 			}

--- a/internal/auth/device_test.go
+++ b/internal/auth/device_test.go
@@ -73,13 +73,7 @@ func TestDevicePoll_PendingThenApproved(t *testing.T) {
 	h := NewHandler(cfg, newTestStore(t), nil, slog.Default())
 
 	// Start.
-	startReq := httptest.NewRequest("POST", "/cli/auth/device", nil)
-	startW := httptest.NewRecorder()
-	h.handleDeviceStart(startW, startReq)
-	var ds deviceStartTestResponse
-	if err := json.NewDecoder(startW.Body).Decode(&ds); err != nil {
-		t.Fatalf("decode start: %v", err)
-	}
+	ds := runDeviceStart(t, h)
 
 	// Poll while pending → 400 authorization_pending.
 	if got := pollDeviceTokenAndExpect(t, h, ds.DeviceCode); got != "authorization_pending" {
@@ -156,10 +150,7 @@ func TestDevicePoll_Denied(t *testing.T) {
 	cfg := &config.Config{}
 	h := NewHandler(cfg, newTestStore(t), nil, slog.Default())
 
-	startW := httptest.NewRecorder()
-	h.handleDeviceStart(startW, httptest.NewRequest("POST", "/cli/auth/device", nil))
-	var ds deviceStartTestResponse
-	json.NewDecoder(startW.Body).Decode(&ds)
+	ds := runDeviceStart(t, h)
 
 	sessToken := mustCreateSession(t, h, "user-1", "alice", "user")
 	form := url.Values{}
@@ -187,10 +178,7 @@ func TestDevicePoll_SlowDown(t *testing.T) {
 	cfg := &config.Config{}
 	h := NewHandler(cfg, newTestStore(t), nil, slog.Default())
 
-	startW := httptest.NewRecorder()
-	h.handleDeviceStart(startW, httptest.NewRequest("POST", "/cli/auth/device", nil))
-	var ds deviceStartTestResponse
-	json.NewDecoder(startW.Body).Decode(&ds)
+	ds := runDeviceStart(t, h)
 
 	// First poll → authorization_pending.
 	if got := pollDeviceTokenAndExpect(t, h, ds.DeviceCode); got != "authorization_pending" {
@@ -299,10 +287,7 @@ func TestDeviceVerify_RendersFormForKnownCode(t *testing.T) {
 	cfg := &config.Config{}
 	h := NewHandler(cfg, newTestStore(t), nil, slog.Default())
 
-	startW := httptest.NewRecorder()
-	h.handleDeviceStart(startW, httptest.NewRequest("POST", "/cli/auth/device", nil))
-	var ds deviceStartTestResponse
-	json.NewDecoder(startW.Body).Decode(&ds)
+	ds := runDeviceStart(t, h)
 
 	sessToken := mustCreateSession(t, h, "user-1", "alice", "user")
 	req := httptest.NewRequest("GET", "/cli/auth?user_code="+url.QueryEscape(ds.UserCode), nil)
@@ -486,6 +471,24 @@ func TestGitHubLogin_ReturnToIsValidated(t *testing.T) {
 	if got.ReturnTo != "" {
 		t.Errorf("stored return_to = %q, want empty", got.ReturnTo)
 	}
+}
+
+// runDeviceStart issues POST /cli/auth/device against h, asserts a 200
+// response, decodes the body, and returns the parsed start response. A
+// failure here surfaces immediately at its source rather than as a chain
+// of "field is empty" assertions later in the calling test.
+func runDeviceStart(t *testing.T, h *Handler) deviceStartTestResponse {
+	t.Helper()
+	startW := httptest.NewRecorder()
+	h.handleDeviceStart(startW, httptest.NewRequest("POST", "/cli/auth/device", nil))
+	if startW.Code != http.StatusOK {
+		t.Fatalf("handleDeviceStart: status %d, body %s", startW.Code, startW.Body.String())
+	}
+	var ds deviceStartTestResponse
+	if err := json.NewDecoder(startW.Body).Decode(&ds); err != nil {
+		t.Fatalf("decoding device-start response: %v", err)
+	}
+	return ds
 }
 
 // mustCreateSession is a test helper that mints a session and fails the

--- a/internal/auth/device_test.go
+++ b/internal/auth/device_test.go
@@ -2,6 +2,7 @@ package auth
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"io"
 	"log/slog"
@@ -13,6 +14,7 @@ import (
 	"time"
 
 	"github.com/goodtune/ghp/internal/config"
+	"github.com/goodtune/ghp/internal/database"
 )
 
 // TestDeviceStart_ReturnsCodes verifies POST /cli/auth/device returns the
@@ -21,7 +23,7 @@ func TestDeviceStart_ReturnsCodes(t *testing.T) {
 	cfg := &config.Config{
 		Server: config.ServerConfig{BaseURL: "https://proxy.example.com"},
 	}
-	h := NewHandler(cfg, nil, nil, slog.Default())
+	h := NewHandler(cfg, newTestStore(t), nil, slog.Default())
 
 	req := httptest.NewRequest("POST", "/cli/auth/device", nil)
 	w := httptest.NewRecorder()
@@ -68,7 +70,7 @@ type deviceStartTestResponse struct {
 // poll-pending, decision=approve, poll-success.
 func TestDevicePoll_PendingThenApproved(t *testing.T) {
 	cfg := &config.Config{}
-	h := NewHandler(cfg, nil, nil, slog.Default())
+	h := NewHandler(cfg, newTestStore(t), nil, slog.Default())
 
 	// Start.
 	startReq := httptest.NewRequest("POST", "/cli/auth/device", nil)
@@ -86,7 +88,7 @@ func TestDevicePoll_PendingThenApproved(t *testing.T) {
 
 	// Now simulate the user approving via the verification page. We need a
 	// session for the decision handler.
-	sessToken := h.createSession("user-1", "alice", "user")
+	sessToken := mustCreateSession(t, h, "user-1", "alice", "user")
 	form := url.Values{}
 	form.Set("user_code", ds.UserCode)
 	form.Set("action", "approve")
@@ -130,7 +132,7 @@ func TestDevicePoll_PendingThenApproved(t *testing.T) {
 	}
 
 	// Token can be used to look up a session.
-	if h.lookupSession(success.SessionToken) == nil {
+	if h.lookupSession(context.Background(), success.SessionToken) == nil {
 		t.Error("issued token did not resolve to an active session")
 	}
 
@@ -150,14 +152,14 @@ func TestDevicePoll_PendingThenApproved(t *testing.T) {
 // access_denied to the CLI.
 func TestDevicePoll_Denied(t *testing.T) {
 	cfg := &config.Config{}
-	h := NewHandler(cfg, nil, nil, slog.Default())
+	h := NewHandler(cfg, newTestStore(t), nil, slog.Default())
 
 	startW := httptest.NewRecorder()
 	h.handleDeviceStart(startW, httptest.NewRequest("POST", "/cli/auth/device", nil))
 	var ds deviceStartTestResponse
 	json.NewDecoder(startW.Body).Decode(&ds)
 
-	sessToken := h.createSession("user-1", "alice", "user")
+	sessToken := mustCreateSession(t, h, "user-1", "alice", "user")
 	form := url.Values{}
 	form.Set("user_code", ds.UserCode)
 	form.Set("action", "deny")
@@ -176,7 +178,7 @@ func TestDevicePoll_Denied(t *testing.T) {
 // interval returns slow_down.
 func TestDevicePoll_SlowDown(t *testing.T) {
 	cfg := &config.Config{}
-	h := NewHandler(cfg, nil, nil, slog.Default())
+	h := NewHandler(cfg, newTestStore(t), nil, slog.Default())
 
 	startW := httptest.NewRecorder()
 	h.handleDeviceStart(startW, httptest.NewRequest("POST", "/cli/auth/device", nil))
@@ -198,7 +200,7 @@ func TestDevicePoll_SlowDown(t *testing.T) {
 // "never existed" — see handler comment).
 func TestDevicePoll_UnknownCode(t *testing.T) {
 	cfg := &config.Config{}
-	h := NewHandler(cfg, nil, nil, slog.Default())
+	h := NewHandler(cfg, newTestStore(t), nil, slog.Default())
 	if got := pollDeviceTokenAndExpect(t, h, "deadbeef-not-a-real-code"); got != "expired_token" {
 		t.Errorf("got %q, want expired_token", got)
 	}
@@ -208,7 +210,7 @@ func TestDevicePoll_UnknownCode(t *testing.T) {
 // invalid_request.
 func TestDevicePoll_InvalidRequest(t *testing.T) {
 	cfg := &config.Config{}
-	h := NewHandler(cfg, nil, nil, slog.Default())
+	h := NewHandler(cfg, newTestStore(t), nil, slog.Default())
 
 	req := httptest.NewRequest("POST", "/cli/auth/device/token", strings.NewReader("not json"))
 	req.Header.Set("Content-Type", "application/json")
@@ -232,7 +234,7 @@ func TestDevicePoll_InvalidRequest(t *testing.T) {
 // unauthenticated browsers to GitHub login with a return_to back to here.
 func TestDeviceVerify_RedirectsWhenLoggedOut(t *testing.T) {
 	cfg := &config.Config{}
-	h := NewHandler(cfg, nil, nil, slog.Default())
+	h := NewHandler(cfg, newTestStore(t), nil, slog.Default())
 
 	req := httptest.NewRequest("GET", "/cli/auth?user_code=ABCD-EFGH", nil)
 	w := httptest.NewRecorder()
@@ -259,14 +261,14 @@ func TestDeviceVerify_RedirectsWhenLoggedOut(t *testing.T) {
 // rendered when a logged-in user visits with a valid user_code.
 func TestDeviceVerify_RendersFormForKnownCode(t *testing.T) {
 	cfg := &config.Config{}
-	h := NewHandler(cfg, nil, nil, slog.Default())
+	h := NewHandler(cfg, newTestStore(t), nil, slog.Default())
 
 	startW := httptest.NewRecorder()
 	h.handleDeviceStart(startW, httptest.NewRequest("POST", "/cli/auth/device", nil))
 	var ds deviceStartTestResponse
 	json.NewDecoder(startW.Body).Decode(&ds)
 
-	sessToken := h.createSession("user-1", "alice", "user")
+	sessToken := mustCreateSession(t, h, "user-1", "alice", "user")
 	req := httptest.NewRequest("GET", "/cli/auth?user_code="+url.QueryEscape(ds.UserCode), nil)
 	req.AddCookie(&http.Cookie{Name: SessionCookieName, Value: sessToken})
 	w := httptest.NewRecorder()
@@ -290,9 +292,9 @@ func TestDeviceVerify_RendersFormForKnownCode(t *testing.T) {
 // invalid or expired (rather than redirecting back to login).
 func TestDeviceVerify_UnknownCode(t *testing.T) {
 	cfg := &config.Config{}
-	h := NewHandler(cfg, nil, nil, slog.Default())
+	h := NewHandler(cfg, newTestStore(t), nil, slog.Default())
 
-	sessToken := h.createSession("user-1", "alice", "user")
+	sessToken := mustCreateSession(t, h, "user-1", "alice", "user")
 	req := httptest.NewRequest("GET", "/cli/auth?user_code=ZZZZ-ZZZZ", nil)
 	req.AddCookie(&http.Cookie{Name: SessionCookieName, Value: sessToken})
 	w := httptest.NewRecorder()
@@ -310,7 +312,7 @@ func TestDeviceVerify_UnknownCode(t *testing.T) {
 // unauthenticated POSTs.
 func TestDeviceDecision_RequiresSession(t *testing.T) {
 	cfg := &config.Config{}
-	h := NewHandler(cfg, nil, nil, slog.Default())
+	h := NewHandler(cfg, newTestStore(t), nil, slog.Default())
 
 	form := url.Values{}
 	form.Set("user_code", "ABCD-EFGH")
@@ -374,7 +376,7 @@ func TestGitHubLogin_HonoursReturnTo(t *testing.T) {
 		GitHub: config.GitHubConfig{ClientID: "id"},
 		Server: config.ServerConfig{BaseURL: "https://proxy.example.com"},
 	}
-	h := NewHandler(cfg, nil, nil, slog.Default())
+	h := NewHandler(cfg, newTestStore(t), nil, slog.Default())
 
 	req := httptest.NewRequest("GET", "/auth/github?return_to=/cli/auth?user_code=ABCD-EFGH", nil)
 	w := httptest.NewRecorder()
@@ -389,24 +391,25 @@ func TestGitHubLogin_HonoursReturnTo(t *testing.T) {
 		t.Fatal("missing state")
 	}
 
-	// The states LRU should now hold the return_to value.
-	got, ok := h.states.Get(state)
-	if !ok {
-		t.Fatal("state not stored")
+	// The state row should now hold the return_to value. ConsumeOAuthState
+	// also deletes it; that's fine for the test's single read.
+	got, err := h.store.ConsumeOAuthState(req.Context(), state, database.OAuthStateKindLogin)
+	if err != nil {
+		t.Fatalf("state not stored: %v", err)
 	}
-	if got != "/cli/auth?user_code=ABCD-EFGH" {
-		t.Errorf("stored return_to = %q", got)
+	if got.ReturnTo != "/cli/auth?user_code=ABCD-EFGH" {
+		t.Errorf("stored return_to = %q", got.ReturnTo)
 	}
 }
 
 // TestGitHubLogin_ReturnToIsValidated verifies that a hostile return_to is
-// dropped (sanitizeReturnTo returns "") and the LRU stores empty.
+// dropped (sanitizeReturnTo returns "").
 func TestGitHubLogin_ReturnToIsValidated(t *testing.T) {
 	cfg := &config.Config{
 		GitHub: config.GitHubConfig{ClientID: "id"},
 		Server: config.ServerConfig{BaseURL: "https://proxy.example.com"},
 	}
-	h := NewHandler(cfg, nil, nil, slog.Default())
+	h := NewHandler(cfg, newTestStore(t), nil, slog.Default())
 
 	req := httptest.NewRequest("GET", "/auth/github?return_to=https://evil.example.com/x", nil)
 	w := httptest.NewRecorder()
@@ -414,10 +417,25 @@ func TestGitHubLogin_ReturnToIsValidated(t *testing.T) {
 
 	loc, _ := url.Parse(w.Header().Get("Location"))
 	state := loc.Query().Get("state")
-	got, _ := h.states.Get(state)
-	if got != "" {
-		t.Errorf("stored return_to = %q, want empty", got)
+	got, err := h.store.ConsumeOAuthState(req.Context(), state, database.OAuthStateKindLogin)
+	if err != nil {
+		t.Fatalf("state not stored: %v", err)
 	}
+	if got.ReturnTo != "" {
+		t.Errorf("stored return_to = %q, want empty", got.ReturnTo)
+	}
+}
+
+// mustCreateSession is a test helper that mints a session and fails the
+// test on store error. Used in place of the old LRU-backed createSession
+// which returned a single value.
+func mustCreateSession(t *testing.T, h *Handler, userID, username, role string) string {
+	t.Helper()
+	tok, err := h.createSession(context.Background(), userID, username, role)
+	if err != nil {
+		t.Fatalf("createSession: %v", err)
+	}
+	return tok
 }
 
 // pollDeviceTokenAndExpect makes a single POST /cli/auth/device/token call

--- a/internal/auth/device_test.go
+++ b/internal/auth/device_test.go
@@ -210,14 +210,24 @@ func TestDevicePoll_SlowDown(t *testing.T) {
 	if da.LastPolledAt == nil {
 		t.Fatal("expected LastPolledAt to be set after slow_down")
 	}
-	prev := *da.LastPolledAt
-	// Third poll: still slow_down, LastPolledAt must move forward.
-	if got := pollDeviceTokenAndExpect(t, h, ds.DeviceCode); got != "slow_down" {
-		t.Errorf("third poll: got %q, want slow_down", got)
+	// Backdate the row so we can verify the next slow_down really did
+	// re-write LastPolledAt (rather than just observing two polls hitting
+	// the same wall-clock millisecond, which the millisecond-precision
+	// storage format would render indistinguishable).
+	bumped := time.Now().Add(-time.Hour).UTC()
+	da.LastPolledAt = &bumped
+	if err := h.store.UpdateDeviceAuth(context.Background(), da); err != nil {
+		t.Fatalf("seed LastPolledAt: %v", err)
+	}
+	// Third poll: still slow_down (we backdated, so it's now > minInterval
+	// since the seeded LastPolledAt and the request advances the window
+	// anyway — the assertion is that the row got re-written).
+	if got := pollDeviceTokenAndExpect(t, h, ds.DeviceCode); got != "authorization_pending" && got != "slow_down" {
+		t.Errorf("third poll: got %q, want slow_down or authorization_pending", got)
 	}
 	da2, _ := h.store.GetDeviceAuthByDeviceCode(context.Background(), ds.DeviceCode)
-	if da2.LastPolledAt == nil || !da2.LastPolledAt.After(prev) {
-		t.Errorf("LastPolledAt should advance on every slow_down: prev=%v new=%v", prev, da2.LastPolledAt)
+	if da2.LastPolledAt == nil || !da2.LastPolledAt.After(bumped) {
+		t.Errorf("LastPolledAt should advance after another poll: prev=%v new=%v", bumped, da2.LastPolledAt)
 	}
 }
 

--- a/internal/auth/device_test.go
+++ b/internal/auth/device_test.go
@@ -104,8 +104,9 @@ func TestDevicePoll_PendingThenApproved(t *testing.T) {
 		t.Errorf("expected approval HTML, got: %s", decisionW.Body.String())
 	}
 
-	// Wait long enough that the poll-rate limit doesn't trigger.
-	time.Sleep(devicePollMinInterval + 100*time.Millisecond)
+	// The poll-rate limiter is enforced via LastPolledAt on the device row.
+	// Backdate it so the next poll passes without waiting wall-clock time.
+	bumpLastPolledAt(t, h, ds.DeviceCode, -time.Hour)
 
 	// Poll → 200 with token.
 	pollReq := httptest.NewRequest("POST", "/cli/auth/device/token",
@@ -136,8 +137,9 @@ func TestDevicePoll_PendingThenApproved(t *testing.T) {
 		t.Error("issued token did not resolve to an active session")
 	}
 
-	// Polling again must fail (record consumed).
-	time.Sleep(devicePollMinInterval + 100*time.Millisecond)
+	// Polling again must fail (record consumed). The first successful poll
+	// removed the row from the store, so this is a not-found path and the
+	// rate-limit timer is irrelevant.
 	pollReq2 := httptest.NewRequest("POST", "/cli/auth/device/token",
 		bytes.NewReader([]byte(`{"device_code":"`+ds.DeviceCode+`"}`)))
 	pollReq2.Header.Set("Content-Type", "application/json")
@@ -168,7 +170,11 @@ func TestDevicePoll_Denied(t *testing.T) {
 	dr.AddCookie(&http.Cookie{Name: SessionCookieName, Value: sessToken})
 	h.handleDeviceDecision(httptest.NewRecorder(), dr)
 
-	time.Sleep(devicePollMinInterval + 100*time.Millisecond)
+	// Backdate LastPolledAt so the rate-limit timer doesn't suppress this
+	// poll (no decision endpoint has run a poll yet, but the start handler
+	// doesn't seed it either, so this is a no-op when LastPolledAt is nil
+	// — included for clarity and consistency with TestDevicePoll_PendingThenApproved).
+	bumpLastPolledAt(t, h, ds.DeviceCode, -time.Hour)
 	if got := pollDeviceTokenAndExpect(t, h, ds.DeviceCode); got != "access_denied" {
 		t.Errorf("got %q, want access_denied", got)
 	}
@@ -436,6 +442,28 @@ func mustCreateSession(t *testing.T, h *Handler, userID, username, role string) 
 		t.Fatalf("createSession: %v", err)
 	}
 	return tok
+}
+
+// bumpLastPolledAt rewrites the device row's LastPolledAt to now+offset.
+// Tests use this to fast-forward past the poll-rate limiter without sleeping
+// real time. A negative offset (e.g. -time.Hour) makes the next poll succeed
+// immediately; a positive offset is rarely needed but supported for symmetry.
+//
+// If the row doesn't exist (which happens after an approved poll deletes it),
+// this is a no-op so callers don't have to special-case the post-consume path.
+func bumpLastPolledAt(t *testing.T, h *Handler, deviceCode string, offset time.Duration) {
+	t.Helper()
+	ctx := context.Background()
+	da, err := h.store.GetDeviceAuthByDeviceCode(ctx, deviceCode)
+	if err != nil {
+		// ErrNotFound is expected for already-consumed rows.
+		return
+	}
+	t1 := time.Now().Add(offset).UTC()
+	da.LastPolledAt = &t1
+	if err := h.store.UpdateDeviceAuth(ctx, da); err != nil {
+		t.Fatalf("bumpLastPolledAt: %v", err)
+	}
 }
 
 // pollDeviceTokenAndExpect makes a single POST /cli/auth/device/token call

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -158,6 +158,17 @@ type ServerConfig struct {
 	ManagementHost          string `koanf:"management_host"`
 	SystemdSocketActivation bool   `koanf:"systemd_socket_activation"`
 	BaseURL                 string `koanf:"base_url"`
+	// TrustProxyHeaders controls whether ghp honours the standardised
+	// Forwarded (RFC 7239) and X-Forwarded-Proto/X-Forwarded-Host headers
+	// when constructing absolute URLs (e.g. the device-auth verification
+	// URI and OAuth callback URLs) and base_url is unset. Set to true only
+	// when ghp sits behind a trusted reverse proxy/L7 LB that strips and
+	// rewrites these headers. Default false: an internet-reachable instance
+	// would otherwise allow a client to spoof scheme/host via these
+	// headers and influence generated URLs (host-header injection). The
+	// preferred deployment pattern is to set base_url explicitly so the
+	// fallback path is never exercised.
+	TrustProxyHeaders bool `koanf:"trust_proxy_headers"`
 }
 
 type TokensConfig struct {

--- a/internal/database/migrations/postgres/010_add_auth_state.down.sql
+++ b/internal/database/migrations/postgres/010_add_auth_state.down.sql
@@ -1,0 +1,3 @@
+DROP TABLE cli_device_authorizations;
+DROP TABLE oauth_states;
+DROP TABLE sessions;

--- a/internal/database/migrations/postgres/010_add_auth_state.up.sql
+++ b/internal/database/migrations/postgres/010_add_auth_state.up.sql
@@ -1,0 +1,62 @@
+-- Persistent storage for ghp's auth state. Previously these were held in
+-- in-memory LRUs in the auth handler, which broke any flow whose round-trips
+-- crossed instances in an HA deployment (browser sessions, OAuth state for
+-- the GitHub login redirect, OAuth broker state, and the CLI device-
+-- authorization records). All four are now backed by the database.
+
+-- Browser/CLI session tokens. The raw bearer (a `ghpr_` prefix + 32 bytes
+-- of randomness) is hashed with SHA-256 before storage so a database
+-- compromise does not yield active session tokens — handlers hash the
+-- presented token on every lookup.
+CREATE TABLE sessions (
+    token_hash TEXT PRIMARY KEY,
+    user_id TEXT NOT NULL,
+    username TEXT NOT NULL,
+    role TEXT NOT NULL,
+    expires_at TIMESTAMPTZ NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+CREATE INDEX sessions_expires_at_idx ON sessions (expires_at);
+CREATE INDEX sessions_user_id_idx ON sessions (user_id);
+
+-- In-flight OAuth state tokens. `kind` distinguishes the main GitHub login
+-- flow ('login') from the OAuth broker flow ('broker'). Each kind has its
+-- own optional payload columns; the unused ones are empty strings. One-time
+-- use: rows are deleted by the consume operation as soon as the matching
+-- callback validates them.
+CREATE TABLE oauth_states (
+    state TEXT PRIMARY KEY,
+    kind TEXT NOT NULL CHECK (kind IN ('login', 'broker')),
+    -- 'login' kind: optional return-to path appended to the post-callback
+    -- redirect target. Empty means the default ("/").
+    return_to TEXT NOT NULL DEFAULT '',
+    -- 'broker' kind: the validated downstream redirect_uri to bounce back to.
+    broker_redirect_uri TEXT NOT NULL DEFAULT '',
+    -- 'broker' kind: the downstream service's own state value, echoed back
+    -- to it so it can match its own request.
+    broker_downstream_state TEXT NOT NULL DEFAULT '',
+    expires_at TIMESTAMPTZ NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+CREATE INDEX oauth_states_expires_at_idx ON oauth_states (expires_at);
+
+-- CLI device-authorization (RFC 8628 shape, against ghp itself).
+CREATE TABLE cli_device_authorizations (
+    -- The long, high-entropy secret the CLI polls with.
+    device_code TEXT PRIMARY KEY,
+    -- The short, human-readable code displayed to the user. Globally unique
+    -- within the active TTL window so the verification page can resolve a
+    -- request from the URL parameter alone.
+    user_code TEXT NOT NULL UNIQUE,
+    status TEXT NOT NULL CHECK (status IN ('pending', 'approved', 'denied')),
+    -- Populated once status transitions to 'approved'. The CLI receives
+    -- this on its next successful poll, after which the row is deleted.
+    session_token TEXT,
+    username TEXT,
+    -- Updated on every poll to enforce the minimum poll interval.
+    last_polled_at TIMESTAMPTZ,
+    expires_at TIMESTAMPTZ NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+CREATE INDEX cli_device_authorizations_user_code_idx ON cli_device_authorizations (user_code);
+CREATE INDEX cli_device_authorizations_expires_at_idx ON cli_device_authorizations (expires_at);

--- a/internal/database/migrations/postgres/010_add_auth_state.up.sql
+++ b/internal/database/migrations/postgres/010_add_auth_state.up.sql
@@ -58,5 +58,6 @@ CREATE TABLE cli_device_authorizations (
     expires_at TIMESTAMPTZ NOT NULL,
     created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
-CREATE INDEX cli_device_authorizations_user_code_idx ON cli_device_authorizations (user_code);
+-- user_code already has an implicit unique index via the UNIQUE column
+-- constraint above; no separate index is needed for verification-page lookups.
 CREATE INDEX cli_device_authorizations_expires_at_idx ON cli_device_authorizations (expires_at);

--- a/internal/database/migrations/sqlite/010_add_auth_state.down.sql
+++ b/internal/database/migrations/sqlite/010_add_auth_state.down.sql
@@ -1,0 +1,3 @@
+DROP TABLE cli_device_authorizations;
+DROP TABLE oauth_states;
+DROP TABLE sessions;

--- a/internal/database/migrations/sqlite/010_add_auth_state.up.sql
+++ b/internal/database/migrations/sqlite/010_add_auth_state.up.sql
@@ -1,0 +1,36 @@
+-- See postgres/010_add_auth_state.up.sql for design rationale.
+
+CREATE TABLE sessions (
+    token_hash TEXT PRIMARY KEY,
+    user_id TEXT NOT NULL,
+    username TEXT NOT NULL,
+    role TEXT NOT NULL,
+    expires_at TEXT NOT NULL,
+    created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+);
+CREATE INDEX sessions_expires_at_idx ON sessions (expires_at);
+CREATE INDEX sessions_user_id_idx ON sessions (user_id);
+
+CREATE TABLE oauth_states (
+    state TEXT PRIMARY KEY,
+    kind TEXT NOT NULL CHECK (kind IN ('login', 'broker')),
+    return_to TEXT NOT NULL DEFAULT '',
+    broker_redirect_uri TEXT NOT NULL DEFAULT '',
+    broker_downstream_state TEXT NOT NULL DEFAULT '',
+    expires_at TEXT NOT NULL,
+    created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+);
+CREATE INDEX oauth_states_expires_at_idx ON oauth_states (expires_at);
+
+CREATE TABLE cli_device_authorizations (
+    device_code TEXT PRIMARY KEY,
+    user_code TEXT NOT NULL UNIQUE,
+    status TEXT NOT NULL CHECK (status IN ('pending', 'approved', 'denied')),
+    session_token TEXT,
+    username TEXT,
+    last_polled_at TEXT,
+    expires_at TEXT NOT NULL,
+    created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+);
+CREATE INDEX cli_device_authorizations_user_code_idx ON cli_device_authorizations (user_code);
+CREATE INDEX cli_device_authorizations_expires_at_idx ON cli_device_authorizations (expires_at);

--- a/internal/database/migrations/sqlite/010_add_auth_state.up.sql
+++ b/internal/database/migrations/sqlite/010_add_auth_state.up.sql
@@ -32,5 +32,6 @@ CREATE TABLE cli_device_authorizations (
     expires_at TEXT NOT NULL,
     created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
 );
-CREATE INDEX cli_device_authorizations_user_code_idx ON cli_device_authorizations (user_code);
+-- user_code already has an implicit unique index via the UNIQUE column
+-- constraint above; no separate index is needed for verification-page lookups.
 CREATE INDEX cli_device_authorizations_expires_at_idx ON cli_device_authorizations (expires_at);

--- a/internal/database/models.go
+++ b/internal/database/models.go
@@ -120,6 +120,68 @@ type CachedRepository struct {
 	UpdatedAt       time.Time `json:"updated_at"`
 }
 
+// Session represents a persisted browser/CLI session. The bearer token
+// presented in the Authorization header (or the ghp_session cookie) is
+// hashed with SHA-256 before being looked up here, so the database never
+// holds raw bearer tokens.
+type Session struct {
+	TokenHash string    `json:"-"`
+	UserID    string    `json:"user_id"`
+	Username  string    `json:"username"`
+	Role      string    `json:"role"`
+	ExpiresAt time.Time `json:"expires_at"`
+	CreatedAt time.Time `json:"created_at"`
+}
+
+// OAuthStateKind identifies which OAuth flow an oauth_states row belongs to.
+const (
+	OAuthStateKindLogin  = "login"
+	OAuthStateKindBroker = "broker"
+)
+
+// OAuthState captures the per-row payload for an in-flight OAuth state. The
+// Kind field selects which payload columns are meaningful: "login" uses
+// ReturnTo; "broker" uses BrokerRedirectURI and BrokerDownstreamState.
+type OAuthState struct {
+	State                 string    `json:"state"`
+	Kind                  string    `json:"kind"`
+	ReturnTo              string    `json:"return_to"`
+	BrokerRedirectURI     string    `json:"broker_redirect_uri"`
+	BrokerDownstreamState string    `json:"broker_downstream_state"`
+	ExpiresAt             time.Time `json:"expires_at"`
+	CreatedAt             time.Time `json:"created_at"`
+}
+
+// DeviceAuthStatusPending, DeviceAuthStatusApproved, DeviceAuthStatusDenied
+// are the lifecycle states of a CLI device-authorization request. The DB
+// CHECK constraint enforces these values; keep them in sync.
+const (
+	DeviceAuthStatusPending  = "pending"
+	DeviceAuthStatusApproved = "approved"
+	DeviceAuthStatusDenied   = "denied"
+)
+
+// DeviceAuth represents an in-flight CLI device-authorization request. It is
+// persisted across the four round-trips that make up the flow (start, poll,
+// browser verify, browser decision) so that the request survives load
+// balancing in HA deployments — every ghp instance reads the same row.
+//
+// Lifecycle:
+//   - created with Status=pending by POST /cli/auth/device
+//   - transitions to approved or denied by POST /cli/auth/decision
+//   - deleted by the polling endpoint once the CLI receives the token, or
+//     by the cleanup goroutine after ExpiresAt passes
+type DeviceAuth struct {
+	DeviceCode   string     `json:"device_code"`
+	UserCode     string     `json:"user_code"`
+	Status       string     `json:"status"`
+	SessionToken string     `json:"session_token,omitempty"`
+	Username     string     `json:"username,omitempty"`
+	LastPolledAt *time.Time `json:"last_polled_at,omitempty"`
+	ExpiresAt    time.Time  `json:"expires_at"`
+	CreatedAt    time.Time  `json:"created_at"`
+}
+
 // Store defines the database operations for ghp.
 type Store interface {
 	// Apps
@@ -175,6 +237,60 @@ type Store interface {
 	ListCachedRepositories(ctx context.Context) ([]*CachedRepository, error)
 	UpdateCachedRepository(ctx context.Context, repo *CachedRepository) error
 	DeleteCachedRepository(ctx context.Context, id string) error
+
+	// Sessions (browser cookie / CLI bearer).
+	//
+	// CreateSession persists a new session keyed by the SHA-256 hash of the
+	// raw bearer token. Callers retain the raw token and present it on
+	// subsequent requests; the DB never holds the unhashed value.
+	CreateSession(ctx context.Context, s *Session) error
+	// GetSessionByTokenHash returns the session for the given hash, or
+	// wrapped ErrNotFound if the hash is unknown or its ExpiresAt has
+	// passed.
+	GetSessionByTokenHash(ctx context.Context, tokenHash string) (*Session, error)
+	// DeleteSession removes the session for the given token hash. No-op
+	// (no error) if the row does not exist.
+	DeleteSession(ctx context.Context, tokenHash string) error
+	// DeleteExpiredSessions removes sessions past their ExpiresAt. Returns
+	// the number of rows deleted.
+	DeleteExpiredSessions(ctx context.Context) (int64, error)
+
+	// In-flight OAuth state tokens (one-time use, short-lived).
+	//
+	// CreateOAuthState persists a new state row.
+	CreateOAuthState(ctx context.Context, s *OAuthState) error
+	// ConsumeOAuthState atomically reads and deletes the state row matching
+	// state and kind. Returns wrapped ErrNotFound if the state is unknown,
+	// expired, or of a different kind. The atomic consume prevents a state
+	// from being replayed if the same callback fires twice.
+	ConsumeOAuthState(ctx context.Context, state, kind string) (*OAuthState, error)
+	// DeleteExpiredOAuthStates removes oauth_states rows past their
+	// ExpiresAt. Returns the number of rows deleted.
+	DeleteExpiredOAuthStates(ctx context.Context) (int64, error)
+
+	// CLI device-authorization requests.
+	//
+	// CreateDeviceAuth inserts a new pending request. It must reject duplicate
+	// device_code or user_code values at the database level.
+	CreateDeviceAuth(ctx context.Context, da *DeviceAuth) error
+	// GetDeviceAuthByDeviceCode looks up a request by the long polling
+	// secret. Returns wrapped ErrNotFound if absent. Implementations also
+	// return ErrNotFound when the row exists but is past its ExpiresAt — the
+	// poll endpoint and cleanup goroutine should treat those identically.
+	GetDeviceAuthByDeviceCode(ctx context.Context, deviceCode string) (*DeviceAuth, error)
+	// GetDeviceAuthByUserCode is the verification page's lookup. Same
+	// not-found / expiry semantics as GetDeviceAuthByDeviceCode.
+	GetDeviceAuthByUserCode(ctx context.Context, userCode string) (*DeviceAuth, error)
+	// UpdateDeviceAuth persists the in-memory mutation back to storage.
+	// Returns ErrNotFound if the device_code does not exist.
+	UpdateDeviceAuth(ctx context.Context, da *DeviceAuth) error
+	// DeleteDeviceAuth removes a row by device_code. It is a no-op (no error)
+	// if the row does not exist; the polling endpoint deletes after handing
+	// the token to the CLI and races with the cleanup goroutine.
+	DeleteDeviceAuth(ctx context.Context, deviceCode string) error
+	// DeleteExpiredDeviceAuths removes all rows whose ExpiresAt is in the
+	// past. Returns the number of rows deleted.
+	DeleteExpiredDeviceAuths(ctx context.Context) (int64, error)
 
 	// Lifecycle
 	Close() error

--- a/internal/database/postgres.go
+++ b/internal/database/postgres.go
@@ -672,6 +672,223 @@ func (s *PostgresStore) DeleteCachedRepository(ctx context.Context, id string) e
 	return nil
 }
 
+// --- Sessions ---
+
+func (s *PostgresStore) CreateSession(ctx context.Context, sess *Session) error {
+	if sess.TokenHash == "" {
+		return fmt.Errorf("CreateSession: TokenHash required")
+	}
+	if sess.CreatedAt.IsZero() {
+		sess.CreatedAt = time.Now().UTC()
+	}
+	_, err := s.db.ExecContext(ctx, `
+		INSERT INTO sessions (token_hash, user_id, username, role, expires_at, created_at)
+		VALUES ($1, $2, $3, $4, $5, $6)
+	`, sess.TokenHash, sess.UserID, sess.Username, sess.Role, sess.ExpiresAt.UTC(), sess.CreatedAt.UTC())
+	return err
+}
+
+func (s *PostgresStore) GetSessionByTokenHash(ctx context.Context, tokenHash string) (*Session, error) {
+	row := s.db.QueryRowContext(ctx, `
+		SELECT token_hash, user_id, username, role, expires_at, created_at
+		FROM sessions WHERE token_hash = $1
+	`, tokenHash)
+	sess := &Session{}
+	err := row.Scan(&sess.TokenHash, &sess.UserID, &sess.Username, &sess.Role, &sess.ExpiresAt, &sess.CreatedAt)
+	if err == sql.ErrNoRows {
+		return nil, fmt.Errorf("session: %w", ErrNotFound)
+	}
+	if err != nil {
+		return nil, err
+	}
+	if !sess.ExpiresAt.IsZero() && time.Now().After(sess.ExpiresAt) {
+		return nil, fmt.Errorf("session: %w", ErrNotFound)
+	}
+	return sess, nil
+}
+
+func (s *PostgresStore) DeleteSession(ctx context.Context, tokenHash string) error {
+	_, err := s.db.ExecContext(ctx, `DELETE FROM sessions WHERE token_hash = $1`, tokenHash)
+	return err
+}
+
+func (s *PostgresStore) DeleteExpiredSessions(ctx context.Context) (int64, error) {
+	cutoff := time.Now().UTC()
+	res, err := s.db.ExecContext(ctx, `DELETE FROM sessions WHERE expires_at < $1`, cutoff)
+	if err != nil {
+		return 0, err
+	}
+	return res.RowsAffected()
+}
+
+// --- OAuth states ---
+
+func (s *PostgresStore) CreateOAuthState(ctx context.Context, st *OAuthState) error {
+	if st.State == "" {
+		return fmt.Errorf("CreateOAuthState: State required")
+	}
+	if st.Kind != OAuthStateKindLogin && st.Kind != OAuthStateKindBroker {
+		return fmt.Errorf("CreateOAuthState: invalid Kind %q", st.Kind)
+	}
+	if st.CreatedAt.IsZero() {
+		st.CreatedAt = time.Now().UTC()
+	}
+	_, err := s.db.ExecContext(ctx, `
+		INSERT INTO oauth_states (state, kind, return_to, broker_redirect_uri, broker_downstream_state, expires_at, created_at)
+		VALUES ($1, $2, $3, $4, $5, $6, $7)
+	`, st.State, st.Kind, st.ReturnTo, st.BrokerRedirectURI, st.BrokerDownstreamState,
+		st.ExpiresAt.UTC(), st.CreatedAt.UTC())
+	return err
+}
+
+func (s *PostgresStore) ConsumeOAuthState(ctx context.Context, state, kind string) (*OAuthState, error) {
+	// DELETE ... RETURNING is atomic — exactly the read-and-delete semantics
+	// we need so a state token can never be replayed by a duplicate callback.
+	row := s.db.QueryRowContext(ctx, `
+		DELETE FROM oauth_states WHERE state = $1 AND kind = $2
+		RETURNING state, kind, return_to, broker_redirect_uri, broker_downstream_state, expires_at, created_at
+	`, state, kind)
+	st := &OAuthState{}
+	err := row.Scan(&st.State, &st.Kind, &st.ReturnTo, &st.BrokerRedirectURI, &st.BrokerDownstreamState, &st.ExpiresAt, &st.CreatedAt)
+	if err == sql.ErrNoRows {
+		return nil, fmt.Errorf("oauth_state: %w", ErrNotFound)
+	}
+	if err != nil {
+		return nil, err
+	}
+	if !st.ExpiresAt.IsZero() && time.Now().After(st.ExpiresAt) {
+		return nil, fmt.Errorf("oauth_state: %w", ErrNotFound)
+	}
+	return st, nil
+}
+
+func (s *PostgresStore) DeleteExpiredOAuthStates(ctx context.Context) (int64, error) {
+	cutoff := time.Now().UTC()
+	res, err := s.db.ExecContext(ctx, `DELETE FROM oauth_states WHERE expires_at < $1`, cutoff)
+	if err != nil {
+		return 0, err
+	}
+	return res.RowsAffected()
+}
+
+// --- Device authorization ---
+
+func (s *PostgresStore) CreateDeviceAuth(ctx context.Context, da *DeviceAuth) error {
+	if da.DeviceCode == "" || da.UserCode == "" {
+		return fmt.Errorf("CreateDeviceAuth: DeviceCode and UserCode required")
+	}
+	if da.Status == "" {
+		da.Status = DeviceAuthStatusPending
+	}
+	if da.CreatedAt.IsZero() {
+		da.CreatedAt = time.Now().UTC()
+	}
+	var lastPolled interface{}
+	if da.LastPolledAt != nil {
+		lastPolled = da.LastPolledAt.UTC()
+	}
+	var sessTok, username interface{}
+	if da.SessionToken != "" {
+		sessTok = da.SessionToken
+	}
+	if da.Username != "" {
+		username = da.Username
+	}
+	_, err := s.db.ExecContext(ctx, `
+		INSERT INTO cli_device_authorizations
+			(device_code, user_code, status, session_token, username, last_polled_at, expires_at, created_at)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+	`, da.DeviceCode, da.UserCode, da.Status, sessTok, username, lastPolled,
+		da.ExpiresAt.UTC(), da.CreatedAt.UTC())
+	return err
+}
+
+func (s *PostgresStore) GetDeviceAuthByDeviceCode(ctx context.Context, deviceCode string) (*DeviceAuth, error) {
+	return s.scanDeviceAuth(ctx, `
+		SELECT device_code, user_code, status, session_token, username, last_polled_at, expires_at, created_at
+		FROM cli_device_authorizations WHERE device_code = $1
+	`, deviceCode)
+}
+
+func (s *PostgresStore) GetDeviceAuthByUserCode(ctx context.Context, userCode string) (*DeviceAuth, error) {
+	return s.scanDeviceAuth(ctx, `
+		SELECT device_code, user_code, status, session_token, username, last_polled_at, expires_at, created_at
+		FROM cli_device_authorizations WHERE user_code = $1
+	`, userCode)
+}
+
+func (s *PostgresStore) scanDeviceAuth(ctx context.Context, query, arg string) (*DeviceAuth, error) {
+	row := s.db.QueryRowContext(ctx, query, arg)
+	da := &DeviceAuth{}
+	var sessTok, username sql.NullString
+	var lastPolled sql.NullTime
+	err := row.Scan(&da.DeviceCode, &da.UserCode, &da.Status, &sessTok, &username, &lastPolled, &da.ExpiresAt, &da.CreatedAt)
+	if err == sql.ErrNoRows {
+		return nil, fmt.Errorf("device_auth: %w", ErrNotFound)
+	}
+	if err != nil {
+		return nil, err
+	}
+	if sessTok.Valid {
+		da.SessionToken = sessTok.String
+	}
+	if username.Valid {
+		da.Username = username.String
+	}
+	if lastPolled.Valid {
+		t := lastPolled.Time
+		da.LastPolledAt = &t
+	}
+	if !da.ExpiresAt.IsZero() && time.Now().After(da.ExpiresAt) {
+		return nil, fmt.Errorf("device_auth: %w", ErrNotFound)
+	}
+	return da, nil
+}
+
+func (s *PostgresStore) UpdateDeviceAuth(ctx context.Context, da *DeviceAuth) error {
+	var lastPolled interface{}
+	if da.LastPolledAt != nil {
+		lastPolled = da.LastPolledAt.UTC()
+	}
+	var sessTok, username interface{}
+	if da.SessionToken != "" {
+		sessTok = da.SessionToken
+	}
+	if da.Username != "" {
+		username = da.Username
+	}
+	res, err := s.db.ExecContext(ctx, `
+		UPDATE cli_device_authorizations
+		SET status = $1, session_token = $2, username = $3, last_polled_at = $4, expires_at = $5
+		WHERE device_code = $6
+	`, da.Status, sessTok, username, lastPolled, da.ExpiresAt.UTC(), da.DeviceCode)
+	if err != nil {
+		return err
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if n == 0 {
+		return fmt.Errorf("device_auth %s: %w", da.DeviceCode, ErrNotFound)
+	}
+	return nil
+}
+
+func (s *PostgresStore) DeleteDeviceAuth(ctx context.Context, deviceCode string) error {
+	_, err := s.db.ExecContext(ctx, `DELETE FROM cli_device_authorizations WHERE device_code = $1`, deviceCode)
+	return err
+}
+
+func (s *PostgresStore) DeleteExpiredDeviceAuths(ctx context.Context) (int64, error) {
+	cutoff := time.Now().UTC()
+	res, err := s.db.ExecContext(ctx, `DELETE FROM cli_device_authorizations WHERE expires_at < $1`, cutoff)
+	if err != nil {
+		return 0, err
+	}
+	return res.RowsAffected()
+}
+
 // Ensure PostgresStore implements all required interfaces.
 var (
 	_ Store             = (*PostgresStore)(nil)

--- a/internal/database/postgres.go
+++ b/internal/database/postgres.go
@@ -678,6 +678,9 @@ func (s *PostgresStore) CreateSession(ctx context.Context, sess *Session) error 
 	if sess.TokenHash == "" {
 		return fmt.Errorf("CreateSession: TokenHash required")
 	}
+	if sess.ExpiresAt.IsZero() {
+		return fmt.Errorf("CreateSession: ExpiresAt required")
+	}
 	if sess.CreatedAt.IsZero() {
 		sess.CreatedAt = time.Now().UTC()
 	}
@@ -730,6 +733,9 @@ func (s *PostgresStore) CreateOAuthState(ctx context.Context, st *OAuthState) er
 	if st.Kind != OAuthStateKindLogin && st.Kind != OAuthStateKindBroker {
 		return fmt.Errorf("CreateOAuthState: invalid Kind %q", st.Kind)
 	}
+	if st.ExpiresAt.IsZero() {
+		return fmt.Errorf("CreateOAuthState: ExpiresAt required")
+	}
 	if st.CreatedAt.IsZero() {
 		st.CreatedAt = time.Now().UTC()
 	}
@@ -776,6 +782,9 @@ func (s *PostgresStore) DeleteExpiredOAuthStates(ctx context.Context) (int64, er
 func (s *PostgresStore) CreateDeviceAuth(ctx context.Context, da *DeviceAuth) error {
 	if da.DeviceCode == "" || da.UserCode == "" {
 		return fmt.Errorf("CreateDeviceAuth: DeviceCode and UserCode required")
+	}
+	if da.ExpiresAt.IsZero() {
+		return fmt.Errorf("CreateDeviceAuth: ExpiresAt required")
 	}
 	if da.Status == "" {
 		da.Status = DeviceAuthStatusPending

--- a/internal/database/postgres_test.go
+++ b/internal/database/postgres_test.go
@@ -71,6 +71,13 @@ func newTestPostgresStore(t *testing.T) *PostgresStore {
 func TestPostgresStoreContract(t *testing.T) {
 	store := newTestPostgresStore(t)
 	testStoreContract(t, store)
+
+	// Postgres uses DELETE ... RETURNING for ConsumeOAuthState, so the
+	// stronger atomicity invariant holds. See store_test.go for why this
+	// isn't part of the shared contract suite.
+	t.Run("OAuthStateConsumeAtomic", func(t *testing.T) {
+		testOAuthStateConsumeAtomic(t, store)
+	})
 }
 
 func TestPostgresUserCRUD(t *testing.T) {

--- a/internal/database/sqlite.go
+++ b/internal/database/sqlite.go
@@ -904,19 +904,18 @@ func (s *SQLiteStore) CreateOAuthState(ctx context.Context, st *OAuthState) erro
 }
 
 func (s *SQLiteStore) ConsumeOAuthState(ctx context.Context, state, kind string) (*OAuthState, error) {
-	tx, err := s.db.BeginTx(ctx, nil)
-	if err != nil {
-		return nil, err
-	}
-	defer tx.Rollback()
-
-	row := tx.QueryRowContext(ctx, `
-		SELECT state, kind, return_to, broker_redirect_uri, broker_downstream_state, expires_at, created_at
-		FROM oauth_states WHERE state = ? AND kind = ?
+	// DELETE ... RETURNING is atomic — exactly the read-and-delete semantics
+	// we need so a state token cannot be replayed by a duplicate callback.
+	// Mirrors PostgresStore.ConsumeOAuthState. SELECT-then-DELETE in a
+	// transaction is not enough: two concurrent readers can both observe
+	// the row before either DELETE runs.
+	row := s.db.QueryRowContext(ctx, `
+		DELETE FROM oauth_states WHERE state = ? AND kind = ?
+		RETURNING state, kind, return_to, broker_redirect_uri, broker_downstream_state, expires_at, created_at
 	`, state, kind)
 	st := &OAuthState{}
 	var expiresStr, createdStr string
-	err = row.Scan(&st.State, &st.Kind, &st.ReturnTo, &st.BrokerRedirectURI, &st.BrokerDownstreamState, &expiresStr, &createdStr)
+	err := row.Scan(&st.State, &st.Kind, &st.ReturnTo, &st.BrokerRedirectURI, &st.BrokerDownstreamState, &expiresStr, &createdStr)
 	if err == sql.ErrNoRows {
 		return nil, fmt.Errorf("oauth_state: %w", ErrNotFound)
 	}
@@ -925,14 +924,6 @@ func (s *SQLiteStore) ConsumeOAuthState(ctx context.Context, state, kind string)
 	}
 	st.ExpiresAt = parseTime(expiresStr)
 	st.CreatedAt = parseTime(createdStr)
-
-	if _, err := tx.ExecContext(ctx, `DELETE FROM oauth_states WHERE state = ?`, state); err != nil {
-		return nil, err
-	}
-	if err := tx.Commit(); err != nil {
-		return nil, err
-	}
-
 	if !st.ExpiresAt.IsZero() && time.Now().After(st.ExpiresAt) {
 		return nil, fmt.Errorf("oauth_state: %w", ErrNotFound)
 	}

--- a/internal/database/sqlite.go
+++ b/internal/database/sqlite.go
@@ -794,6 +794,251 @@ func (s *SQLiteStore) DeleteCachedRepository(ctx context.Context, id string) err
 	return nil
 }
 
+// --- Sessions ---
+
+func (s *SQLiteStore) CreateSession(ctx context.Context, sess *Session) error {
+	if sess.TokenHash == "" {
+		return fmt.Errorf("CreateSession: TokenHash required")
+	}
+	if sess.CreatedAt.IsZero() {
+		sess.CreatedAt = time.Now().UTC()
+	}
+	_, err := s.db.ExecContext(ctx, `
+		INSERT INTO sessions (token_hash, user_id, username, role, expires_at, created_at)
+		VALUES (?, ?, ?, ?, ?, ?)
+	`, sess.TokenHash, sess.UserID, sess.Username, sess.Role,
+		sess.ExpiresAt.UTC().Format(time.RFC3339Nano),
+		sess.CreatedAt.UTC().Format(time.RFC3339Nano))
+	return err
+}
+
+func (s *SQLiteStore) GetSessionByTokenHash(ctx context.Context, tokenHash string) (*Session, error) {
+	row := s.db.QueryRowContext(ctx, `
+		SELECT token_hash, user_id, username, role, expires_at, created_at
+		FROM sessions WHERE token_hash = ?
+	`, tokenHash)
+	sess := &Session{}
+	var expiresStr, createdStr string
+	err := row.Scan(&sess.TokenHash, &sess.UserID, &sess.Username, &sess.Role, &expiresStr, &createdStr)
+	if err == sql.ErrNoRows {
+		return nil, fmt.Errorf("session: %w", ErrNotFound)
+	}
+	if err != nil {
+		return nil, err
+	}
+	sess.ExpiresAt = parseTime(expiresStr)
+	sess.CreatedAt = parseTime(createdStr)
+	if !sess.ExpiresAt.IsZero() && time.Now().After(sess.ExpiresAt) {
+		// Treat expired rows as not-found; the cleanup goroutine will remove them.
+		return nil, fmt.Errorf("session: %w", ErrNotFound)
+	}
+	return sess, nil
+}
+
+func (s *SQLiteStore) DeleteSession(ctx context.Context, tokenHash string) error {
+	_, err := s.db.ExecContext(ctx, `DELETE FROM sessions WHERE token_hash = ?`, tokenHash)
+	return err
+}
+
+func (s *SQLiteStore) DeleteExpiredSessions(ctx context.Context) (int64, error) {
+	cutoff := time.Now().UTC().Format(time.RFC3339Nano)
+	res, err := s.db.ExecContext(ctx, `DELETE FROM sessions WHERE expires_at < ?`, cutoff)
+	if err != nil {
+		return 0, err
+	}
+	return res.RowsAffected()
+}
+
+// --- OAuth states ---
+
+func (s *SQLiteStore) CreateOAuthState(ctx context.Context, st *OAuthState) error {
+	if st.State == "" {
+		return fmt.Errorf("CreateOAuthState: State required")
+	}
+	if st.Kind != OAuthStateKindLogin && st.Kind != OAuthStateKindBroker {
+		return fmt.Errorf("CreateOAuthState: invalid Kind %q", st.Kind)
+	}
+	if st.CreatedAt.IsZero() {
+		st.CreatedAt = time.Now().UTC()
+	}
+	_, err := s.db.ExecContext(ctx, `
+		INSERT INTO oauth_states (state, kind, return_to, broker_redirect_uri, broker_downstream_state, expires_at, created_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?)
+	`, st.State, st.Kind, st.ReturnTo, st.BrokerRedirectURI, st.BrokerDownstreamState,
+		st.ExpiresAt.UTC().Format(time.RFC3339Nano),
+		st.CreatedAt.UTC().Format(time.RFC3339Nano))
+	return err
+}
+
+func (s *SQLiteStore) ConsumeOAuthState(ctx context.Context, state, kind string) (*OAuthState, error) {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, err
+	}
+	defer tx.Rollback()
+
+	row := tx.QueryRowContext(ctx, `
+		SELECT state, kind, return_to, broker_redirect_uri, broker_downstream_state, expires_at, created_at
+		FROM oauth_states WHERE state = ? AND kind = ?
+	`, state, kind)
+	st := &OAuthState{}
+	var expiresStr, createdStr string
+	err = row.Scan(&st.State, &st.Kind, &st.ReturnTo, &st.BrokerRedirectURI, &st.BrokerDownstreamState, &expiresStr, &createdStr)
+	if err == sql.ErrNoRows {
+		return nil, fmt.Errorf("oauth_state: %w", ErrNotFound)
+	}
+	if err != nil {
+		return nil, err
+	}
+	st.ExpiresAt = parseTime(expiresStr)
+	st.CreatedAt = parseTime(createdStr)
+
+	if _, err := tx.ExecContext(ctx, `DELETE FROM oauth_states WHERE state = ?`, state); err != nil {
+		return nil, err
+	}
+	if err := tx.Commit(); err != nil {
+		return nil, err
+	}
+
+	if !st.ExpiresAt.IsZero() && time.Now().After(st.ExpiresAt) {
+		return nil, fmt.Errorf("oauth_state: %w", ErrNotFound)
+	}
+	return st, nil
+}
+
+func (s *SQLiteStore) DeleteExpiredOAuthStates(ctx context.Context) (int64, error) {
+	cutoff := time.Now().UTC().Format(time.RFC3339Nano)
+	res, err := s.db.ExecContext(ctx, `DELETE FROM oauth_states WHERE expires_at < ?`, cutoff)
+	if err != nil {
+		return 0, err
+	}
+	return res.RowsAffected()
+}
+
+// --- Device authorization ---
+
+func (s *SQLiteStore) CreateDeviceAuth(ctx context.Context, da *DeviceAuth) error {
+	if da.DeviceCode == "" || da.UserCode == "" {
+		return fmt.Errorf("CreateDeviceAuth: DeviceCode and UserCode required")
+	}
+	if da.Status == "" {
+		da.Status = DeviceAuthStatusPending
+	}
+	if da.CreatedAt.IsZero() {
+		da.CreatedAt = time.Now().UTC()
+	}
+	var lastPolledStr interface{}
+	if da.LastPolledAt != nil {
+		lastPolledStr = da.LastPolledAt.UTC().Format(time.RFC3339Nano)
+	}
+	var sessTok, username interface{}
+	if da.SessionToken != "" {
+		sessTok = da.SessionToken
+	}
+	if da.Username != "" {
+		username = da.Username
+	}
+	_, err := s.db.ExecContext(ctx, `
+		INSERT INTO cli_device_authorizations
+			(device_code, user_code, status, session_token, username, last_polled_at, expires_at, created_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+	`, da.DeviceCode, da.UserCode, da.Status, sessTok, username, lastPolledStr,
+		da.ExpiresAt.UTC().Format(time.RFC3339Nano),
+		da.CreatedAt.UTC().Format(time.RFC3339Nano))
+	return err
+}
+
+func (s *SQLiteStore) GetDeviceAuthByDeviceCode(ctx context.Context, deviceCode string) (*DeviceAuth, error) {
+	return s.scanDeviceAuth(ctx, `
+		SELECT device_code, user_code, status, session_token, username, last_polled_at, expires_at, created_at
+		FROM cli_device_authorizations WHERE device_code = ?
+	`, deviceCode)
+}
+
+func (s *SQLiteStore) GetDeviceAuthByUserCode(ctx context.Context, userCode string) (*DeviceAuth, error) {
+	return s.scanDeviceAuth(ctx, `
+		SELECT device_code, user_code, status, session_token, username, last_polled_at, expires_at, created_at
+		FROM cli_device_authorizations WHERE user_code = ?
+	`, userCode)
+}
+
+func (s *SQLiteStore) scanDeviceAuth(ctx context.Context, query, arg string) (*DeviceAuth, error) {
+	row := s.db.QueryRowContext(ctx, query, arg)
+	da := &DeviceAuth{}
+	var sessTok, username sql.NullString
+	var lastPolledStr sql.NullString
+	var expiresStr, createdStr string
+	err := row.Scan(&da.DeviceCode, &da.UserCode, &da.Status, &sessTok, &username, &lastPolledStr, &expiresStr, &createdStr)
+	if err == sql.ErrNoRows {
+		return nil, fmt.Errorf("device_auth: %w", ErrNotFound)
+	}
+	if err != nil {
+		return nil, err
+	}
+	if sessTok.Valid {
+		da.SessionToken = sessTok.String
+	}
+	if username.Valid {
+		da.Username = username.String
+	}
+	if lastPolledStr.Valid {
+		t := parseTime(lastPolledStr.String)
+		da.LastPolledAt = &t
+	}
+	da.ExpiresAt = parseTime(expiresStr)
+	da.CreatedAt = parseTime(createdStr)
+	if !da.ExpiresAt.IsZero() && time.Now().After(da.ExpiresAt) {
+		return nil, fmt.Errorf("device_auth: %w", ErrNotFound)
+	}
+	return da, nil
+}
+
+func (s *SQLiteStore) UpdateDeviceAuth(ctx context.Context, da *DeviceAuth) error {
+	var lastPolledStr interface{}
+	if da.LastPolledAt != nil {
+		lastPolledStr = da.LastPolledAt.UTC().Format(time.RFC3339Nano)
+	}
+	var sessTok, username interface{}
+	if da.SessionToken != "" {
+		sessTok = da.SessionToken
+	}
+	if da.Username != "" {
+		username = da.Username
+	}
+	res, err := s.db.ExecContext(ctx, `
+		UPDATE cli_device_authorizations
+		SET status = ?, session_token = ?, username = ?, last_polled_at = ?, expires_at = ?
+		WHERE device_code = ?
+	`, da.Status, sessTok, username, lastPolledStr,
+		da.ExpiresAt.UTC().Format(time.RFC3339Nano),
+		da.DeviceCode)
+	if err != nil {
+		return err
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if n == 0 {
+		return fmt.Errorf("device_auth %s: %w", da.DeviceCode, ErrNotFound)
+	}
+	return nil
+}
+
+func (s *SQLiteStore) DeleteDeviceAuth(ctx context.Context, deviceCode string) error {
+	_, err := s.db.ExecContext(ctx, `DELETE FROM cli_device_authorizations WHERE device_code = ?`, deviceCode)
+	return err
+}
+
+func (s *SQLiteStore) DeleteExpiredDeviceAuths(ctx context.Context) (int64, error) {
+	cutoff := time.Now().UTC().Format(time.RFC3339Nano)
+	res, err := s.db.ExecContext(ctx, `DELETE FROM cli_device_authorizations WHERE expires_at < ?`, cutoff)
+	if err != nil {
+		return 0, err
+	}
+	return res.RowsAffected()
+}
+
 // Ensure SQLiteStore implements all required interfaces.
 var (
 	_ Store             = (*SQLiteStore)(nil)

--- a/internal/database/sqlite.go
+++ b/internal/database/sqlite.go
@@ -821,6 +821,12 @@ func (s *SQLiteStore) CreateSession(ctx context.Context, sess *Session) error {
 	if sess.TokenHash == "" {
 		return fmt.Errorf("CreateSession: TokenHash required")
 	}
+	if sess.ExpiresAt.IsZero() {
+		// GetSessionByTokenHash treats zero ExpiresAt as "no expiry", so a
+		// row inserted without one would behave as an immortal session
+		// until a cleanup sweep happened to notice it. Reject up-front.
+		return fmt.Errorf("CreateSession: ExpiresAt required")
+	}
 	if sess.CreatedAt.IsZero() {
 		sess.CreatedAt = time.Now().UTC()
 	}
@@ -881,6 +887,9 @@ func (s *SQLiteStore) CreateOAuthState(ctx context.Context, st *OAuthState) erro
 	}
 	if st.Kind != OAuthStateKindLogin && st.Kind != OAuthStateKindBroker {
 		return fmt.Errorf("CreateOAuthState: invalid Kind %q", st.Kind)
+	}
+	if st.ExpiresAt.IsZero() {
+		return fmt.Errorf("CreateOAuthState: ExpiresAt required")
 	}
 	if st.CreatedAt.IsZero() {
 		st.CreatedAt = time.Now().UTC()
@@ -944,6 +953,9 @@ func (s *SQLiteStore) DeleteExpiredOAuthStates(ctx context.Context) (int64, erro
 func (s *SQLiteStore) CreateDeviceAuth(ctx context.Context, da *DeviceAuth) error {
 	if da.DeviceCode == "" || da.UserCode == "" {
 		return fmt.Errorf("CreateDeviceAuth: DeviceCode and UserCode required")
+	}
+	if da.ExpiresAt.IsZero() {
+		return fmt.Errorf("CreateDeviceAuth: ExpiresAt required")
 	}
 	if da.Status == "" {
 		da.Status = DeviceAuthStatusPending

--- a/internal/database/sqlite.go
+++ b/internal/database/sqlite.go
@@ -842,7 +842,14 @@ func (s *SQLiteStore) DeleteSession(ctx context.Context, tokenHash string) error
 
 func (s *SQLiteStore) DeleteExpiredSessions(ctx context.Context) (int64, error) {
 	cutoff := time.Now().UTC().Format(time.RFC3339Nano)
-	res, err := s.db.ExecContext(ctx, `DELETE FROM sessions WHERE expires_at < ?`, cutoff)
+	// Wrap both sides in datetime() so SQLite normalises the timestamps
+	// before comparing. A raw lexicographic comparison of RFC3339Nano
+	// strings can flip ordering near second boundaries because Go omits
+	// trailing-zero fractional digits ("...05Z" vs "...05.123Z" sort
+	// '.' < 'Z'), which would over-delete future-expiring rows. The
+	// performance cost is negligible: cleanup runs every few minutes
+	// against a small table.
+	res, err := s.db.ExecContext(ctx, `DELETE FROM sessions WHERE datetime(expires_at) < datetime(?)`, cutoff)
 	if err != nil {
 		return 0, err
 	}
@@ -908,7 +915,9 @@ func (s *SQLiteStore) ConsumeOAuthState(ctx context.Context, state, kind string)
 
 func (s *SQLiteStore) DeleteExpiredOAuthStates(ctx context.Context) (int64, error) {
 	cutoff := time.Now().UTC().Format(time.RFC3339Nano)
-	res, err := s.db.ExecContext(ctx, `DELETE FROM oauth_states WHERE expires_at < ?`, cutoff)
+	// See DeleteExpiredSessions for why this uses datetime() rather than a
+	// raw TEXT comparison.
+	res, err := s.db.ExecContext(ctx, `DELETE FROM oauth_states WHERE datetime(expires_at) < datetime(?)`, cutoff)
 	if err != nil {
 		return 0, err
 	}
@@ -1032,7 +1041,9 @@ func (s *SQLiteStore) DeleteDeviceAuth(ctx context.Context, deviceCode string) e
 
 func (s *SQLiteStore) DeleteExpiredDeviceAuths(ctx context.Context) (int64, error) {
 	cutoff := time.Now().UTC().Format(time.RFC3339Nano)
-	res, err := s.db.ExecContext(ctx, `DELETE FROM cli_device_authorizations WHERE expires_at < ?`, cutoff)
+	// See DeleteExpiredSessions for why this uses datetime() rather than a
+	// raw TEXT comparison.
+	res, err := s.db.ExecContext(ctx, `DELETE FROM cli_device_authorizations WHERE datetime(expires_at) < datetime(?)`, cutoff)
 	if err != nil {
 		return 0, err
 	}

--- a/internal/database/sqlite.go
+++ b/internal/database/sqlite.go
@@ -82,6 +82,27 @@ func parseTime(s string) time.Time {
 	return time.Time{}
 }
 
+// sqliteAuthTimestampLayout is the fixed-width, millisecond-precision
+// timestamp layout used for auth-state rows (sessions, oauth_states,
+// cli_device_authorizations). Two reasons to prefer it over RFC3339Nano:
+//
+//   - It always emits exactly 3 fractional digits, so lexicographic
+//     comparison agrees with chronological order. RFC3339Nano omits
+//     trailing zeros ("...:05Z" vs "...:05.123Z"), which would flip
+//     ordering at second boundaries in the cleanup DELETEs.
+//   - It matches the migration's own default expression
+//     (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')) so DB-defaulted and
+//     application-written values share one format.
+//
+// We deliberately do NOT change the timestamp format for older tables
+// (proxy_tokens etc.); their cleanup logic is unaffected and rewriting
+// existing values is out of scope for this PR.
+const sqliteAuthTimestampLayout = "2006-01-02T15:04:05.000Z"
+
+func sqliteFmtAuthTime(t time.Time) string {
+	return t.UTC().Format(sqliteAuthTimestampLayout)
+}
+
 // --- Migration support ---
 
 func (s *SQLiteStore) EnsureMigrationsTable(ctx context.Context) error {
@@ -807,8 +828,8 @@ func (s *SQLiteStore) CreateSession(ctx context.Context, sess *Session) error {
 		INSERT INTO sessions (token_hash, user_id, username, role, expires_at, created_at)
 		VALUES (?, ?, ?, ?, ?, ?)
 	`, sess.TokenHash, sess.UserID, sess.Username, sess.Role,
-		sess.ExpiresAt.UTC().Format(time.RFC3339Nano),
-		sess.CreatedAt.UTC().Format(time.RFC3339Nano))
+		sqliteFmtAuthTime(sess.ExpiresAt),
+		sqliteFmtAuthTime(sess.CreatedAt))
 	return err
 }
 
@@ -841,15 +862,11 @@ func (s *SQLiteStore) DeleteSession(ctx context.Context, tokenHash string) error
 }
 
 func (s *SQLiteStore) DeleteExpiredSessions(ctx context.Context) (int64, error) {
-	cutoff := time.Now().UTC().Format(time.RFC3339Nano)
-	// Wrap both sides in datetime() so SQLite normalises the timestamps
-	// before comparing. A raw lexicographic comparison of RFC3339Nano
-	// strings can flip ordering near second boundaries because Go omits
-	// trailing-zero fractional digits ("...05Z" vs "...05.123Z" sort
-	// '.' < 'Z'), which would over-delete future-expiring rows. The
-	// performance cost is negligible: cleanup runs every few minutes
-	// against a small table.
-	res, err := s.db.ExecContext(ctx, `DELETE FROM sessions WHERE datetime(expires_at) < datetime(?)`, cutoff)
+	// Auth-state rows are written with sqliteAuthTimestampLayout (fixed-width
+	// 3-digit fractional), so a direct lexicographic comparison is
+	// chronologically correct and faster than wrapping with datetime().
+	cutoff := sqliteFmtAuthTime(time.Now())
+	res, err := s.db.ExecContext(ctx, `DELETE FROM sessions WHERE expires_at < ?`, cutoff)
 	if err != nil {
 		return 0, err
 	}
@@ -872,8 +889,8 @@ func (s *SQLiteStore) CreateOAuthState(ctx context.Context, st *OAuthState) erro
 		INSERT INTO oauth_states (state, kind, return_to, broker_redirect_uri, broker_downstream_state, expires_at, created_at)
 		VALUES (?, ?, ?, ?, ?, ?, ?)
 	`, st.State, st.Kind, st.ReturnTo, st.BrokerRedirectURI, st.BrokerDownstreamState,
-		st.ExpiresAt.UTC().Format(time.RFC3339Nano),
-		st.CreatedAt.UTC().Format(time.RFC3339Nano))
+		sqliteFmtAuthTime(st.ExpiresAt),
+		sqliteFmtAuthTime(st.CreatedAt))
 	return err
 }
 
@@ -914,10 +931,8 @@ func (s *SQLiteStore) ConsumeOAuthState(ctx context.Context, state, kind string)
 }
 
 func (s *SQLiteStore) DeleteExpiredOAuthStates(ctx context.Context) (int64, error) {
-	cutoff := time.Now().UTC().Format(time.RFC3339Nano)
-	// See DeleteExpiredSessions for why this uses datetime() rather than a
-	// raw TEXT comparison.
-	res, err := s.db.ExecContext(ctx, `DELETE FROM oauth_states WHERE datetime(expires_at) < datetime(?)`, cutoff)
+	cutoff := sqliteFmtAuthTime(time.Now())
+	res, err := s.db.ExecContext(ctx, `DELETE FROM oauth_states WHERE expires_at < ?`, cutoff)
 	if err != nil {
 		return 0, err
 	}
@@ -938,7 +953,7 @@ func (s *SQLiteStore) CreateDeviceAuth(ctx context.Context, da *DeviceAuth) erro
 	}
 	var lastPolledStr interface{}
 	if da.LastPolledAt != nil {
-		lastPolledStr = da.LastPolledAt.UTC().Format(time.RFC3339Nano)
+		lastPolledStr = sqliteFmtAuthTime(*da.LastPolledAt)
 	}
 	var sessTok, username interface{}
 	if da.SessionToken != "" {
@@ -952,8 +967,8 @@ func (s *SQLiteStore) CreateDeviceAuth(ctx context.Context, da *DeviceAuth) erro
 			(device_code, user_code, status, session_token, username, last_polled_at, expires_at, created_at)
 		VALUES (?, ?, ?, ?, ?, ?, ?, ?)
 	`, da.DeviceCode, da.UserCode, da.Status, sessTok, username, lastPolledStr,
-		da.ExpiresAt.UTC().Format(time.RFC3339Nano),
-		da.CreatedAt.UTC().Format(time.RFC3339Nano))
+		sqliteFmtAuthTime(da.ExpiresAt),
+		sqliteFmtAuthTime(da.CreatedAt))
 	return err
 }
 
@@ -1005,7 +1020,7 @@ func (s *SQLiteStore) scanDeviceAuth(ctx context.Context, query, arg string) (*D
 func (s *SQLiteStore) UpdateDeviceAuth(ctx context.Context, da *DeviceAuth) error {
 	var lastPolledStr interface{}
 	if da.LastPolledAt != nil {
-		lastPolledStr = da.LastPolledAt.UTC().Format(time.RFC3339Nano)
+		lastPolledStr = sqliteFmtAuthTime(*da.LastPolledAt)
 	}
 	var sessTok, username interface{}
 	if da.SessionToken != "" {
@@ -1019,7 +1034,7 @@ func (s *SQLiteStore) UpdateDeviceAuth(ctx context.Context, da *DeviceAuth) erro
 		SET status = ?, session_token = ?, username = ?, last_polled_at = ?, expires_at = ?
 		WHERE device_code = ?
 	`, da.Status, sessTok, username, lastPolledStr,
-		da.ExpiresAt.UTC().Format(time.RFC3339Nano),
+		sqliteFmtAuthTime(da.ExpiresAt),
 		da.DeviceCode)
 	if err != nil {
 		return err
@@ -1040,10 +1055,8 @@ func (s *SQLiteStore) DeleteDeviceAuth(ctx context.Context, deviceCode string) e
 }
 
 func (s *SQLiteStore) DeleteExpiredDeviceAuths(ctx context.Context) (int64, error) {
-	cutoff := time.Now().UTC().Format(time.RFC3339Nano)
-	// See DeleteExpiredSessions for why this uses datetime() rather than a
-	// raw TEXT comparison.
-	res, err := s.db.ExecContext(ctx, `DELETE FROM cli_device_authorizations WHERE datetime(expires_at) < datetime(?)`, cutoff)
+	cutoff := sqliteFmtAuthTime(time.Now())
+	res, err := s.db.ExecContext(ctx, `DELETE FROM cli_device_authorizations WHERE expires_at < ?`, cutoff)
 	if err != nil {
 		return 0, err
 	}

--- a/internal/database/sqlite_test.go
+++ b/internal/database/sqlite_test.go
@@ -291,6 +291,13 @@ func TestMigrations(t *testing.T) {
 func TestSQLiteStoreContract(t *testing.T) {
 	store := newTestStore(t)
 	testStoreContract(t, store)
+
+	// SQLite uses DELETE ... RETURNING for ConsumeOAuthState, so the
+	// stronger atomicity invariant holds. The Vault backend cannot offer
+	// it (read-then-delete) and is therefore not invoked here.
+	t.Run("OAuthStateConsumeAtomic", func(t *testing.T) {
+		testOAuthStateConsumeAtomic(t, store)
+	})
 }
 
 // Ensure temporary files are cleaned up.

--- a/internal/database/store_test.go
+++ b/internal/database/store_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"sync"
 	"testing"
 	"time"
 )
@@ -1430,6 +1431,51 @@ func testOAuthStateConsume(t *testing.T, store Store) {
 	_, err = store.ConsumeOAuthState(ctx, "never-existed", OAuthStateKindLogin)
 	if err == nil || !errors.Is(err, ErrNotFound) {
 		t.Errorf("expected ErrNotFound for unknown state, got: %v", err)
+	}
+
+	// Concurrent consume race: many goroutines hammer the same state and
+	// exactly one must observe it; the rest must see ErrNotFound. Without
+	// atomic read-and-delete (e.g. the prior SELECT-then-DELETE on
+	// SQLite), a snapshot-isolation race could let two callers both read
+	// the row and "consume" it, allowing replay.
+	if err := store.CreateOAuthState(ctx, &OAuthState{
+		State:     "race-state",
+		Kind:      OAuthStateKindLogin,
+		ReturnTo:  "/race",
+		ExpiresAt: now.Add(10 * time.Minute),
+	}); err != nil {
+		t.Fatalf("CreateOAuthState (race): %v", err)
+	}
+	const racers = 16
+	var wg sync.WaitGroup
+	wg.Add(racers)
+	results := make(chan error, racers)
+	start := make(chan struct{})
+	for i := 0; i < racers; i++ {
+		go func() {
+			defer wg.Done()
+			<-start
+			_, err := store.ConsumeOAuthState(ctx, "race-state", OAuthStateKindLogin)
+			results <- err
+		}()
+	}
+	close(start)
+	wg.Wait()
+	close(results)
+	winners, notFound, otherErrs := 0, 0, 0
+	for err := range results {
+		switch {
+		case err == nil:
+			winners++
+		case errors.Is(err, ErrNotFound):
+			notFound++
+		default:
+			otherErrs++
+			t.Errorf("unexpected error from concurrent ConsumeOAuthState: %v", err)
+		}
+	}
+	if winners != 1 {
+		t.Errorf("concurrent consume: %d winners, want exactly 1 (notFound=%d, errs=%d)", winners, notFound, otherErrs)
 	}
 }
 

--- a/internal/database/store_test.go
+++ b/internal/database/store_test.go
@@ -25,6 +25,9 @@ func testStoreContract(t *testing.T, store Store) {
 	t.Run("SyncAdminRoles", func(t *testing.T) { testSyncAdminRoles(t, store) })
 	t.Run("CachedRepositoryCRUD", func(t *testing.T) { testCachedRepositoryCRUD(t, store) })
 	t.Run("DeleteExpiredProxyTokens", func(t *testing.T) { testDeleteExpiredProxyTokens(t, store) })
+	t.Run("SessionCRUD", func(t *testing.T) { testSessionCRUD(t, store) })
+	t.Run("OAuthStateConsume", func(t *testing.T) { testOAuthStateConsume(t, store) })
+	t.Run("DeviceAuthCRUD", func(t *testing.T) { testDeviceAuthCRUD(t, store) })
 }
 
 func testAppCRUD(t *testing.T, store Store) {
@@ -1267,5 +1270,280 @@ func testDeleteExpiredProxyTokens(t *testing.T, store Store) {
 	}
 	if n2 != 0 {
 		t.Errorf("expected 0 deletions on second call (idempotent), got %d", n2)
+	}
+}
+
+func testSessionCRUD(t *testing.T, store Store) {
+	ctx := context.Background()
+	now := time.Now().UTC().Truncate(time.Second)
+
+	sess := &Session{
+		TokenHash: "session-hash-aaa",
+		UserID:    "user-1",
+		Username:  "alice",
+		Role:      "user",
+		ExpiresAt: now.Add(time.Hour),
+	}
+	if err := store.CreateSession(ctx, sess); err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+
+	got, err := store.GetSessionByTokenHash(ctx, sess.TokenHash)
+	if err != nil {
+		t.Fatalf("GetSessionByTokenHash: %v", err)
+	}
+	if got.UserID != sess.UserID || got.Username != sess.Username || got.Role != sess.Role {
+		t.Errorf("session round-trip mismatch: got %+v, want %+v", got, sess)
+	}
+	if got.CreatedAt.IsZero() {
+		t.Error("expected CreatedAt to be set on retrieved session")
+	}
+
+	// Lookup with an unknown hash must return wrapped ErrNotFound. Use a
+	// non-empty hash to exercise the not-found path rather than the empty
+	// guard.
+	_, err = store.GetSessionByTokenHash(ctx, "unknown-hash-xxx")
+	if err == nil || !errors.Is(err, ErrNotFound) {
+		t.Errorf("expected ErrNotFound for unknown session, got: %v", err)
+	}
+
+	// Expired sessions are also not found.
+	expired := &Session{
+		TokenHash: "session-hash-expired",
+		UserID:    "user-2",
+		Username:  "bob",
+		Role:      "user",
+		ExpiresAt: now.Add(-time.Minute),
+	}
+	if err := store.CreateSession(ctx, expired); err != nil {
+		t.Fatalf("CreateSession (expired): %v", err)
+	}
+	_, err = store.GetSessionByTokenHash(ctx, expired.TokenHash)
+	if err == nil || !errors.Is(err, ErrNotFound) {
+		t.Errorf("expected ErrNotFound for expired session, got: %v", err)
+	}
+
+	// Cleanup removes the expired row.
+	n, err := store.DeleteExpiredSessions(ctx)
+	if err != nil {
+		t.Fatalf("DeleteExpiredSessions: %v", err)
+	}
+	if n < 1 {
+		t.Errorf("DeleteExpiredSessions removed %d rows, want >= 1", n)
+	}
+
+	// Active session is preserved.
+	if _, err := store.GetSessionByTokenHash(ctx, sess.TokenHash); err != nil {
+		t.Errorf("active session should survive cleanup: %v", err)
+	}
+
+	// Explicit delete is idempotent (no-op for missing rows).
+	if err := store.DeleteSession(ctx, sess.TokenHash); err != nil {
+		t.Fatalf("DeleteSession: %v", err)
+	}
+	if err := store.DeleteSession(ctx, sess.TokenHash); err != nil {
+		t.Errorf("DeleteSession on missing row should be a no-op: %v", err)
+	}
+	_, err = store.GetSessionByTokenHash(ctx, sess.TokenHash)
+	if err == nil || !errors.Is(err, ErrNotFound) {
+		t.Errorf("expected ErrNotFound after delete, got: %v", err)
+	}
+}
+
+func testOAuthStateConsume(t *testing.T, store Store) {
+	ctx := context.Background()
+	now := time.Now().UTC().Truncate(time.Second)
+
+	// Login state: round-trip ReturnTo.
+	if err := store.CreateOAuthState(ctx, &OAuthState{
+		State:     "login-state-123",
+		Kind:      OAuthStateKindLogin,
+		ReturnTo:  "/cli/auth?user_code=ABCD-EFGH",
+		ExpiresAt: now.Add(10 * time.Minute),
+	}); err != nil {
+		t.Fatalf("CreateOAuthState (login): %v", err)
+	}
+
+	got, err := store.ConsumeOAuthState(ctx, "login-state-123", OAuthStateKindLogin)
+	if err != nil {
+		t.Fatalf("ConsumeOAuthState (login): %v", err)
+	}
+	if got.ReturnTo != "/cli/auth?user_code=ABCD-EFGH" {
+		t.Errorf("ReturnTo round-trip: got %q", got.ReturnTo)
+	}
+	if got.Kind != OAuthStateKindLogin {
+		t.Errorf("Kind = %q, want login", got.Kind)
+	}
+
+	// Consume must be one-shot: a second consume of the same state returns
+	// ErrNotFound.
+	_, err = store.ConsumeOAuthState(ctx, "login-state-123", OAuthStateKindLogin)
+	if err == nil || !errors.Is(err, ErrNotFound) {
+		t.Errorf("expected ErrNotFound on second consume, got: %v", err)
+	}
+
+	// Wrong-kind consume of a present state must also return ErrNotFound.
+	if err := store.CreateOAuthState(ctx, &OAuthState{
+		State:                 "broker-state-456",
+		Kind:                  OAuthStateKindBroker,
+		BrokerRedirectURI:     "https://app.example.com/cb",
+		BrokerDownstreamState: "csrf-789",
+		ExpiresAt:             now.Add(10 * time.Minute),
+	}); err != nil {
+		t.Fatalf("CreateOAuthState (broker): %v", err)
+	}
+	_, err = store.ConsumeOAuthState(ctx, "broker-state-456", OAuthStateKindLogin)
+	if err == nil || !errors.Is(err, ErrNotFound) {
+		t.Errorf("expected ErrNotFound for wrong-kind consume, got: %v", err)
+	}
+
+	// The broker state itself must round-trip correctly.
+	bs, err := store.ConsumeOAuthState(ctx, "broker-state-456", OAuthStateKindBroker)
+	if err != nil {
+		t.Fatalf("ConsumeOAuthState (broker): %v", err)
+	}
+	if bs.BrokerRedirectURI != "https://app.example.com/cb" {
+		t.Errorf("BrokerRedirectURI round-trip: got %q", bs.BrokerRedirectURI)
+	}
+	if bs.BrokerDownstreamState != "csrf-789" {
+		t.Errorf("BrokerDownstreamState round-trip: got %q", bs.BrokerDownstreamState)
+	}
+
+	// Expired state is not returned and is cleaned up.
+	if err := store.CreateOAuthState(ctx, &OAuthState{
+		State:     "expired-state",
+		Kind:      OAuthStateKindLogin,
+		ExpiresAt: now.Add(-time.Minute),
+	}); err != nil {
+		t.Fatalf("CreateOAuthState (expired): %v", err)
+	}
+	_, err = store.ConsumeOAuthState(ctx, "expired-state", OAuthStateKindLogin)
+	if err == nil || !errors.Is(err, ErrNotFound) {
+		t.Errorf("expected ErrNotFound for expired state, got: %v", err)
+	}
+
+	if _, err := store.DeleteExpiredOAuthStates(ctx); err != nil {
+		t.Fatalf("DeleteExpiredOAuthStates: %v", err)
+	}
+
+	// Lookup of a never-issued state is ErrNotFound.
+	_, err = store.ConsumeOAuthState(ctx, "never-existed", OAuthStateKindLogin)
+	if err == nil || !errors.Is(err, ErrNotFound) {
+		t.Errorf("expected ErrNotFound for unknown state, got: %v", err)
+	}
+}
+
+func testDeviceAuthCRUD(t *testing.T, store Store) {
+	ctx := context.Background()
+	now := time.Now().UTC().Truncate(time.Second)
+
+	da := &DeviceAuth{
+		DeviceCode: "device-code-aaaa",
+		UserCode:   "AAAA-BBBB",
+		Status:     DeviceAuthStatusPending,
+		ExpiresAt:  now.Add(10 * time.Minute),
+	}
+	if err := store.CreateDeviceAuth(ctx, da); err != nil {
+		t.Fatalf("CreateDeviceAuth: %v", err)
+	}
+
+	// Lookup by device_code.
+	got, err := store.GetDeviceAuthByDeviceCode(ctx, da.DeviceCode)
+	if err != nil {
+		t.Fatalf("GetDeviceAuthByDeviceCode: %v", err)
+	}
+	if got.UserCode != da.UserCode || got.Status != da.Status {
+		t.Errorf("round-trip mismatch: got %+v", got)
+	}
+
+	// Lookup by user_code.
+	got2, err := store.GetDeviceAuthByUserCode(ctx, da.UserCode)
+	if err != nil {
+		t.Fatalf("GetDeviceAuthByUserCode: %v", err)
+	}
+	if got2.DeviceCode != da.DeviceCode {
+		t.Errorf("user_code -> device_code resolve mismatch: got %q", got2.DeviceCode)
+	}
+
+	// Update to approved with session token + last_polled_at.
+	polled := now.Add(-time.Second)
+	got.Status = DeviceAuthStatusApproved
+	got.SessionToken = "ghpr_xxx"
+	got.Username = "alice"
+	got.LastPolledAt = &polled
+	if err := store.UpdateDeviceAuth(ctx, got); err != nil {
+		t.Fatalf("UpdateDeviceAuth: %v", err)
+	}
+
+	got3, err := store.GetDeviceAuthByDeviceCode(ctx, da.DeviceCode)
+	if err != nil {
+		t.Fatalf("GetDeviceAuthByDeviceCode (post-update): %v", err)
+	}
+	if got3.Status != DeviceAuthStatusApproved {
+		t.Errorf("status after update = %q, want approved", got3.Status)
+	}
+	if got3.SessionToken != "ghpr_xxx" {
+		t.Errorf("session_token round-trip: got %q", got3.SessionToken)
+	}
+	if got3.Username != "alice" {
+		t.Errorf("username round-trip: got %q", got3.Username)
+	}
+	if got3.LastPolledAt == nil || !got3.LastPolledAt.Equal(polled) {
+		t.Errorf("LastPolledAt round-trip: got %v, want %v", got3.LastPolledAt, polled)
+	}
+
+	// Update of unknown device_code returns ErrNotFound.
+	missing := &DeviceAuth{
+		DeviceCode: "nonexistent-device-code",
+		UserCode:   "ZZZZ-ZZZZ",
+		Status:     DeviceAuthStatusPending,
+		ExpiresAt:  now.Add(time.Minute),
+	}
+	if err := store.UpdateDeviceAuth(ctx, missing); err == nil || !errors.Is(err, ErrNotFound) {
+		t.Errorf("UpdateDeviceAuth on missing row: got %v, want ErrNotFound", err)
+	}
+
+	// Duplicate user_code is rejected.
+	dupe := &DeviceAuth{
+		DeviceCode: "device-code-bbbb",
+		UserCode:   da.UserCode,
+		Status:     DeviceAuthStatusPending,
+		ExpiresAt:  now.Add(10 * time.Minute),
+	}
+	if err := store.CreateDeviceAuth(ctx, dupe); err == nil {
+		t.Error("expected error for duplicate user_code, got nil")
+	}
+
+	// Delete is idempotent.
+	if err := store.DeleteDeviceAuth(ctx, da.DeviceCode); err != nil {
+		t.Fatalf("DeleteDeviceAuth: %v", err)
+	}
+	if err := store.DeleteDeviceAuth(ctx, da.DeviceCode); err != nil {
+		t.Errorf("DeleteDeviceAuth on missing row should be a no-op: %v", err)
+	}
+	_, err = store.GetDeviceAuthByDeviceCode(ctx, da.DeviceCode)
+	if err == nil || !errors.Is(err, ErrNotFound) {
+		t.Errorf("expected ErrNotFound after delete, got: %v", err)
+	}
+
+	// Expired records are filtered out and cleaned up.
+	if err := store.CreateDeviceAuth(ctx, &DeviceAuth{
+		DeviceCode: "device-code-expired",
+		UserCode:   "EXPI-RED1",
+		Status:     DeviceAuthStatusPending,
+		ExpiresAt:  now.Add(-time.Minute),
+	}); err != nil {
+		t.Fatalf("CreateDeviceAuth (expired): %v", err)
+	}
+	_, err = store.GetDeviceAuthByDeviceCode(ctx, "device-code-expired")
+	if err == nil || !errors.Is(err, ErrNotFound) {
+		t.Errorf("expected ErrNotFound for expired device_auth, got: %v", err)
+	}
+	n, err := store.DeleteExpiredDeviceAuths(ctx)
+	if err != nil {
+		t.Fatalf("DeleteExpiredDeviceAuths: %v", err)
+	}
+	if n < 1 {
+		t.Errorf("DeleteExpiredDeviceAuths removed %d, want >= 1", n)
 	}
 }

--- a/internal/database/store_test.go
+++ b/internal/database/store_test.go
@@ -1433,16 +1433,25 @@ func testOAuthStateConsume(t *testing.T, store Store) {
 		t.Errorf("expected ErrNotFound for unknown state, got: %v", err)
 	}
 
-	// Concurrent consume race: many goroutines hammer the same state and
-	// exactly one must observe it; the rest must see ErrNotFound. Without
-	// atomic read-and-delete (e.g. the prior SELECT-then-DELETE on
-	// SQLite), a snapshot-isolation race could let two callers both read
-	// the row and "consume" it, allowing replay.
+}
+
+// testOAuthStateConsumeAtomic asserts that ConsumeOAuthState is atomic
+// under concurrent callers — exactly one observes the row and the rest
+// see ErrNotFound. This invariant is required to prevent state-token
+// replay across racing OAuth callbacks.
+//
+// Not part of testStoreContract because the Vault backend cannot offer
+// this guarantee with its current read-then-delete implementation (Vault
+// KV v2 has no atomic read-and-delete primitive, and the trade-off is
+// documented in vault.go). Invoked directly from sqlite_test.go and
+// postgres_test.go where the implementation uses DELETE ... RETURNING.
+func testOAuthStateConsumeAtomic(t *testing.T, store Store) {
+	ctx := context.Background()
 	if err := store.CreateOAuthState(ctx, &OAuthState{
 		State:     "race-state",
 		Kind:      OAuthStateKindLogin,
 		ReturnTo:  "/race",
-		ExpiresAt: now.Add(10 * time.Minute),
+		ExpiresAt: time.Now().Add(10 * time.Minute),
 	}); err != nil {
 		t.Fatalf("CreateOAuthState (race): %v", err)
 	}

--- a/internal/database/vault.go
+++ b/internal/database/vault.go
@@ -1167,7 +1167,17 @@ func (s *VaultStore) DeleteExpiredSessions(ctx context.Context) (int64, error) {
 	}
 	now := time.Now()
 	var deleted int64
+	var firstErr error
 	for _, k := range keys {
+		// Stop early on context cancellation so shutdown is not delayed by
+		// a loop full of Vault reads/deletes that would all fail anyway.
+		// Mirrors DeleteExpiredProxyTokens.
+		if ctx.Err() != nil {
+			if firstErr == nil {
+				firstErr = ctx.Err()
+			}
+			break
+		}
 		data, err := s.kvRead(ctx, "sessions/"+k)
 		if err != nil {
 			return deleted, err
@@ -1177,6 +1187,15 @@ func (s *VaultStore) DeleteExpiredSessions(ctx context.Context) (int64, error) {
 		}
 		var sess Session
 		if err := unmarshalFromMap(data, &sess); err != nil {
+			// A row that cannot be unmarshalled will never become readable
+			// later (the schema is fixed), so leaving it would let bad
+			// values pile up under sessions/ forever. Delete it and surface
+			// the parse error so an operator sees the cause.
+			if delErr := s.kvDelete(ctx, "sessions/"+k); delErr != nil && firstErr == nil {
+				firstErr = fmt.Errorf("deleting unreadable session %s: %w", k, delErr)
+			} else if firstErr == nil {
+				firstErr = fmt.Errorf("unmarshalling session %s: %w", k, err)
+			}
 			continue
 		}
 		if !sess.ExpiresAt.IsZero() && now.After(sess.ExpiresAt) {
@@ -1186,7 +1205,7 @@ func (s *VaultStore) DeleteExpiredSessions(ctx context.Context) (int64, error) {
 			deleted++
 		}
 	}
-	return deleted, nil
+	return deleted, firstErr
 }
 
 // --- OAuth states ---
@@ -1258,7 +1277,14 @@ func (s *VaultStore) DeleteExpiredOAuthStates(ctx context.Context) (int64, error
 	}
 	now := time.Now()
 	var deleted int64
+	var firstErr error
 	for _, k := range keys {
+		if ctx.Err() != nil {
+			if firstErr == nil {
+				firstErr = ctx.Err()
+			}
+			break
+		}
 		data, err := s.kvRead(ctx, "oauth-states/"+k)
 		if err != nil {
 			return deleted, err
@@ -1268,6 +1294,13 @@ func (s *VaultStore) DeleteExpiredOAuthStates(ctx context.Context) (int64, error
 		}
 		var st OAuthState
 		if err := unmarshalFromMap(data, &st); err != nil {
+			// Unreadable rows would otherwise stay under oauth-states/
+			// forever; remove them and report the parse error.
+			if delErr := s.kvDelete(ctx, "oauth-states/"+k); delErr != nil && firstErr == nil {
+				firstErr = fmt.Errorf("deleting unreadable oauth_state %s: %w", k, delErr)
+			} else if firstErr == nil {
+				firstErr = fmt.Errorf("unmarshalling oauth_state %s: %w", k, err)
+			}
 			continue
 		}
 		if !st.ExpiresAt.IsZero() && now.After(st.ExpiresAt) {
@@ -1277,7 +1310,7 @@ func (s *VaultStore) DeleteExpiredOAuthStates(ctx context.Context) (int64, error
 			deleted++
 		}
 	}
-	return deleted, nil
+	return deleted, firstErr
 }
 
 // --- Device authorization ---
@@ -1396,7 +1429,14 @@ func (s *VaultStore) DeleteExpiredDeviceAuths(ctx context.Context) (int64, error
 	}
 	now := time.Now()
 	var deleted int64
+	var firstErr error
 	for _, k := range keys {
+		if ctx.Err() != nil {
+			if firstErr == nil {
+				firstErr = ctx.Err()
+			}
+			break
+		}
 		// Skip the index sub-prefix; we'll prune dangling entries below.
 		if k == "by-user-code" {
 			continue
@@ -1410,6 +1450,14 @@ func (s *VaultStore) DeleteExpiredDeviceAuths(ctx context.Context) (int64, error
 		}
 		var da DeviceAuth
 		if err := unmarshalFromMap(data, &da); err != nil {
+			// The user_code index for an unreadable row is unknown, so
+			// pruning it is best-effort via the dangling-index sweep below.
+			// Delete the primary so it can't sit unreadable forever.
+			if delErr := s.kvDelete(ctx, "device-auth/"+k); delErr != nil && firstErr == nil {
+				firstErr = fmt.Errorf("deleting unreadable device_auth %s: %w", k, delErr)
+			} else if firstErr == nil {
+				firstErr = fmt.Errorf("unmarshalling device_auth %s: %w", k, err)
+			}
 			continue
 		}
 		if !da.ExpiresAt.IsZero() && now.After(da.ExpiresAt) {
@@ -1427,6 +1475,12 @@ func (s *VaultStore) DeleteExpiredDeviceAuths(ctx context.Context) (int64, error
 	idxKeys, err := s.kvList(ctx, "device-auth/by-user-code")
 	if err == nil {
 		for _, idxKey := range idxKeys {
+			if ctx.Err() != nil {
+				if firstErr == nil {
+					firstErr = ctx.Err()
+				}
+				break
+			}
 			idx, err := s.kvRead(ctx, "device-auth/by-user-code/"+idxKey)
 			if err != nil || idx == nil {
 				continue
@@ -1441,7 +1495,7 @@ func (s *VaultStore) DeleteExpiredDeviceAuths(ctx context.Context) (int64, error
 			}
 		}
 	}
-	return deleted, nil
+	return deleted, firstErr
 }
 
 // Ensure VaultStore implements Store.

--- a/internal/database/vault.go
+++ b/internal/database/vault.go
@@ -1498,7 +1498,16 @@ func (s *VaultStore) DeleteExpiredDeviceAuths(ctx context.Context) (int64, error
 			break
 		}
 		idx, err := s.kvRead(ctx, "device-auth/by-user-code/"+idxKey)
-		if err != nil || idx == nil {
+		if err != nil {
+			// A read failure here doesn't mean the index is dangling;
+			// surface it instead so the cleanup logger can alert on
+			// transient Vault issues, but don't delete anything.
+			if firstErr == nil {
+				firstErr = fmt.Errorf("reading device-auth/by-user-code/%s: %w", idxKey, err)
+			}
+			continue
+		}
+		if idx == nil {
 			continue
 		}
 		deviceCode, _ := idx["device_code"].(string)
@@ -1506,7 +1515,20 @@ func (s *VaultStore) DeleteExpiredDeviceAuths(ctx context.Context) (int64, error
 			_ = s.kvDelete(ctx, "device-auth/by-user-code/"+idxKey)
 			continue
 		}
-		if primary, _ := s.kvRead(ctx, "device-auth/"+deviceCode); primary == nil {
+		// Only prune the index when we can confirm the primary record is
+		// absent. A transient kvRead error must NOT cause us to delete a
+		// valid index entry — that would make GetDeviceAuthByUserCode
+		// fail for a still-pending device-auth row. Surface the read
+		// error and leave the index in place; the next cleanup pass can
+		// re-evaluate.
+		primary, primaryErr := s.kvRead(ctx, "device-auth/"+deviceCode)
+		if primaryErr != nil {
+			if firstErr == nil {
+				firstErr = fmt.Errorf("reading device-auth/%s: %w", deviceCode, primaryErr)
+			}
+			continue
+		}
+		if primary == nil {
 			_ = s.kvDelete(ctx, "device-auth/by-user-code/"+idxKey)
 		}
 	}

--- a/internal/database/vault.go
+++ b/internal/database/vault.go
@@ -944,5 +944,306 @@ func (s *VaultStore) DeleteCachedRepository(ctx context.Context, id string) erro
 	return s.kvDelete(ctx, "cached-repos/"+id)
 }
 
+// --- Sessions ---
+
+func (s *VaultStore) CreateSession(ctx context.Context, sess *Session) error {
+	if sess.TokenHash == "" {
+		return fmt.Errorf("CreateSession: TokenHash required")
+	}
+	if sess.CreatedAt.IsZero() {
+		sess.CreatedAt = time.Now().UTC()
+	}
+	data, err := marshalToMap(sess)
+	if err != nil {
+		return fmt.Errorf("marshaling session: %w", err)
+	}
+	return s.kvWrite(ctx, "sessions/"+sess.TokenHash, data)
+}
+
+func (s *VaultStore) GetSessionByTokenHash(ctx context.Context, tokenHash string) (*Session, error) {
+	data, err := s.kvRead(ctx, "sessions/"+tokenHash)
+	if err != nil {
+		return nil, err
+	}
+	if data == nil {
+		return nil, fmt.Errorf("session: %w", ErrNotFound)
+	}
+	var sess Session
+	if err := unmarshalFromMap(data, &sess); err != nil {
+		return nil, err
+	}
+	if !sess.ExpiresAt.IsZero() && time.Now().After(sess.ExpiresAt) {
+		return nil, fmt.Errorf("session: %w", ErrNotFound)
+	}
+	return &sess, nil
+}
+
+func (s *VaultStore) DeleteSession(ctx context.Context, tokenHash string) error {
+	return s.kvDelete(ctx, "sessions/"+tokenHash)
+}
+
+// DeleteExpiredSessions iterates the sessions/ prefix and deletes anything
+// past its expiry. Vault has no list-with-filter, so this fans out one Read
+// per row. Acceptable because cleanup runs infrequently (configurable
+// interval, default minutes).
+func (s *VaultStore) DeleteExpiredSessions(ctx context.Context) (int64, error) {
+	keys, err := s.kvList(ctx, "sessions")
+	if err != nil {
+		return 0, err
+	}
+	now := time.Now()
+	var deleted int64
+	for _, k := range keys {
+		data, err := s.kvRead(ctx, "sessions/"+k)
+		if err != nil {
+			return deleted, err
+		}
+		if data == nil {
+			continue
+		}
+		var sess Session
+		if err := unmarshalFromMap(data, &sess); err != nil {
+			continue
+		}
+		if !sess.ExpiresAt.IsZero() && now.After(sess.ExpiresAt) {
+			if err := s.kvDelete(ctx, "sessions/"+k); err != nil {
+				return deleted, err
+			}
+			deleted++
+		}
+	}
+	return deleted, nil
+}
+
+// --- OAuth states ---
+
+func (s *VaultStore) CreateOAuthState(ctx context.Context, st *OAuthState) error {
+	if st.State == "" {
+		return fmt.Errorf("CreateOAuthState: State required")
+	}
+	if st.Kind != OAuthStateKindLogin && st.Kind != OAuthStateKindBroker {
+		return fmt.Errorf("CreateOAuthState: invalid Kind %q", st.Kind)
+	}
+	if st.CreatedAt.IsZero() {
+		st.CreatedAt = time.Now().UTC()
+	}
+	data, err := marshalToMap(st)
+	if err != nil {
+		return fmt.Errorf("marshaling oauth_state: %w", err)
+	}
+	return s.kvWrite(ctx, "oauth-states/"+st.State, data)
+}
+
+// ConsumeOAuthState reads then deletes. Vault KV does not support atomic
+// read-and-delete, so a duplicate concurrent callback could in principle
+// receive the same state twice. The window is bounded by the time between
+// the kvRead and kvDelete here (typically single-digit ms), and the state
+// payload itself is non-secret — at worst a duplicate browser session
+// would race to consume the same row. Documented in CLAUDE.md as the
+// Vault read-modify-write trade-off.
+func (s *VaultStore) ConsumeOAuthState(ctx context.Context, state, kind string) (*OAuthState, error) {
+	data, err := s.kvRead(ctx, "oauth-states/"+state)
+	if err != nil {
+		return nil, err
+	}
+	if data == nil {
+		return nil, fmt.Errorf("oauth_state: %w", ErrNotFound)
+	}
+	var st OAuthState
+	if err := unmarshalFromMap(data, &st); err != nil {
+		return nil, err
+	}
+	if st.Kind != kind {
+		return nil, fmt.Errorf("oauth_state: %w", ErrNotFound)
+	}
+	if !st.ExpiresAt.IsZero() && time.Now().After(st.ExpiresAt) {
+		_ = s.kvDelete(ctx, "oauth-states/"+state)
+		return nil, fmt.Errorf("oauth_state: %w", ErrNotFound)
+	}
+	if err := s.kvDelete(ctx, "oauth-states/"+state); err != nil {
+		return nil, err
+	}
+	return &st, nil
+}
+
+func (s *VaultStore) DeleteExpiredOAuthStates(ctx context.Context) (int64, error) {
+	keys, err := s.kvList(ctx, "oauth-states")
+	if err != nil {
+		return 0, err
+	}
+	now := time.Now()
+	var deleted int64
+	for _, k := range keys {
+		data, err := s.kvRead(ctx, "oauth-states/"+k)
+		if err != nil {
+			return deleted, err
+		}
+		if data == nil {
+			continue
+		}
+		var st OAuthState
+		if err := unmarshalFromMap(data, &st); err != nil {
+			continue
+		}
+		if !st.ExpiresAt.IsZero() && now.After(st.ExpiresAt) {
+			if err := s.kvDelete(ctx, "oauth-states/"+k); err != nil {
+				return deleted, err
+			}
+			deleted++
+		}
+	}
+	return deleted, nil
+}
+
+// --- Device authorization ---
+
+func (s *VaultStore) CreateDeviceAuth(ctx context.Context, da *DeviceAuth) error {
+	if da.DeviceCode == "" || da.UserCode == "" {
+		return fmt.Errorf("CreateDeviceAuth: DeviceCode and UserCode required")
+	}
+	if da.Status == "" {
+		da.Status = DeviceAuthStatusPending
+	}
+	if da.CreatedAt.IsZero() {
+		da.CreatedAt = time.Now().UTC()
+	}
+	// Reject duplicate user_code at the application level; Vault has no
+	// unique-index equivalent.
+	if existing, err := s.kvRead(ctx, "device-auth/by-user-code/"+da.UserCode); err != nil {
+		return err
+	} else if existing != nil {
+		return fmt.Errorf("user_code already in use")
+	}
+	data, err := marshalToMap(da)
+	if err != nil {
+		return fmt.Errorf("marshaling device_auth: %w", err)
+	}
+	if err := s.kvWrite(ctx, "device-auth/"+da.DeviceCode, data); err != nil {
+		return err
+	}
+	// Index user_code -> device_code for the verification page lookup.
+	return s.kvWrite(ctx, "device-auth/by-user-code/"+da.UserCode, map[string]interface{}{
+		"device_code": da.DeviceCode,
+	})
+}
+
+func (s *VaultStore) GetDeviceAuthByDeviceCode(ctx context.Context, deviceCode string) (*DeviceAuth, error) {
+	data, err := s.kvRead(ctx, "device-auth/"+deviceCode)
+	if err != nil {
+		return nil, err
+	}
+	if data == nil {
+		return nil, fmt.Errorf("device_auth: %w", ErrNotFound)
+	}
+	var da DeviceAuth
+	if err := unmarshalFromMap(data, &da); err != nil {
+		return nil, err
+	}
+	if !da.ExpiresAt.IsZero() && time.Now().After(da.ExpiresAt) {
+		return nil, fmt.Errorf("device_auth: %w", ErrNotFound)
+	}
+	return &da, nil
+}
+
+func (s *VaultStore) GetDeviceAuthByUserCode(ctx context.Context, userCode string) (*DeviceAuth, error) {
+	idx, err := s.kvRead(ctx, "device-auth/by-user-code/"+userCode)
+	if err != nil {
+		return nil, err
+	}
+	if idx == nil {
+		return nil, fmt.Errorf("device_auth: %w", ErrNotFound)
+	}
+	deviceCode, _ := idx["device_code"].(string)
+	if deviceCode == "" {
+		return nil, fmt.Errorf("device_auth: %w", ErrNotFound)
+	}
+	return s.GetDeviceAuthByDeviceCode(ctx, deviceCode)
+}
+
+func (s *VaultStore) UpdateDeviceAuth(ctx context.Context, da *DeviceAuth) error {
+	existing, err := s.kvRead(ctx, "device-auth/"+da.DeviceCode)
+	if err != nil {
+		return err
+	}
+	if existing == nil {
+		return fmt.Errorf("device_auth %s: %w", da.DeviceCode, ErrNotFound)
+	}
+	data, err := marshalToMap(da)
+	if err != nil {
+		return fmt.Errorf("marshaling device_auth: %w", err)
+	}
+	return s.kvWrite(ctx, "device-auth/"+da.DeviceCode, data)
+}
+
+func (s *VaultStore) DeleteDeviceAuth(ctx context.Context, deviceCode string) error {
+	// Delete the user_code index too. Best-effort: if the primary record
+	// is gone the index is harmless and will be cleaned up on TTL.
+	if data, err := s.kvRead(ctx, "device-auth/"+deviceCode); err == nil && data != nil {
+		var da DeviceAuth
+		if err := unmarshalFromMap(data, &da); err == nil && da.UserCode != "" {
+			_ = s.kvDelete(ctx, "device-auth/by-user-code/"+da.UserCode)
+		}
+	}
+	return s.kvDelete(ctx, "device-auth/"+deviceCode)
+}
+
+// DeleteExpiredDeviceAuths iterates device-auth/ and deletes expired records
+// along with their user_code indexes. by-user-code/ entries that point at
+// missing primary records are also pruned.
+func (s *VaultStore) DeleteExpiredDeviceAuths(ctx context.Context) (int64, error) {
+	keys, err := s.kvList(ctx, "device-auth")
+	if err != nil {
+		return 0, err
+	}
+	now := time.Now()
+	var deleted int64
+	for _, k := range keys {
+		// Skip the index sub-prefix; we'll prune dangling entries below.
+		if k == "by-user-code" {
+			continue
+		}
+		data, err := s.kvRead(ctx, "device-auth/"+k)
+		if err != nil {
+			return deleted, err
+		}
+		if data == nil {
+			continue
+		}
+		var da DeviceAuth
+		if err := unmarshalFromMap(data, &da); err != nil {
+			continue
+		}
+		if !da.ExpiresAt.IsZero() && now.After(da.ExpiresAt) {
+			if da.UserCode != "" {
+				_ = s.kvDelete(ctx, "device-auth/by-user-code/"+da.UserCode)
+			}
+			if err := s.kvDelete(ctx, "device-auth/"+k); err != nil {
+				return deleted, err
+			}
+			deleted++
+		}
+	}
+	// Prune dangling user_code index entries (records deleted directly,
+	// e.g. by the polling endpoint).
+	idxKeys, err := s.kvList(ctx, "device-auth/by-user-code")
+	if err == nil {
+		for _, idxKey := range idxKeys {
+			idx, err := s.kvRead(ctx, "device-auth/by-user-code/"+idxKey)
+			if err != nil || idx == nil {
+				continue
+			}
+			deviceCode, _ := idx["device_code"].(string)
+			if deviceCode == "" {
+				_ = s.kvDelete(ctx, "device-auth/by-user-code/"+idxKey)
+				continue
+			}
+			if primary, _ := s.kvRead(ctx, "device-auth/"+deviceCode); primary == nil {
+				_ = s.kvDelete(ctx, "device-auth/by-user-code/"+idxKey)
+			}
+		}
+	}
+	return deleted, nil
+}
+
 // Ensure VaultStore implements Store.
 var _ Store = (*VaultStore)(nil)

--- a/internal/database/vault.go
+++ b/internal/database/vault.go
@@ -1480,28 +1480,34 @@ func (s *VaultStore) DeleteExpiredDeviceAuths(ctx context.Context) (int64, error
 		}
 	}
 	// Prune dangling user_code index entries (records deleted directly,
-	// e.g. by the polling endpoint).
+	// e.g. by the polling endpoint). A list error here is recorded so the
+	// caller can surface it; otherwise dangling indexes can pile up
+	// indefinitely without any signal.
 	idxKeys, err := s.kvList(ctx, "device-auth/by-user-code")
-	if err == nil {
-		for _, idxKey := range idxKeys {
-			if ctx.Err() != nil {
-				if firstErr == nil {
-					firstErr = ctx.Err()
-				}
-				break
+	if err != nil {
+		if firstErr == nil {
+			firstErr = fmt.Errorf("listing device-auth/by-user-code: %w", err)
+		}
+		return deleted, firstErr
+	}
+	for _, idxKey := range idxKeys {
+		if ctx.Err() != nil {
+			if firstErr == nil {
+				firstErr = ctx.Err()
 			}
-			idx, err := s.kvRead(ctx, "device-auth/by-user-code/"+idxKey)
-			if err != nil || idx == nil {
-				continue
-			}
-			deviceCode, _ := idx["device_code"].(string)
-			if deviceCode == "" {
-				_ = s.kvDelete(ctx, "device-auth/by-user-code/"+idxKey)
-				continue
-			}
-			if primary, _ := s.kvRead(ctx, "device-auth/"+deviceCode); primary == nil {
-				_ = s.kvDelete(ctx, "device-auth/by-user-code/"+idxKey)
-			}
+			break
+		}
+		idx, err := s.kvRead(ctx, "device-auth/by-user-code/"+idxKey)
+		if err != nil || idx == nil {
+			continue
+		}
+		deviceCode, _ := idx["device_code"].(string)
+		if deviceCode == "" {
+			_ = s.kvDelete(ctx, "device-auth/by-user-code/"+idxKey)
+			continue
+		}
+		if primary, _ := s.kvRead(ctx, "device-auth/"+deviceCode); primary == nil {
+			_ = s.kvDelete(ctx, "device-auth/by-user-code/"+idxKey)
 		}
 	}
 	return deleted, firstErr

--- a/internal/database/vault.go
+++ b/internal/database/vault.go
@@ -1113,6 +1113,9 @@ func (s *VaultStore) CreateSession(ctx context.Context, sess *Session) error {
 	if sess.TokenHash == "" {
 		return fmt.Errorf("CreateSession: TokenHash required")
 	}
+	if sess.ExpiresAt.IsZero() {
+		return fmt.Errorf("CreateSession: ExpiresAt required")
+	}
 	if sess.CreatedAt.IsZero() {
 		sess.CreatedAt = time.Now().UTC()
 	}
@@ -1217,6 +1220,9 @@ func (s *VaultStore) CreateOAuthState(ctx context.Context, st *OAuthState) error
 	if st.Kind != OAuthStateKindLogin && st.Kind != OAuthStateKindBroker {
 		return fmt.Errorf("CreateOAuthState: invalid Kind %q", st.Kind)
 	}
+	if st.ExpiresAt.IsZero() {
+		return fmt.Errorf("CreateOAuthState: ExpiresAt required")
+	}
 	if st.CreatedAt.IsZero() {
 		st.CreatedAt = time.Now().UTC()
 	}
@@ -1318,6 +1324,9 @@ func (s *VaultStore) DeleteExpiredOAuthStates(ctx context.Context) (int64, error
 func (s *VaultStore) CreateDeviceAuth(ctx context.Context, da *DeviceAuth) error {
 	if da.DeviceCode == "" || da.UserCode == "" {
 		return fmt.Errorf("CreateDeviceAuth: DeviceCode and UserCode required")
+	}
+	if da.ExpiresAt.IsZero() {
+		return fmt.Errorf("CreateDeviceAuth: ExpiresAt required")
 	}
 	if da.Status == "" {
 		da.Status = DeviceAuthStatusPending

--- a/internal/database/vault.go
+++ b/internal/database/vault.go
@@ -998,7 +998,17 @@ func (s *VaultStore) CreateSession(ctx context.Context, sess *Session) error {
 	if err != nil {
 		return fmt.Errorf("marshaling session: %w", err)
 	}
-	return s.kvWrite(ctx, "sessions/"+sess.TokenHash, data)
+	// Sessions are create-once: the token hash is the primary key in the
+	// SQL backends, and a duplicate must be rejected rather than silently
+	// overwriting an existing session. Use CAS-protected create so the
+	// Vault backend matches that contract under retries/concurrency.
+	if err := s.kvCreate(ctx, "sessions/"+sess.TokenHash, data); err != nil {
+		if errors.Is(err, errKVAlreadyExists) {
+			return fmt.Errorf("session token_hash already in use")
+		}
+		return err
+	}
+	return nil
 }
 
 func (s *VaultStore) GetSessionByTokenHash(ctx context.Context, tokenHash string) (*Session, error) {
@@ -1073,7 +1083,18 @@ func (s *VaultStore) CreateOAuthState(ctx context.Context, st *OAuthState) error
 	if err != nil {
 		return fmt.Errorf("marshaling oauth_state: %w", err)
 	}
-	return s.kvWrite(ctx, "oauth-states/"+st.State, data)
+	// OAuth state rows are create-once and one-time-consumed; the State is
+	// a high-entropy token whose collisions are vanishingly unlikely, but
+	// using CAS-protected create matches the SQL backends' PK uniqueness
+	// guarantee and prevents a retried generate-then-create from
+	// overwriting an existing in-flight state.
+	if err := s.kvCreate(ctx, "oauth-states/"+st.State, data); err != nil {
+		if errors.Is(err, errKVAlreadyExists) {
+			return fmt.Errorf("oauth_state already in use")
+		}
+		return err
+	}
+	return nil
 }
 
 // ConsumeOAuthState reads then deletes. Vault KV does not support atomic

--- a/internal/database/vault.go
+++ b/internal/database/vault.go
@@ -151,6 +151,47 @@ func (s *VaultStore) kvWrite(ctx context.Context, key string, data map[string]in
 	})
 }
 
+// errKVAlreadyExists is returned by kvCreate when the target path already
+// has a non-deleted value. Vault surfaces a CAS mismatch as an HTTP 400 with
+// a specific "check-and-set parameter did not match the current version"
+// error, which is what we look for here.
+var errKVAlreadyExists = errors.New("kv: already exists")
+
+// kvCreate writes data to a KV v2 path only if no value exists there. It
+// uses KV v2's check-and-set option (`cas: 0`) so the operation is atomic
+// and concurrent callers cannot race past each other to overwrite the same
+// key. Returns errKVAlreadyExists if the key is already present.
+//
+// Re-authenticates once on 403 errors via withRelogin, like the other KV
+// helpers; CAS conflicts are returned to the caller as errKVAlreadyExists
+// so they can be distinguished from authentication failures.
+func (s *VaultStore) kvCreate(ctx context.Context, key string, data map[string]interface{}) error {
+	return s.withRelogin(ctx, func() error {
+		_, err := s.client.Logical().WriteWithContext(ctx, s.dataPath(key), map[string]interface{}{
+			"data":    data,
+			"options": map[string]interface{}{"cas": 0},
+		})
+		if err != nil && isKVCASMismatch(err) {
+			return errKVAlreadyExists
+		}
+		return err
+	})
+}
+
+// isKVCASMismatch detects the specific Vault response that indicates a
+// check-and-set conflict so the caller can surface a typed error. Vault
+// emits the phrase "check-and-set parameter did not match" in the body of
+// a 400 response on a CAS conflict; structured detection via
+// vault.ResponseError would be preferable but the response error type
+// embedded in the SDK does not expose a code we can match on directly.
+func isKVCASMismatch(err error) bool {
+	if err == nil {
+		return false
+	}
+	return strings.Contains(err.Error(), "check-and-set") ||
+		strings.Contains(err.Error(), "cas parameter")
+}
+
 // kvRead reads data from a KV v2 path. Returns nil, nil if not found.
 // Re-authenticates once on 403 errors.
 func (s *VaultStore) kvRead(ctx context.Context, key string) (map[string]interface{}, error) {
@@ -984,8 +1025,9 @@ func (s *VaultStore) DeleteSession(ctx context.Context, tokenHash string) error 
 
 // DeleteExpiredSessions iterates the sessions/ prefix and deletes anything
 // past its expiry. Vault has no list-with-filter, so this fans out one Read
-// per row. Acceptable because cleanup runs infrequently (configurable
-// interval, default minutes).
+// per row. Acceptable because cleanup runs infrequently — the auth handler
+// invokes it on a fixed cadence (see authStateCleanupInterval in the auth
+// package, currently 5 minutes).
 func (s *VaultStore) DeleteExpiredSessions(ctx context.Context) (int64, error) {
 	keys, err := s.kvList(ctx, "sessions")
 	if err != nil {
@@ -1107,24 +1149,38 @@ func (s *VaultStore) CreateDeviceAuth(ctx context.Context, da *DeviceAuth) error
 	if da.CreatedAt.IsZero() {
 		da.CreatedAt = time.Now().UTC()
 	}
-	// Reject duplicate user_code at the application level; Vault has no
-	// unique-index equivalent.
-	if existing, err := s.kvRead(ctx, "device-auth/by-user-code/"+da.UserCode); err != nil {
-		return err
-	} else if existing != nil {
-		return fmt.Errorf("user_code already in use")
-	}
 	data, err := marshalToMap(da)
 	if err != nil {
 		return fmt.Errorf("marshaling device_auth: %w", err)
 	}
-	if err := s.kvWrite(ctx, "device-auth/"+da.DeviceCode, data); err != nil {
+	// Use KV v2 check-and-set (cas=0) for both writes so duplicate
+	// device_code or user_code values are rejected atomically. SQL backends
+	// rely on UNIQUE indexes for this guarantee; Vault has no equivalent
+	// constraint, but `cas: 0` provides per-key create-only semantics, which
+	// is enough when both keys are written together.
+	if err := s.kvCreate(ctx, "device-auth/"+da.DeviceCode, data); err != nil {
+		if errors.Is(err, errKVAlreadyExists) {
+			return fmt.Errorf("device_code already in use")
+		}
 		return err
 	}
 	// Index user_code -> device_code for the verification page lookup.
-	return s.kvWrite(ctx, "device-auth/by-user-code/"+da.UserCode, map[string]interface{}{
+	if err := s.kvCreate(ctx, "device-auth/by-user-code/"+da.UserCode, map[string]interface{}{
 		"device_code": da.DeviceCode,
-	})
+	}); err != nil {
+		// Roll back the primary record if the user_code index conflicts so
+		// we don't leave an orphan device-auth row pointing at a user_code
+		// that resolves to someone else.
+		if delErr := s.kvDelete(ctx, "device-auth/"+da.DeviceCode); delErr != nil {
+			// Best-effort; the cleanup goroutine will eventually purge it.
+			_ = delErr
+		}
+		if errors.Is(err, errKVAlreadyExists) {
+			return fmt.Errorf("user_code already in use")
+		}
+		return err
+	}
+	return nil
 }
 
 func (s *VaultStore) GetDeviceAuthByDeviceCode(ctx context.Context, deviceCode string) (*DeviceAuth, error) {

--- a/internal/github/registry_test.go
+++ b/internal/github/registry_test.go
@@ -95,6 +95,39 @@ func (m *mockStore) UpdateCachedRepository(_ context.Context, _ *database.Cached
 func (m *mockStore) DeleteCachedRepository(_ context.Context, _ string) error {
 	panic("unexpected")
 }
+func (m *mockStore) CreateSession(_ context.Context, _ *database.Session) error { panic("unexpected") }
+func (m *mockStore) GetSessionByTokenHash(_ context.Context, _ string) (*database.Session, error) {
+	panic("unexpected")
+}
+func (m *mockStore) DeleteSession(_ context.Context, _ string) error { panic("unexpected") }
+func (m *mockStore) DeleteExpiredSessions(_ context.Context) (int64, error) {
+	panic("unexpected")
+}
+func (m *mockStore) CreateOAuthState(_ context.Context, _ *database.OAuthState) error {
+	panic("unexpected")
+}
+func (m *mockStore) ConsumeOAuthState(_ context.Context, _, _ string) (*database.OAuthState, error) {
+	panic("unexpected")
+}
+func (m *mockStore) DeleteExpiredOAuthStates(_ context.Context) (int64, error) {
+	panic("unexpected")
+}
+func (m *mockStore) CreateDeviceAuth(_ context.Context, _ *database.DeviceAuth) error {
+	panic("unexpected")
+}
+func (m *mockStore) GetDeviceAuthByDeviceCode(_ context.Context, _ string) (*database.DeviceAuth, error) {
+	panic("unexpected")
+}
+func (m *mockStore) GetDeviceAuthByUserCode(_ context.Context, _ string) (*database.DeviceAuth, error) {
+	panic("unexpected")
+}
+func (m *mockStore) UpdateDeviceAuth(_ context.Context, _ *database.DeviceAuth) error {
+	panic("unexpected")
+}
+func (m *mockStore) DeleteDeviceAuth(_ context.Context, _ string) error { panic("unexpected") }
+func (m *mockStore) DeleteExpiredDeviceAuths(_ context.Context) (int64, error) {
+	panic("unexpected")
+}
 func (m *mockStore) Close() error { return nil }
 
 // makeApp creates a minimal App record with a valid private key for testing.

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -250,6 +250,23 @@ var (
 		Help: "Current total size of cached protocol response files per repository.",
 	}, []string{"owner", "repo"})
 
+	// CLIDeviceStartedTotal counts CLI device-authorization requests
+	// initiated via POST /cli/auth/device. Each "ghp auth login" invocation
+	// increments this counter exactly once.
+	CLIDeviceStartedTotal = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "ghp_cli_auth_device_started_total",
+		Help: "Total number of CLI device-authorization requests initiated.",
+	})
+
+	// CLIDeviceCompletedTotal counts CLI device-authorization requests that
+	// reached a terminal state, labeled by result: "approved" (user
+	// authorized and CLI received a session token), "denied" (user clicked
+	// deny), or "expired" (record TTL'd before the user acted).
+	CLIDeviceCompletedTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "ghp_cli_auth_device_completed_total",
+		Help: "Total number of CLI device-authorization requests that reached a terminal state.",
+	}, []string{"result"})
+
 	// BuildInfo is a gauge with a constant value of 1 labeled by build
 	// metadata. It follows the node_exporter_build_info convention.
 	BuildInfo = promauto.NewGaugeVec(prometheus.GaugeOpts{

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -351,6 +351,9 @@ func (s *Server) Run(ctx context.Context) error {
 	defer lifecycleCancel()
 
 	authHandler := auth.NewHandler(s.cfg, store, enc, s.logger)
+	// Periodically purge expired sessions, oauth_states, and
+	// cli_device_authorizations rows so the tables don't grow unbounded.
+	authHandler.StartCleanup(lifecycleCtx)
 	usernameResolver := proxy.NewUsernameResolver(store, s.logger)
 	proxyTokenResolver := proxy.NewProxyTokenResolver(tokenSvc, store, enc, appTokenProvider)
 	usernameResolver.WarmCache(lifecycleCtx, proxyTokenResolver)

--- a/internal/token/cache_test.go
+++ b/internal/token/cache_test.go
@@ -81,7 +81,28 @@ func (m *mockStore) ListCachedRepositories(_ context.Context) ([]*database.Cache
 }
 func (m *mockStore) UpdateCachedRepository(_ context.Context, _ *database.CachedRepository) error { return nil }
 func (m *mockStore) DeleteCachedRepository(_ context.Context, _ string) error                     { return nil }
-func (m *mockStore) Close() error                                                                  { return nil }
+func (m *mockStore) CreateSession(_ context.Context, _ *database.Session) error                   { return nil }
+func (m *mockStore) GetSessionByTokenHash(_ context.Context, _ string) (*database.Session, error) {
+	return nil, database.ErrNotFound
+}
+func (m *mockStore) DeleteSession(_ context.Context, _ string) error             { return nil }
+func (m *mockStore) DeleteExpiredSessions(_ context.Context) (int64, error)      { return 0, nil }
+func (m *mockStore) CreateOAuthState(_ context.Context, _ *database.OAuthState) error { return nil }
+func (m *mockStore) ConsumeOAuthState(_ context.Context, _, _ string) (*database.OAuthState, error) {
+	return nil, database.ErrNotFound
+}
+func (m *mockStore) DeleteExpiredOAuthStates(_ context.Context) (int64, error)        { return 0, nil }
+func (m *mockStore) CreateDeviceAuth(_ context.Context, _ *database.DeviceAuth) error { return nil }
+func (m *mockStore) GetDeviceAuthByDeviceCode(_ context.Context, _ string) (*database.DeviceAuth, error) {
+	return nil, database.ErrNotFound
+}
+func (m *mockStore) GetDeviceAuthByUserCode(_ context.Context, _ string) (*database.DeviceAuth, error) {
+	return nil, database.ErrNotFound
+}
+func (m *mockStore) UpdateDeviceAuth(_ context.Context, _ *database.DeviceAuth) error { return nil }
+func (m *mockStore) DeleteDeviceAuth(_ context.Context, _ string) error               { return nil }
+func (m *mockStore) DeleteExpiredDeviceAuths(_ context.Context) (int64, error)        { return 0, nil }
+func (m *mockStore) Close() error                                                     { return nil }
 
 // newTestToken creates a valid proxy token for testing with the given hash, ID,
 // and expiry.

--- a/internal/web/middleware_test.go
+++ b/internal/web/middleware_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
@@ -236,23 +237,46 @@ func (noopStore) ListCachedRepositories(_ context.Context) ([]*database.CachedRe
 }
 func (noopStore) UpdateCachedRepository(_ context.Context, _ *database.CachedRepository) error { return nil }
 func (noopStore) DeleteCachedRepository(_ context.Context, _ string) error                     { return nil }
-func (noopStore) Close() error { return nil }
+func (noopStore) CreateSession(_ context.Context, _ *database.Session) error                   { return nil }
+func (noopStore) GetSessionByTokenHash(_ context.Context, _ string) (*database.Session, error) {
+	return nil, fmt.Errorf("session: %w", database.ErrNotFound)
+}
+func (noopStore) DeleteSession(_ context.Context, _ string) error                  { return nil }
+func (noopStore) DeleteExpiredSessions(_ context.Context) (int64, error)           { return 0, nil }
+func (noopStore) CreateOAuthState(_ context.Context, _ *database.OAuthState) error { return nil }
+func (noopStore) ConsumeOAuthState(_ context.Context, _, _ string) (*database.OAuthState, error) {
+	return nil, fmt.Errorf("oauth_state: %w", database.ErrNotFound)
+}
+func (noopStore) DeleteExpiredOAuthStates(_ context.Context) (int64, error)        { return 0, nil }
+func (noopStore) CreateDeviceAuth(_ context.Context, _ *database.DeviceAuth) error { return nil }
+func (noopStore) GetDeviceAuthByDeviceCode(_ context.Context, _ string) (*database.DeviceAuth, error) {
+	return nil, fmt.Errorf("device_auth: %w", database.ErrNotFound)
+}
+func (noopStore) GetDeviceAuthByUserCode(_ context.Context, _ string) (*database.DeviceAuth, error) {
+	return nil, fmt.Errorf("device_auth: %w", database.ErrNotFound)
+}
+func (noopStore) UpdateDeviceAuth(_ context.Context, _ *database.DeviceAuth) error { return nil }
+func (noopStore) DeleteDeviceAuth(_ context.Context, _ string) error               { return nil }
+func (noopStore) DeleteExpiredDeviceAuths(_ context.Context) (int64, error)        { return 0, nil }
+func (noopStore) Close() error                                                     { return nil }
 
-// stubStore is a minimal database.Store that overrides UpsertUser and
-// UpsertGitHubToken for the auth test-login flow. All other methods
-// are provided by the embedded noopStore and return zero values.
-type stubStore struct{ noopStore }
-
-func (s *stubStore) UpsertUser(_ context.Context, u *database.User) error {
-	if u.ID == "" {
-		u.ID = "test-user-id"
+// newTestAuthStore returns an in-memory SQLite store with all migrations
+// applied. Used in tests that genuinely exercise auth flows (sessions,
+// oauth_states, device auth) — noopStore's not-found-everywhere semantics
+// would short-circuit those flows.
+func newTestAuthStore(t *testing.T) database.Store {
+	t.Helper()
+	store, err := database.NewSQLiteStore(":memory:")
+	if err != nil {
+		t.Fatalf("create test store: %v", err)
 	}
-	return nil
+	t.Cleanup(func() { _ = store.Close() })
+	migrator := database.NewMigrator(store, "sqlite")
+	if err := migrator.Migrate(context.Background()); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	return store
 }
-func (s *stubStore) UpsertGitHubToken(_ context.Context, _ *database.GitHubToken) error {
-	return nil
-}
-func (s *stubStore) Close() error { return nil }
 
 func TestSessionUsernameMiddleware_WithSession(t *testing.T) {
 	key, err := crypto.GenerateKey()
@@ -264,7 +288,7 @@ func TestSessionUsernameMiddleware_WithSession(t *testing.T) {
 		t.Fatal(err)
 	}
 	cfg := &config.Config{DevMode: true}
-	ah := auth.NewHandler(cfg, &stubStore{}, enc, slog.Default())
+	ah := auth.NewHandler(cfg, newTestAuthStore(t), enc, slog.Default())
 
 	// Use test-login to create a session.
 	mux := http.NewServeMux()
@@ -333,7 +357,7 @@ func TestSessionUsernameMiddleware_NoSession(t *testing.T) {
 		t.Fatal(err)
 	}
 	cfg := &config.Config{DevMode: true}
-	ah := auth.NewHandler(cfg, &stubStore{}, enc, slog.Default())
+	ah := auth.NewHandler(cfg, newTestAuthStore(t), enc, slog.Default())
 
 	var gotUsername, gotUserID string
 	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Summary

Two related fixes that together repair `ghp auth login` and stop ghp from depending on in-process state for any auth flow.

**1. CLI sign-in no longer round-trips through github.com.** The original failure mode was that `ghp auth login` returned a `github.com/login/oauth/authorize?...&redirect_uri=<ghp>/auth/github/callback` URL, and GitHub rejected it whenever that redirect_uri did not exactly match the value registered against the OAuth app (the common case in proxied/internal environments, or when `server.base_url` was unset). The CLI now uses an OAuth 2.0 device-authorization grant against the ghp server itself: it prints a URL on the **ghp server** plus a short user code, polls until the user approves it in a browser, and saves the issued session token automatically. GitHub OAuth remains the identity provider for the ghp web UI, but `ghp auth login` never sees a `github.com` URL.

**2. All transient auth state is persisted in the Store.** Previously, sessions, in-flight OAuth state tokens for the GitHub login redirect, OAuth broker state, and CLI device-authorization records lived in per-instance `expirable.LRU` maps. Any auth flow whose round-trips crossed instances broke under HA load balancing — the state simply was not visible to the next instance. The same applied to ordinary cookie-bearing traffic: a user signed in on instance A would be treated as anonymous by instance B. All four pieces of state are now stored via the Store interface, so a flow that spans multiple HTTP requests is correct regardless of which ghp instance handles each one.

## What changes

**New endpoints (CLI device flow):**

| Method | Path | Purpose |
|---|---|---|
| `POST` | `/cli/auth/device` | CLI initiates a sign-in; returns `device_code`, `user_code`, verify URL, expires/interval. Per-IP rate-limited (10/min). |
| `POST` | `/cli/auth/device/token` | CLI polls; returns the issued `ghpr_` session token on approval, RFC-8628 error codes (`authorization_pending`, `slow_down`, `expired_token`, `access_denied`, `server_error`) until then. Per-IP rate-limited (600/min); the CLI honours HTTP 429 + `Retry-After`. |
| `GET` | `/cli/auth` | Verification page; redirects unauthenticated users through `/auth/github?return_to=…` and back. |
| `POST` | `/cli/auth/decision` | Approve/deny form submission (requires session, body bounded by `MaxBytesReader`). |

`/auth/github` gained an optional `return_to` query parameter, validated to local paths only (no open redirect). The verification page uses it to bounce unauthenticated users through the existing GitHub login and back to the approval page automatically. The handler also now honours `Forwarded` / `X-Forwarded-Proto` / `X-Forwarded-Host` so deployments where TLS terminates at a reverse proxy still produce correct `https://` callback URLs when `server.base_url` is unset.

**New persistent tables (migration 010, postgres + sqlite):**

- `sessions` — bearer-token-keyed (SHA-256 hashed) session rows. The raw bearer is never stored; handlers hash on every lookup, matching the proxy-token pattern.
- `oauth_states` — one-time OAuth state tokens with `kind` of `login` or `broker`. Atomic read-and-delete via `DELETE … RETURNING` on Postgres and a transaction on SQLite. The Vault backend uses `kvCreate` with KV v2 check-and-set (`cas:0`) for create-once semantics, plus best-effort read-then-delete for consume.
- `cli_device_authorizations` — pending CLI device-flow records, with a CHECK constraint on `status` and a UNIQUE index on `user_code`. Vault uses `kvCreate` (CAS) for both the primary record and the user_code index, and rolls back the primary on index conflict.

SQLite auth-state rows are written in a fixed-width millisecond layout (`2006-01-02T15:04:05.000Z`) so the cleanup queries can compare directly with `<` without going through `datetime()`.

**Store interface:** new methods `CreateSession`, `GetSessionByTokenHash`, `DeleteSession`, `DeleteExpiredSessions`, `CreateOAuthState`, `ConsumeOAuthState`, `DeleteExpiredOAuthStates`, `CreateDeviceAuth`, `GetDeviceAuthByDeviceCode`, `GetDeviceAuthByUserCode`, `UpdateDeviceAuth`, `DeleteDeviceAuth`, `DeleteExpiredDeviceAuths` — implemented for SQLite, Postgres, and Vault. Full contract tests run against every backend.

**Auth handler:** the four `expirable.LRU` instances (`sessions`, `states`, `brokerStates`, `deviceRequests`/`deviceUserCodes`) are gone. `Handler.StartCleanup` runs a 5-minute periodic sweep that purges expired sessions, oauth_states, and device-auth rows; expired device records also increment the metric counter for observability. Cleanup errors during context cancellation are demoted from Warn to Debug so server shutdown stays quiet.

**CLI (`cmd/ghp/auth.go`):** `ghp auth login` POSTs `/cli/auth/device`, prints the verify URL plus user code, opens the browser, polls `/cli/auth/device/token` at the server-supplied interval, and saves the issued token to `~/.config/ghp/config.yaml` automatically. The CLI rejects an issued token without the `ghpr_` prefix; on `server_error` it surfaces a clear message instead of "unexpected error"; on HTTP 429 it parses `Retry-After` (delta-seconds or HTTP-date) and backs off (capped at 60s). `Ctrl-C` cancels the poll loop.

**Metrics:**

- `ghp_cli_auth_device_started_total` (counter, one per `ghp auth login`)
- `ghp_cli_auth_device_completed_total{result}` — `result` is one of `approved`, `denied`, or `expired` (the latter emitted by the cleanup goroutine when a record TTLs out before the user acts)

**Docs:** `docs/cli/auth.md` rewritten for the new flow including SSH/headless usage; `docs/getting-started.md` updated; `docs/how-it-works.md` gains an "HA" section describing the persisted-state guarantee; `docs/admin/monitoring.md` lists the new metrics.

## Test plan

- [x] `go build ./...`, `go vet ./...`
- [x] `go test ./cmd/ghp/ ./internal/auth/ ./internal/database/ ./internal/metrics/ ./internal/server/ ./internal/web/ ./internal/token/ ./internal/github/`
- [x] Store contract tests for `SessionCRUD`, `OAuthStateConsume`, `DeviceAuthCRUD` against SQLite (Postgres + Vault container tests will run on CI)
- [x] Handler tests for happy path, denied, slow_down (with persisted `LastPolledAt`), expired/unknown codes, invalid request, unauthenticated POST, return_to validation, user_code normalisation, atomic state consume, broker round-trip, X-Forwarded-Proto / RFC 7239 Forwarded handling, `server_error`, and HTTP 429 + `Retry-After`
- [x] CLI test exercises start → polling → token-saved end-to-end against an httptest stub
- [x] Manually applied migration 010 to a fresh SQLite DB
- [ ] Manual smoke test of `ghp auth login` against a running server
- [ ] Existing Playwright e2e (login, logout, dashboard, tokens, admin) — auth surface unchanged for the web UI