### PR TITLE
feat: support Vault kubernetes auth method for database backend

### DIFF
--- a/docs/admin/configuration.md
+++ b/docs/admin/configuration.md
@@ -23,8 +23,12 @@ values from the config file.
 | `GHP_DATABASE_VAULT_ADDR` | Vault server address (vault driver only) | |
 | `GHP_DATABASE_VAULT_MOUNT` | Vault KV v2 mount path | `secret` |
 | `GHP_DATABASE_VAULT_PATH` | Key prefix within the mount | `ghp` |
-| `GHP_DATABASE_VAULT_ROLE_ID` | Vault AppRole role ID | |
-| `GHP_DATABASE_VAULT_SECRET_ID` | Vault AppRole secret ID | |
+| `GHP_DATABASE_VAULT_AUTH_METHOD` | Vault auth method: `approle` or `kubernetes` | `approle` |
+| `GHP_DATABASE_VAULT_ROLE_ID` | Vault AppRole role ID (when method=`approle`) | |
+| `GHP_DATABASE_VAULT_SECRET_ID` | Vault AppRole secret ID (when method=`approle`) | |
+| `GHP_DATABASE_VAULT_K8S_ROLE` | Vault role name (when method=`kubernetes`) | |
+| `GHP_DATABASE_VAULT_K8S_MOUNT` | Vault auth mount for kubernetes method (e.g. `kubernetes/cluster-name`) | `kubernetes` |
+| `GHP_DATABASE_VAULT_K8S_TOKEN_PATH` | Path to the projected service account JWT | `/var/run/secrets/kubernetes.io/serviceaccount/token` |
 
 ### Server
 
@@ -161,8 +165,12 @@ database:
   # vault_addr: ""             # Vault server address (vault driver only)
   # vault_mount: "secret"      # KV v2 mount path
   # vault_path: "ghp"          # key prefix within the mount
-  # vault_role_id: ""          # AppRole role ID
-  # vault_secret_id: ""        # AppRole secret ID
+  # vault_auth_method: "approle"  # "approle" (default) or "kubernetes"
+  # vault_role_id: ""          # AppRole role ID (auth_method=approle)
+  # vault_secret_id: ""        # AppRole secret ID (auth_method=approle)
+  # vault_k8s_role: ""         # Vault role to authenticate as (auth_method=kubernetes)
+  # vault_k8s_mount: "kubernetes"  # auth mount path (auth_method=kubernetes)
+  # vault_k8s_token_path: "/var/run/secrets/kubernetes.io/serviceaccount/token"
 
 server:
   listen: ":8080"              # plain HTTP mode (development or behind reverse proxy)

--- a/docs/admin/vault.md
+++ b/docs/admin/vault.md
@@ -238,8 +238,9 @@ ghp automatically re-authenticates when its token expires (up to
     export GHP_DATABASE_VAULT_K8S_ROLE=ghp
     # Optional — override only if you mounted the auth backend at a non-default path:
     # export GHP_DATABASE_VAULT_K8S_MOUNT=kubernetes/my-cluster
-    # Optional — override only if your projected token is at a non-standard path:
-    # export GHP_DATABASE_VAULT_K8S_TOKEN_PATH=/var/run/secrets/kubernetes.io/serviceaccount/token
+    # Optional — override only if your projected token is at a non-standard path
+    # (the default is /var/run/secrets/kubernetes.io/serviceaccount/token):
+    # export GHP_DATABASE_VAULT_K8S_TOKEN_PATH=/var/run/secrets/projected/ghp-token
     ```
 
 === "Kubernetes — YAML"
@@ -253,7 +254,7 @@ ghp automatically re-authenticates when its token expires (up to
       vault_auth_method: kubernetes
       vault_k8s_role: ghp
       # vault_k8s_mount: kubernetes        # default; override for multi-cluster mounts
-      # vault_k8s_token_path: /var/run/secrets/kubernetes.io/serviceaccount/token
+      # vault_k8s_token_path: /var/run/secrets/projected/ghp-token  # default is /var/run/secrets/kubernetes.io/serviceaccount/token
     ```
 
 | Field | Env Var | Default | Description |

--- a/docs/admin/vault.md
+++ b/docs/admin/vault.md
@@ -1,16 +1,28 @@
 # Vault Storage Backend
 
 ghp supports HashiCorp Vault as a storage backend, using the KV v2 secrets
-engine with AppRole authentication. All data — users, tokens, apps, and
-credentials — is stored as versioned secrets within a configurable keyspace.
+engine. All data — users, tokens, apps, and credentials — is stored as
+versioned secrets within a configurable keyspace.
 
 Vault provides encryption at rest natively, so the `GHP_ENCRYPTION_KEY`
 setting is not required when using this backend.
 
+ghp can authenticate to Vault using one of two methods:
+
+- **AppRole** (default) — role ID and secret ID credentials are provisioned
+  out-of-band and supplied via configuration. Suitable for VMs, bare metal,
+  or any deployment where a Kubernetes-issued JWT is not available.
+- **Kubernetes** — ghp uses the pod's projected service account JWT to
+  authenticate directly to Vault's kubernetes auth backend. Recommended for
+  Kubernetes deployments because it eliminates the need to manage role-id /
+  secret-id credentials and removes Vault Secret Operator (VSO) from the
+  authentication path.
+
 ## Prerequisites
 
 - HashiCorp Vault 1.12+ with the KV v2 secrets engine enabled
-- AppRole auth method enabled
+- One of: AppRole auth method enabled, or kubernetes auth method enabled and
+  bound to the cluster ghp runs in
 - A dedicated policy granting ghp access to its keyspace
 
 ## Vault Setup
@@ -24,11 +36,39 @@ skip this step. Otherwise, enable a dedicated mount:
 vault secrets enable -path=ghp-data -version=2 kv
 ```
 
-### 2. Enable AppRole Authentication
+### 2. Enable an Authentication Method
 
-```bash
-vault auth enable approle
-```
+Choose one of the following based on where ghp runs:
+
+=== "AppRole"
+
+    ```bash
+    vault auth enable approle
+    ```
+
+=== "Kubernetes"
+
+    ```bash
+    vault auth enable kubernetes
+    # Or, for multi-cluster setups, mount the backend at a per-cluster path:
+    vault auth enable -path=kubernetes/my-cluster kubernetes
+    ```
+
+    Configure the auth backend so Vault can validate JWTs issued by the
+    cluster's API server. The recommended pattern is to use Vault's own
+    service account to call the TokenReview API:
+
+    ```bash
+    vault write auth/kubernetes/config \
+      kubernetes_host="https://kubernetes.default.svc:443" \
+      kubernetes_ca_cert=@/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+    ```
+
+    See the [Vault kubernetes auth docs][k8s-auth] for full setup details
+    and alternative configurations (e.g. validating JWTs locally without
+    contacting the API server).
+
+[k8s-auth]: https://developer.hashicorp.com/vault/docs/auth/kubernetes
 
 ### 3. Create the GHP Policy
 
@@ -57,68 +97,156 @@ configuration if you are not using the defaults.
     the paths beyond `ghp/*` — ghp does not need access to any other Vault
     secrets.
 
-### 4. Create the AppRole Role
+### 4. Create the Vault Role
 
-```bash
-vault write auth/approle/role/ghp \
-  policies="ghp" \
-  token_ttl=1h \
-  token_max_ttl=4h \
-  secret_id_ttl=0 \
-  token_num_uses=0
-```
+=== "AppRole"
 
-| Parameter | Recommended | Description |
-|-----------|-------------|-------------|
-| `policies` | `"ghp"` | The policy created above |
-| `token_ttl` | `1h` | How long each issued token is valid before renewal |
-| `token_max_ttl` | `4h` | Maximum lifetime before re-authentication is required |
-| `secret_id_ttl` | `0` (no expiry) or org policy | How long the secret ID remains valid |
-| `token_num_uses` | `0` (unlimited) | ghp makes many Vault calls per request |
+    ```bash
+    vault write auth/approle/role/ghp \
+      policies="ghp" \
+      token_ttl=1h \
+      token_max_ttl=4h \
+      secret_id_ttl=0 \
+      token_num_uses=0
+    ```
+
+    | Parameter | Recommended | Description |
+    |-----------|-------------|-------------|
+    | `policies` | `"ghp"` | The policy created above |
+    | `token_ttl` | `1h` | How long each issued token is valid before renewal |
+    | `token_max_ttl` | `4h` | Maximum lifetime before re-authentication is required |
+    | `secret_id_ttl` | `0` (no expiry) or org policy | How long the secret ID remains valid |
+    | `token_num_uses` | `0` (unlimited) | ghp makes many Vault calls per request |
+
+=== "Kubernetes"
+
+    Bind the Vault role to the Kubernetes service account that ghp's pod
+    uses. Update `bound_service_account_names` and
+    `bound_service_account_namespaces` to match your deployment.
+
+    ```bash
+    vault write auth/kubernetes/role/ghp \
+      bound_service_account_names=ghp \
+      bound_service_account_namespaces=ghp \
+      policies=ghp \
+      token_ttl=1h \
+      token_max_ttl=4h
+    ```
+
+    | Parameter | Recommended | Description |
+    |-----------|-------------|-------------|
+    | `bound_service_account_names` | `ghp` | Service account names allowed to assume this role |
+    | `bound_service_account_namespaces` | `ghp` | Namespaces those service accounts must live in |
+    | `policies` | `"ghp"` | The policy created above |
+    | `token_ttl` | `1h` | How long each issued token is valid before renewal |
+    | `token_max_ttl` | `4h` | Maximum lifetime before re-authentication is required |
+
+    If you mounted the kubernetes backend at a per-cluster path (e.g.
+    `kubernetes/my-cluster`), substitute that path in the command above.
 
 ghp automatically re-authenticates when its token expires (up to
 `token_max_ttl`), so short TTLs are safe and recommended.
 
 ### 5. Retrieve Credentials
 
-```bash
-# Get the role ID (stable, not secret)
-vault read auth/approle/role/ghp/role-id
+=== "AppRole"
 
-# Generate a secret ID (treat as a secret — store securely)
-vault write -f auth/approle/role/ghp/secret-id
-```
+    ```bash
+    # Get the role ID (stable, not secret)
+    vault read auth/approle/role/ghp/role-id
 
-For development, you can set fixed credentials instead:
+    # Generate a secret ID (treat as a secret — store securely)
+    vault write -f auth/approle/role/ghp/secret-id
+    ```
 
-```bash
-vault write auth/approle/role/ghp/role-id role_id="my-role-id"
-vault write auth/approle/role/ghp/custom-secret-id secret_id="my-secret-id"
-```
+    For development, you can set fixed credentials instead:
+
+    ```bash
+    vault write auth/approle/role/ghp/role-id role_id="my-role-id"
+    vault write auth/approle/role/ghp/custom-secret-id secret_id="my-secret-id"
+    ```
+
+=== "Kubernetes"
+
+    No credential retrieval is required. ghp authenticates directly using
+    the projected service account JWT mounted into its pod by Kubernetes
+    at `/var/run/secrets/kubernetes.io/serviceaccount/token`.
+
+    Ensure the pod runs as the service account bound to the Vault role:
+
+    ```yaml
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      name: ghp
+      namespace: ghp
+    ---
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: ghp
+      namespace: ghp
+    spec:
+      template:
+        spec:
+          serviceAccountName: ghp
+          # ...
+    ```
 
 ## GHP Configuration
 
-=== "Environment Variables"
+=== "AppRole — Environment Variables"
 
     ```bash
     export GHP_DATABASE_DRIVER=vault
     export GHP_DATABASE_VAULT_ADDR=https://vault.example.com:8200
     export GHP_DATABASE_VAULT_MOUNT=secret       # KV v2 mount path
     export GHP_DATABASE_VAULT_PATH=ghp            # key prefix within the mount
+    export GHP_DATABASE_VAULT_AUTH_METHOD=approle # default; can be omitted
     export GHP_DATABASE_VAULT_ROLE_ID=<role-id>
     export GHP_DATABASE_VAULT_SECRET_ID=<secret-id>
     ```
 
-=== "YAML"
+=== "AppRole — YAML"
 
     ```yaml
     database:
       driver: vault
       vault_addr: https://vault.example.com:8200
-      vault_mount: secret    # KV v2 mount path
-      vault_path: ghp        # key prefix within the mount
-      vault_role_id: ""      # set via GHP_DATABASE_VAULT_ROLE_ID env var
-      vault_secret_id: ""    # set via GHP_DATABASE_VAULT_SECRET_ID env var
+      vault_mount: secret              # KV v2 mount path
+      vault_path: ghp                  # key prefix within the mount
+      vault_auth_method: approle       # default
+      vault_role_id: ""                # set via GHP_DATABASE_VAULT_ROLE_ID env var
+      vault_secret_id: ""              # set via GHP_DATABASE_VAULT_SECRET_ID env var
+    ```
+
+=== "Kubernetes — Environment Variables"
+
+    ```bash
+    export GHP_DATABASE_DRIVER=vault
+    export GHP_DATABASE_VAULT_ADDR=https://vault.example.com:8200
+    export GHP_DATABASE_VAULT_MOUNT=secret
+    export GHP_DATABASE_VAULT_PATH=ghp
+    export GHP_DATABASE_VAULT_AUTH_METHOD=kubernetes
+    export GHP_DATABASE_VAULT_K8S_ROLE=ghp
+    # Optional — override only if you mounted the auth backend at a non-default path:
+    # export GHP_DATABASE_VAULT_K8S_MOUNT=kubernetes/my-cluster
+    # Optional — override only if your projected token is at a non-standard path:
+    # export GHP_DATABASE_VAULT_K8S_TOKEN_PATH=/var/run/secrets/kubernetes.io/serviceaccount/token
+    ```
+
+=== "Kubernetes — YAML"
+
+    ```yaml
+    database:
+      driver: vault
+      vault_addr: https://vault.example.com:8200
+      vault_mount: secret
+      vault_path: ghp
+      vault_auth_method: kubernetes
+      vault_k8s_role: ghp
+      # vault_k8s_mount: kubernetes        # default; override for multi-cluster mounts
+      # vault_k8s_token_path: /var/run/secrets/kubernetes.io/serviceaccount/token
     ```
 
 | Field | Env Var | Default | Description |
@@ -126,8 +254,12 @@ vault write auth/approle/role/ghp/custom-secret-id secret_id="my-secret-id"
 | `vault_addr` | `GHP_DATABASE_VAULT_ADDR` | — | Vault server address (required) |
 | `vault_mount` | `GHP_DATABASE_VAULT_MOUNT` | `secret` | KV v2 secrets engine mount path |
 | `vault_path` | `GHP_DATABASE_VAULT_PATH` | `ghp` | Key prefix within the mount |
-| `vault_role_id` | `GHP_DATABASE_VAULT_ROLE_ID` | — | AppRole role ID (required) |
-| `vault_secret_id` | `GHP_DATABASE_VAULT_SECRET_ID` | — | AppRole secret ID (required) |
+| `vault_auth_method` | `GHP_DATABASE_VAULT_AUTH_METHOD` | `approle` | Auth method: `approle` or `kubernetes` |
+| `vault_role_id` | `GHP_DATABASE_VAULT_ROLE_ID` | — | AppRole role ID (required when method=`approle`) |
+| `vault_secret_id` | `GHP_DATABASE_VAULT_SECRET_ID` | — | AppRole secret ID (required when method=`approle`) |
+| `vault_k8s_role` | `GHP_DATABASE_VAULT_K8S_ROLE` | — | Vault role name (required when method=`kubernetes`) |
+| `vault_k8s_mount` | `GHP_DATABASE_VAULT_K8S_MOUNT` | `kubernetes` | Auth mount path for the kubernetes backend |
+| `vault_k8s_token_path` | `GHP_DATABASE_VAULT_K8S_TOKEN_PATH` | `/var/run/secrets/kubernetes.io/serviceaccount/token` | Path to the projected service account JWT |
 
 !!! tip "No encryption key needed"
     When using `driver: vault`, the `GHP_ENCRYPTION_KEY` setting is ignored.
@@ -171,18 +303,36 @@ application. The `ghp migrate` command is not applicable when using Vault.
 
 ## Token Lifecycle and Re-authentication
 
-ghp authenticates to Vault using AppRole at startup. The issued Vault token
-has a limited TTL (configured via `token_ttl` on the role). When the token
-expires:
+ghp authenticates to Vault at startup using the configured method. The
+issued Vault token has a limited TTL (configured via `token_ttl` on the
+role). When the token expires:
 
 1. The next Vault operation returns a 403 (permission denied)
-2. ghp automatically re-authenticates using the stored role ID and secret ID
+2. ghp automatically re-authenticates using the stored credentials
 3. The failed operation is retried with the new token
 
-This is transparent to users and requires no manual intervention. The only
-scenario requiring operator action is if the **secret ID itself expires**
-(controlled by `secret_id_ttl` on the role) — in that case, generate a new
-secret ID and update the `GHP_DATABASE_VAULT_SECRET_ID` environment variable.
+This is transparent to users and requires no manual intervention.
+
+### AppRole
+
+The only scenario requiring operator action is if the **secret ID itself
+expires** (controlled by `secret_id_ttl` on the role) — in that case,
+generate a new secret ID and update the `GHP_DATABASE_VAULT_SECRET_ID`
+environment variable.
+
+### Kubernetes
+
+Kubernetes projects a service account token into the pod and rotates it
+periodically (typically every hour, controlled by `--service-account-extend-token-expiration`
+on the API server). On every re-authentication, ghp **re-reads the token
+file from disk** before calling `auth/<mount>/login`, so rotated tokens
+are picked up automatically without restarting the pod.
+
+No operator action is required for the kubernetes method beyond the initial
+role binding. If the bound service account is deleted or the kubernetes auth
+backend's API server CA changes, ghp's next re-authentication will fail —
+investigate via the Vault audit log and the `ghp_proxy_decision_duration_seconds`
+metric for elevated `github_token_resolution` latency.
 
 ## High Availability
 

--- a/docs/admin/vault.md
+++ b/docs/admin/vault.md
@@ -55,11 +55,18 @@ Choose one of the following based on where ghp runs:
     ```
 
     Configure the auth backend so Vault can validate JWTs issued by the
-    cluster's API server. The recommended pattern is to use Vault's own
+    cluster's API server. Write to `auth/<mount>/config` matching the path
+    you enabled above. The recommended pattern is to use Vault's own
     service account to call the TokenReview API:
 
     ```bash
+    # Default mount:
     vault write auth/kubernetes/config \
+      kubernetes_host="https://kubernetes.default.svc:443" \
+      kubernetes_ca_cert=@/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+
+    # Custom mount (matching `-path=kubernetes/my-cluster` above):
+    vault write auth/kubernetes/my-cluster/config \
       kubernetes_host="https://kubernetes.default.svc:443" \
       kubernetes_ca_cert=@/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
     ```

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -137,12 +137,19 @@ ghp supports three storage backends:
 
 - **SQLite** — single-file database, ideal for development and small deployments
 - **PostgreSQL** — production-grade relational database
-- **HashiCorp Vault** — secrets-native storage using KV v2 secrets engine with AppRole authentication
+- **HashiCorp Vault** — secrets-native storage using KV v2 secrets engine, authenticating via AppRole or Kubernetes service-account auth
 
 All backends implement the same `Store` interface and provide identical
 feature parity. The Vault backend stores all data (users, tokens, apps) as
 KV v2 secrets and uses index entries for lookups. It does not require SQL
 migrations and does not need an `encryption_key` (Vault encrypts at rest).
+
+When ghp runs on Kubernetes, the Vault backend can authenticate using the
+pod's projected service account JWT directly — no AppRole role-id /
+secret-id provisioning is needed and Vault Secret Operator (VSO) is not
+required for the auth path. ghp re-reads the projected token from disk on
+every re-authentication, so kubelet-rotated tokens are picked up
+automatically.
 
 !!! note "Vault concurrency limitation"
     Vault KV does not support atomic increments. Token usage counters use a

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -133,6 +133,22 @@ type DatabaseConfig struct {
 	VaultPath     string `koanf:"vault_path"`
 	VaultRoleID   string `koanf:"vault_role_id"`
 	VaultSecretID string `koanf:"vault_secret_id"`
+
+	// VaultAuthMethod selects how ghp authenticates to Vault.
+	// Supported values: "approle" (default) and "kubernetes".
+	VaultAuthMethod string `koanf:"vault_auth_method"`
+	// VaultK8sRole is the Vault role to authenticate as when
+	// VaultAuthMethod is "kubernetes". Required for that method.
+	VaultK8sRole string `koanf:"vault_k8s_role"`
+	// VaultK8sMount is the Vault auth mount path for the kubernetes
+	// auth backend (e.g. "kubernetes" or "kubernetes/cluster-name").
+	// Defaults to "kubernetes" when empty.
+	VaultK8sMount string `koanf:"vault_k8s_mount"`
+	// VaultK8sTokenPath is the path on disk to the projected service
+	// account token. The file is re-read on each (re-)authentication so
+	// rotated tokens are picked up automatically. Defaults to the
+	// in-cluster path when empty.
+	VaultK8sTokenPath string `koanf:"vault_k8s_token_path"`
 }
 
 type ServerConfig struct {
@@ -215,8 +231,11 @@ type AuthConfig struct {
 func Defaults() *Config {
 	return &Config{
 		Database: DatabaseConfig{
-			Driver: "sqlite",
-			DSN:    "ghp.db",
+			Driver:            "sqlite",
+			DSN:               "ghp.db",
+			VaultAuthMethod:   "approle",
+			VaultK8sMount:     "kubernetes",
+			VaultK8sTokenPath: "/var/run/secrets/kubernetes.io/serviceaccount/token",
 		},
 		Server: ServerConfig{
 			Listen: ":8080",

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -292,3 +292,43 @@ func TestLoadBlockAnonymousGitFromYAML(t *testing.T) {
 		t.Error("expected Block.AnonymousGit to be true when set in YAML")
 	}
 }
+
+func TestVaultAuthDefaults(t *testing.T) {
+	cfg, err := Load("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := cfg.Database.VaultAuthMethod, "approle"; got != want {
+		t.Errorf("VaultAuthMethod default = %q, want %q", got, want)
+	}
+	if got, want := cfg.Database.VaultK8sMount, "kubernetes"; got != want {
+		t.Errorf("VaultK8sMount default = %q, want %q", got, want)
+	}
+	if got, want := cfg.Database.VaultK8sTokenPath, "/var/run/secrets/kubernetes.io/serviceaccount/token"; got != want {
+		t.Errorf("VaultK8sTokenPath default = %q, want %q", got, want)
+	}
+}
+
+func TestLoadVaultK8sFromEnv(t *testing.T) {
+	t.Setenv("GHP_DATABASE_VAULT_AUTH_METHOD", "kubernetes")
+	t.Setenv("GHP_DATABASE_VAULT_K8S_ROLE", "ghp")
+	t.Setenv("GHP_DATABASE_VAULT_K8S_MOUNT", "kubernetes/sin-common-apps-1")
+	t.Setenv("GHP_DATABASE_VAULT_K8S_TOKEN_PATH", "/run/secrets/projected/token")
+
+	cfg, err := Load("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Database.VaultAuthMethod != "kubernetes" {
+		t.Errorf("VaultAuthMethod = %q, want kubernetes", cfg.Database.VaultAuthMethod)
+	}
+	if cfg.Database.VaultK8sRole != "ghp" {
+		t.Errorf("VaultK8sRole = %q, want ghp", cfg.Database.VaultK8sRole)
+	}
+	if cfg.Database.VaultK8sMount != "kubernetes/sin-common-apps-1" {
+		t.Errorf("VaultK8sMount = %q, want kubernetes/sin-common-apps-1", cfg.Database.VaultK8sMount)
+	}
+	if cfg.Database.VaultK8sTokenPath != "/run/secrets/projected/token" {
+		t.Errorf("VaultK8sTokenPath = %q, want /run/secrets/projected/token", cfg.Database.VaultK8sTokenPath)
+	}
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -294,10 +294,10 @@ func TestLoadBlockAnonymousGitFromYAML(t *testing.T) {
 }
 
 func TestVaultAuthDefaults(t *testing.T) {
-	cfg, err := Load("")
-	if err != nil {
-		t.Fatal(err)
-	}
+	// Assert against Defaults() rather than Load("") so ambient
+	// GHP_DATABASE_VAULT_* environment variables on a developer or CI
+	// machine cannot mask a regression in the documented defaults.
+	cfg := Defaults()
 	if got, want := cfg.Database.VaultAuthMethod, "approle"; got != want {
 		t.Errorf("VaultAuthMethod default = %q, want %q", got, want)
 	}

--- a/internal/database/vault.go
+++ b/internal/database/vault.go
@@ -111,13 +111,20 @@ func NewVaultStore(ctx context.Context, cfg VaultConfig) (*VaultStore, error) {
 
 	switch authMethod {
 	case VaultAuthMethodAppRole:
-		// No additional defaults required.
+		if store.roleID == "" {
+			return nil, fmt.Errorf("vault approle auth: role_id is required")
+		}
+		if store.secretID == "" {
+			return nil, fmt.Errorf("vault approle auth: secret_id is required")
+		}
 	case VaultAuthMethodKubernetes:
 		if store.k8sRole == "" {
 			return nil, fmt.Errorf("vault kubernetes auth: role is required")
 		}
 		if store.k8sMount == "" {
 			store.k8sMount = DefaultK8sAuthMount
+		} else if strings.Trim(strings.TrimSpace(store.k8sMount), "/") == "" {
+			return nil, fmt.Errorf("vault kubernetes auth: mount path %q is invalid", store.k8sMount)
 		}
 		if store.k8sTokenPath == "" {
 			store.k8sTokenPath = DefaultK8sTokenPath
@@ -209,8 +216,12 @@ func (s *VaultStore) withRelogin(ctx context.Context, fn func() error) error {
 	}
 	if is403 {
 		if reloginErr := s.login(ctx); reloginErr != nil {
-			// Return original error — re-login failed.
-			return err
+			// Surface both the 403 that triggered the re-login and the
+			// re-authentication failure itself. With kubernetes auth, the
+			// inner error is often the actionable one (e.g. "service
+			// account token at /var/run/... is empty") and would otherwise
+			// be hidden behind the original "permission denied".
+			return fmt.Errorf("vault re-authentication after 403 failed: %w (original error: %v)", reloginErr, err)
 		}
 		return fn()
 	}

--- a/internal/database/vault.go
+++ b/internal/database/vault.go
@@ -139,7 +139,7 @@ func NewVaultStore(ctx context.Context, cfg VaultConfig) (*VaultStore, error) {
 	}
 
 	if err := store.login(ctx); err != nil {
-		return nil, fmt.Errorf("vault %s login: %w", authMethod, err)
+		return nil, err
 	}
 
 	return store, nil

--- a/internal/database/vault.go
+++ b/internal/database/vault.go
@@ -6,11 +6,25 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
 	"strings"
 	"time"
 
 	"github.com/google/uuid"
 	vault "github.com/hashicorp/vault/api"
+)
+
+// Supported Vault auth methods for the ghp database backend.
+const (
+	VaultAuthMethodAppRole    = "approle"
+	VaultAuthMethodKubernetes = "kubernetes"
+
+	// DefaultK8sAuthMount is the conventional auth mount path for the
+	// Vault kubernetes auth backend.
+	DefaultK8sAuthMount = "kubernetes"
+	// DefaultK8sTokenPath is the standard path to the projected service
+	// account token inside a pod.
+	DefaultK8sTokenPath = "/var/run/secrets/kubernetes.io/serviceaccount/token"
 )
 
 // VaultStore implements Store using HashiCorp Vault KV v2 secrets engine.
@@ -19,21 +33,47 @@ type VaultStore struct {
 	mountPath string // KV v2 mount path, e.g. "secret"
 	basePath  string // prefix within the mount, e.g. "ghp"
 
-	// Stored for re-authentication when the token expires.
+	// Authentication parameters retained for re-login on token expiry.
+	authMethod string // "approle" or "kubernetes"
+
+	// AppRole fields (used when authMethod == "approle").
 	roleID   string
 	secretID string
+
+	// Kubernetes fields (used when authMethod == "kubernetes").
+	k8sRole      string
+	k8sMount     string
+	k8sTokenPath string
 }
 
 // VaultConfig holds configuration for Vault connectivity.
 type VaultConfig struct {
 	Addr      string // Vault server address
-	RoleID    string // AppRole role ID
-	SecretID  string // AppRole secret ID
 	MountPath string // KV v2 mount path (default: "secret")
 	BasePath  string // key prefix (default: "ghp")
+
+	// AuthMethod selects how ghp authenticates to Vault. Valid values:
+	// "approle" (default) and "kubernetes". An empty string is treated as
+	// "approle" for backwards compatibility.
+	AuthMethod string
+
+	// AppRole credentials. Required when AuthMethod is "approle".
+	RoleID   string
+	SecretID string
+
+	// Kubernetes auth fields. Required when AuthMethod is "kubernetes".
+	// K8sRole is the Vault role to authenticate as.
+	// K8sMount is the auth mount path (default: "kubernetes").
+	// K8sTokenPath is the path to the projected service account JWT
+	// (default: /var/run/secrets/kubernetes.io/serviceaccount/token).
+	K8sRole      string
+	K8sMount     string
+	K8sTokenPath string
 }
 
-// NewVaultStore creates a VaultStore authenticated via AppRole.
+// NewVaultStore creates a VaultStore authenticated to Vault using the
+// configured auth method (AppRole by default, or kubernetes auth when
+// requested).
 func NewVaultStore(ctx context.Context, cfg VaultConfig) (*VaultStore, error) {
 	vaultCfg := vault.DefaultConfig()
 	vaultCfg.Address = cfg.Addr
@@ -52,25 +92,66 @@ func NewVaultStore(ctx context.Context, cfg VaultConfig) (*VaultStore, error) {
 		basePath = "ghp"
 	}
 
-	store := &VaultStore{
-		client:    client,
-		mountPath: mountPath,
-		basePath:  basePath,
-		roleID:    cfg.RoleID,
-		secretID:  cfg.SecretID,
+	authMethod := cfg.AuthMethod
+	if authMethod == "" {
+		authMethod = VaultAuthMethodAppRole
 	}
 
-	// Authenticate via AppRole.
+	store := &VaultStore{
+		client:       client,
+		mountPath:    mountPath,
+		basePath:     basePath,
+		authMethod:   authMethod,
+		roleID:       cfg.RoleID,
+		secretID:     cfg.SecretID,
+		k8sRole:      cfg.K8sRole,
+		k8sMount:     cfg.K8sMount,
+		k8sTokenPath: cfg.K8sTokenPath,
+	}
+
+	switch authMethod {
+	case VaultAuthMethodAppRole:
+		// No additional defaults required.
+	case VaultAuthMethodKubernetes:
+		if store.k8sRole == "" {
+			return nil, fmt.Errorf("vault kubernetes auth: role is required")
+		}
+		if store.k8sMount == "" {
+			store.k8sMount = DefaultK8sAuthMount
+		}
+		if store.k8sTokenPath == "" {
+			store.k8sTokenPath = DefaultK8sTokenPath
+		}
+	default:
+		return nil, fmt.Errorf("unsupported vault auth method: %q (valid: %q, %q)",
+			authMethod, VaultAuthMethodAppRole, VaultAuthMethodKubernetes)
+	}
+
 	if err := store.login(ctx); err != nil {
-		return nil, fmt.Errorf("vault approle login: %w", err)
+		return nil, fmt.Errorf("vault %s login: %w", authMethod, err)
 	}
 
 	return store, nil
 }
 
-// login authenticates to Vault using the stored AppRole credentials.
-// It is safe to call repeatedly; each call replaces the current token.
+// login authenticates to Vault using the configured auth method. It is
+// safe to call repeatedly; each call replaces the current token.
+//
+// For the kubernetes method, the JWT file is re-read on every call so
+// projected service-account tokens that were rotated by the kubelet are
+// picked up automatically when the previous Vault token expires.
 func (s *VaultStore) login(ctx context.Context) error {
+	switch s.authMethod {
+	case VaultAuthMethodKubernetes:
+		return s.loginKubernetes(ctx)
+	case VaultAuthMethodAppRole, "":
+		return s.loginAppRole(ctx)
+	default:
+		return fmt.Errorf("unsupported vault auth method: %q", s.authMethod)
+	}
+}
+
+func (s *VaultStore) loginAppRole(ctx context.Context) error {
 	loginResp, err := s.client.Logical().WriteWithContext(ctx, "auth/approle/login", map[string]interface{}{
 		"role_id":   s.roleID,
 		"secret_id": s.secretID,
@@ -80,6 +161,31 @@ func (s *VaultStore) login(ctx context.Context) error {
 	}
 	if loginResp == nil || loginResp.Auth == nil {
 		return fmt.Errorf("approle login returned no auth token")
+	}
+	s.client.SetToken(loginResp.Auth.ClientToken)
+	return nil
+}
+
+func (s *VaultStore) loginKubernetes(ctx context.Context) error {
+	jwt, err := os.ReadFile(s.k8sTokenPath)
+	if err != nil {
+		return fmt.Errorf("reading service account token from %s: %w", s.k8sTokenPath, err)
+	}
+	jwtStr := strings.TrimSpace(string(jwt))
+	if jwtStr == "" {
+		return fmt.Errorf("service account token at %s is empty", s.k8sTokenPath)
+	}
+
+	loginPath := fmt.Sprintf("auth/%s/login", strings.Trim(s.k8sMount, "/"))
+	loginResp, err := s.client.Logical().WriteWithContext(ctx, loginPath, map[string]interface{}{
+		"role": s.k8sRole,
+		"jwt":  jwtStr,
+	})
+	if err != nil {
+		return fmt.Errorf("kubernetes login: %w", err)
+	}
+	if loginResp == nil || loginResp.Auth == nil {
+		return fmt.Errorf("kubernetes login returned no auth token")
 	}
 	s.client.SetToken(loginResp.Auth.ClientToken)
 	return nil

--- a/internal/database/vault.go
+++ b/internal/database/vault.go
@@ -123,8 +123,12 @@ func NewVaultStore(ctx context.Context, cfg VaultConfig) (*VaultStore, error) {
 		}
 		if store.k8sMount == "" {
 			store.k8sMount = DefaultK8sAuthMount
-		} else if strings.Trim(strings.TrimSpace(store.k8sMount), "/") == "" {
-			return nil, fmt.Errorf("vault kubernetes auth: mount path %q is invalid", store.k8sMount)
+		} else {
+			normalized := strings.Trim(strings.TrimSpace(store.k8sMount), "/")
+			if normalized == "" {
+				return nil, fmt.Errorf("vault kubernetes auth: mount path %q is invalid", store.k8sMount)
+			}
+			store.k8sMount = normalized
 		}
 		if store.k8sTokenPath == "" {
 			store.k8sTokenPath = DefaultK8sTokenPath
@@ -183,7 +187,7 @@ func (s *VaultStore) loginKubernetes(ctx context.Context) error {
 		return fmt.Errorf("service account token at %s is empty", s.k8sTokenPath)
 	}
 
-	loginPath := fmt.Sprintf("auth/%s/login", strings.Trim(s.k8sMount, "/"))
+	loginPath := fmt.Sprintf("auth/%s/login", s.k8sMount)
 	loginResp, err := s.client.Logical().WriteWithContext(ctx, loginPath, map[string]interface{}{
 		"role": s.k8sRole,
 		"jwt":  jwtStr,
@@ -199,8 +203,9 @@ func (s *VaultStore) loginKubernetes(ctx context.Context) error {
 }
 
 // withRelogin executes fn; if fn returns a 403 (expired/invalid token) it
-// re-authenticates once and retries. This transparently handles AppRole
-// tokens that expire during the server's lifetime.
+// re-authenticates once using the configured Vault auth method and retries.
+// This transparently handles Vault tokens that expire during the server's
+// lifetime, regardless of whether AppRole or kubernetes auth is in use.
 func (s *VaultStore) withRelogin(ctx context.Context, fn func() error) error {
 	err := fn()
 	if err == nil {

--- a/internal/database/vault_k8s_test.go
+++ b/internal/database/vault_k8s_test.go
@@ -13,8 +13,8 @@ import (
 )
 
 // fakeVault is a minimal HTTP stand-in for Vault that records login requests
-// and returns canned responses. It supports both AppRole and kubernetes auth
-// login endpoints and a single KV v2 read used to confirm token usage.
+// and returns canned responses. It supports a kubernetes auth login endpoint
+// and a single KV v2 read used to confirm token usage.
 type fakeVault struct {
 	t      *testing.T
 	server *httptest.Server

--- a/internal/database/vault_k8s_test.go
+++ b/internal/database/vault_k8s_test.go
@@ -202,6 +202,58 @@ func TestNewVaultStoreUnsupportedAuthMethod(t *testing.T) {
 	}
 }
 
+func TestNewVaultStoreAppRoleMissingRoleID(t *testing.T) {
+	_, err := NewVaultStore(context.Background(), VaultConfig{
+		Addr:       "http://localhost:1",
+		AuthMethod: VaultAuthMethodAppRole,
+		SecretID:   "secret",
+	})
+	if err == nil {
+		t.Fatal("expected error when approle role_id is missing")
+	}
+	if !strings.Contains(err.Error(), "role_id is required") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestNewVaultStoreAppRoleMissingSecretID(t *testing.T) {
+	_, err := NewVaultStore(context.Background(), VaultConfig{
+		Addr:       "http://localhost:1",
+		AuthMethod: VaultAuthMethodAppRole,
+		RoleID:     "role",
+	})
+	if err == nil {
+		t.Fatal("expected error when approle secret_id is missing")
+	}
+	if !strings.Contains(err.Error(), "secret_id is required") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestNewVaultStoreKubernetesInvalidMount(t *testing.T) {
+	tokenPath := filepath.Join(t.TempDir(), "token")
+	if err := os.WriteFile(tokenPath, []byte("jwt"), 0o600); err != nil {
+		t.Fatalf("write token: %v", err)
+	}
+	for _, mount := range []string{"/", "//", " / "} {
+		t.Run(mount, func(t *testing.T) {
+			_, err := NewVaultStore(context.Background(), VaultConfig{
+				Addr:         "http://localhost:1",
+				AuthMethod:   VaultAuthMethodKubernetes,
+				K8sRole:      "ghp",
+				K8sMount:     mount,
+				K8sTokenPath: tokenPath,
+			})
+			if err == nil {
+				t.Fatalf("expected error for k8s mount %q", mount)
+			}
+			if !strings.Contains(err.Error(), "mount path") {
+				t.Errorf("error should mention mount path, got: %v", err)
+			}
+		})
+	}
+}
+
 // TestVaultStoreKubernetesReloginRereadsJWT verifies that after a 403 from
 // Vault, withRelogin re-reads the service-account token from disk before
 // calling auth/<mount>/login again. This mirrors how the kubelet rotates
@@ -250,5 +302,50 @@ func TestVaultStoreKubernetesReloginRereadsJWT(t *testing.T) {
 	}
 	if got := store.client.Token(); got != "ghp-vault-token-2" {
 		t.Errorf("client token after relogin = %q, want ghp-vault-token-2", got)
+	}
+}
+
+// TestVaultStoreReloginErrorSurfacesInnerError verifies that when the initial
+// 403-triggered re-authentication itself fails (e.g. the projected SA token
+// went missing), the error returned to the caller includes the re-login
+// failure rather than just the original "permission denied" — otherwise
+// the actionable cause is invisible to operators.
+func TestVaultStoreReloginErrorSurfacesInnerError(t *testing.T) {
+	mount := "kubernetes"
+	fv := newFakeVault(t, mount)
+
+	tokenPath := filepath.Join(t.TempDir(), "token")
+	if err := os.WriteFile(tokenPath, []byte("jwt-1"), 0o600); err != nil {
+		t.Fatalf("write token: %v", err)
+	}
+	store, err := NewVaultStore(context.Background(), VaultConfig{
+		Addr:         fv.server.URL,
+		AuthMethod:   VaultAuthMethodKubernetes,
+		K8sRole:      "ghp",
+		K8sMount:     mount,
+		K8sTokenPath: tokenPath,
+	})
+	if err != nil {
+		t.Fatalf("NewVaultStore: %v", err)
+	}
+
+	// Force a 403 on the next KV op AND make re-login fail by deleting the
+	// token file from under us. The original error is "permission denied";
+	// the re-login error is "service account token at <path> ... no such
+	// file or directory". The returned error must include the latter.
+	fv.forceKVForbidden.Store(true)
+	if err := os.Remove(tokenPath); err != nil {
+		t.Fatalf("remove token: %v", err)
+	}
+
+	_, err = store.kvRead(context.Background(), "anything")
+	if err == nil {
+		t.Fatal("expected error when re-login fails")
+	}
+	if !strings.Contains(err.Error(), "re-authentication") {
+		t.Errorf("error should mention re-authentication: %v", err)
+	}
+	if !strings.Contains(err.Error(), "service account token") {
+		t.Errorf("error should surface inner relogin failure (missing token file): %v", err)
 	}
 }

--- a/internal/database/vault_k8s_test.go
+++ b/internal/database/vault_k8s_test.go
@@ -230,6 +230,32 @@ func TestNewVaultStoreAppRoleMissingSecretID(t *testing.T) {
 	}
 }
 
+// TestNewVaultStoreKubernetesMountNormalized verifies that whitespace and
+// surrounding slashes in K8sMount are stripped at construction so the
+// resulting login URL ("auth/<mount>/login") is well-formed even when the
+// operator supplied a sloppy value.
+func TestNewVaultStoreKubernetesMountNormalized(t *testing.T) {
+	mount := "kubernetes/my-cluster"
+	fv := newFakeVault(t, mount)
+
+	tokenPath := filepath.Join(t.TempDir(), "token")
+	if err := os.WriteFile(tokenPath, []byte("jwt"), 0o600); err != nil {
+		t.Fatalf("write token: %v", err)
+	}
+	if _, err := NewVaultStore(context.Background(), VaultConfig{
+		Addr:         fv.server.URL,
+		AuthMethod:   VaultAuthMethodKubernetes,
+		K8sRole:      "ghp",
+		K8sMount:     "  /kubernetes/my-cluster/  ",
+		K8sTokenPath: tokenPath,
+	}); err != nil {
+		t.Fatalf("NewVaultStore: %v", err)
+	}
+	if got := fv.loginCount.Load(); got != 1 {
+		t.Errorf("login count = %d, want 1 (whitespace-trimmed mount should match the registered handler)", got)
+	}
+}
+
 func TestNewVaultStoreKubernetesInvalidMount(t *testing.T) {
 	tokenPath := filepath.Join(t.TempDir(), "token")
 	if err := os.WriteFile(tokenPath, []byte("jwt"), 0o600); err != nil {

--- a/internal/database/vault_k8s_test.go
+++ b/internal/database/vault_k8s_test.go
@@ -1,0 +1,254 @@
+package database
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+// fakeVault is a minimal HTTP stand-in for Vault that records login requests
+// and returns canned responses. It supports both AppRole and kubernetes auth
+// login endpoints and a single KV v2 read used to confirm token usage.
+type fakeVault struct {
+	t      *testing.T
+	server *httptest.Server
+
+	// Captured kubernetes login fields.
+	gotRole atomic.Value // string
+	gotJWT  atomic.Value // string
+
+	// Number of times the kubernetes login endpoint was hit.
+	loginCount atomic.Int32
+
+	// Canned response token returned by the next login.
+	loginToken atomic.Value // string
+
+	// Whether the next KV read should return 403 to force a re-login.
+	forceKVForbidden atomic.Bool
+}
+
+func newFakeVault(t *testing.T, mountPath string) *fakeVault {
+	t.Helper()
+	fv := &fakeVault{t: t}
+	fv.loginToken.Store("ghp-vault-token-1")
+
+	mux := http.NewServeMux()
+
+	loginPath := "/v1/auth/" + strings.Trim(mountPath, "/") + "/login"
+	mux.HandleFunc(loginPath, func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]interface{}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		role, _ := body["role"].(string)
+		jwt, _ := body["jwt"].(string)
+		fv.gotRole.Store(role)
+		fv.gotJWT.Store(jwt)
+		fv.loginCount.Add(1)
+
+		token, _ := fv.loginToken.Load().(string)
+		writeAuthResponse(w, token)
+	})
+
+	mux.HandleFunc("/v1/secret/data/", func(w http.ResponseWriter, r *http.Request) {
+		if fv.forceKVForbidden.CompareAndSwap(true, false) {
+			w.WriteHeader(http.StatusForbidden)
+			_, _ = w.Write([]byte(`{"errors":["permission denied"]}`))
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":{"data":{"hello":"world"}}}`))
+	})
+
+	fv.server = httptest.NewServer(mux)
+	t.Cleanup(fv.server.Close)
+	return fv
+}
+
+func writeAuthResponse(w http.ResponseWriter, clientToken string) {
+	w.Header().Set("Content-Type", "application/json")
+	resp := map[string]interface{}{
+		"auth": map[string]interface{}{
+			"client_token":   clientToken,
+			"renewable":      true,
+			"lease_duration": 3600,
+		},
+	}
+	_ = json.NewEncoder(w).Encode(resp)
+}
+
+func TestNewVaultStoreKubernetesLogin(t *testing.T) {
+	mount := "kubernetes/test-cluster"
+	fv := newFakeVault(t, mount)
+
+	tokenPath := filepath.Join(t.TempDir(), "token")
+	if err := os.WriteFile(tokenPath, []byte("initial-jwt\n"), 0o600); err != nil {
+		t.Fatalf("write token: %v", err)
+	}
+
+	store, err := NewVaultStore(context.Background(), VaultConfig{
+		Addr:         fv.server.URL,
+		AuthMethod:   VaultAuthMethodKubernetes,
+		K8sRole:      "ghp",
+		K8sMount:     mount,
+		K8sTokenPath: tokenPath,
+	})
+	if err != nil {
+		t.Fatalf("NewVaultStore: %v", err)
+	}
+
+	if got, _ := fv.gotRole.Load().(string); got != "ghp" {
+		t.Errorf("login role = %q, want %q", got, "ghp")
+	}
+	if got, _ := fv.gotJWT.Load().(string); got != "initial-jwt" {
+		t.Errorf("login jwt = %q, want %q", got, "initial-jwt")
+	}
+	if got := fv.loginCount.Load(); got != 1 {
+		t.Errorf("login count = %d, want 1", got)
+	}
+
+	if got := store.client.Token(); got != "ghp-vault-token-1" {
+		t.Errorf("client token = %q, want ghp-vault-token-1", got)
+	}
+}
+
+func TestNewVaultStoreKubernetesDefaults(t *testing.T) {
+	fv := newFakeVault(t, DefaultK8sAuthMount)
+
+	tokenPath := filepath.Join(t.TempDir(), "token")
+	if err := os.WriteFile(tokenPath, []byte("jwt-default"), 0o600); err != nil {
+		t.Fatalf("write token: %v", err)
+	}
+
+	// Omit K8sMount so the default ("kubernetes") is used.
+	if _, err := NewVaultStore(context.Background(), VaultConfig{
+		Addr:         fv.server.URL,
+		AuthMethod:   VaultAuthMethodKubernetes,
+		K8sRole:      "ghp",
+		K8sTokenPath: tokenPath,
+	}); err != nil {
+		t.Fatalf("NewVaultStore: %v", err)
+	}
+	if got := fv.loginCount.Load(); got != 1 {
+		t.Errorf("login count = %d, want 1 (default mount path used)", got)
+	}
+}
+
+func TestNewVaultStoreKubernetesMissingRole(t *testing.T) {
+	_, err := NewVaultStore(context.Background(), VaultConfig{
+		Addr:       "http://localhost:1",
+		AuthMethod: VaultAuthMethodKubernetes,
+	})
+	if err == nil {
+		t.Fatal("expected error when k8s role is missing")
+	}
+	if !strings.Contains(err.Error(), "role is required") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestNewVaultStoreKubernetesMissingTokenFile(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "does-not-exist")
+	_, err := NewVaultStore(context.Background(), VaultConfig{
+		Addr:         "http://localhost:1",
+		AuthMethod:   VaultAuthMethodKubernetes,
+		K8sRole:      "ghp",
+		K8sTokenPath: missing,
+	})
+	if err == nil {
+		t.Fatal("expected error when token file is missing")
+	}
+	if !strings.Contains(err.Error(), "service account token") {
+		t.Errorf("error should mention service account token, got: %v", err)
+	}
+}
+
+func TestNewVaultStoreKubernetesEmptyTokenFile(t *testing.T) {
+	tokenPath := filepath.Join(t.TempDir(), "token")
+	if err := os.WriteFile(tokenPath, []byte("   \n"), 0o600); err != nil {
+		t.Fatalf("write token: %v", err)
+	}
+	_, err := NewVaultStore(context.Background(), VaultConfig{
+		Addr:         "http://localhost:1",
+		AuthMethod:   VaultAuthMethodKubernetes,
+		K8sRole:      "ghp",
+		K8sTokenPath: tokenPath,
+	})
+	if err == nil {
+		t.Fatal("expected error when token file is empty")
+	}
+	if !strings.Contains(err.Error(), "empty") {
+		t.Errorf("error should mention empty token, got: %v", err)
+	}
+}
+
+func TestNewVaultStoreUnsupportedAuthMethod(t *testing.T) {
+	_, err := NewVaultStore(context.Background(), VaultConfig{
+		Addr:       "http://localhost:1",
+		AuthMethod: "ldap",
+	})
+	if err == nil {
+		t.Fatal("expected error for unsupported auth method")
+	}
+	if !strings.Contains(err.Error(), "unsupported vault auth method") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+// TestVaultStoreKubernetesReloginRereadsJWT verifies that after a 403 from
+// Vault, withRelogin re-reads the service-account token from disk before
+// calling auth/<mount>/login again. This mirrors how the kubelet rotates
+// projected tokens during a pod's lifetime.
+func TestVaultStoreKubernetesReloginRereadsJWT(t *testing.T) {
+	mount := "kubernetes"
+	fv := newFakeVault(t, mount)
+
+	tokenPath := filepath.Join(t.TempDir(), "token")
+	if err := os.WriteFile(tokenPath, []byte("jwt-1"), 0o600); err != nil {
+		t.Fatalf("write token: %v", err)
+	}
+
+	store, err := NewVaultStore(context.Background(), VaultConfig{
+		Addr:         fv.server.URL,
+		AuthMethod:   VaultAuthMethodKubernetes,
+		K8sRole:      "ghp",
+		K8sMount:     mount,
+		K8sTokenPath: tokenPath,
+	})
+	if err != nil {
+		t.Fatalf("NewVaultStore: %v", err)
+	}
+	if got, _ := fv.gotJWT.Load().(string); got != "jwt-1" {
+		t.Fatalf("initial login jwt = %q, want jwt-1", got)
+	}
+
+	// Simulate kubelet rotating the projected token on disk.
+	if err := os.WriteFile(tokenPath, []byte("jwt-rotated"), 0o600); err != nil {
+		t.Fatalf("rewrite token: %v", err)
+	}
+	fv.loginToken.Store("ghp-vault-token-2")
+	fv.forceKVForbidden.Store(true)
+
+	// Trigger a KV operation; the first attempt 403s, withRelogin re-reads
+	// the JWT, re-authenticates, and retries.
+	if _, err := store.kvRead(context.Background(), "anything"); err != nil {
+		t.Fatalf("kvRead after relogin: %v", err)
+	}
+
+	if got, _ := fv.gotJWT.Load().(string); got != "jwt-rotated" {
+		t.Errorf("login jwt after relogin = %q, want jwt-rotated", got)
+	}
+	if got := fv.loginCount.Load(); got != 2 {
+		t.Errorf("login count = %d, want 2", got)
+	}
+	if got := store.client.Token(); got != "ghp-vault-token-2" {
+		t.Errorf("client token after relogin = %q, want ghp-vault-token-2", got)
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -207,11 +207,15 @@ func (s *Server) Run(ctx context.Context) error {
 	var err error
 	if s.cfg.Database.Driver == "vault" {
 		store, err = database.OpenVault(ctx, database.VaultConfig{
-			Addr:      s.cfg.Database.VaultAddr,
-			RoleID:    s.cfg.Database.VaultRoleID,
-			SecretID:  s.cfg.Database.VaultSecretID,
-			MountPath: s.cfg.Database.VaultMount,
-			BasePath:  s.cfg.Database.VaultPath,
+			Addr:         s.cfg.Database.VaultAddr,
+			MountPath:    s.cfg.Database.VaultMount,
+			BasePath:     s.cfg.Database.VaultPath,
+			AuthMethod:   s.cfg.Database.VaultAuthMethod,
+			RoleID:       s.cfg.Database.VaultRoleID,
+			SecretID:     s.cfg.Database.VaultSecretID,
+			K8sRole:      s.cfg.Database.VaultK8sRole,
+			K8sMount:     s.cfg.Database.VaultK8sMount,
+			K8sTokenPath: s.cfg.Database.VaultK8sTokenPath,
 		})
 	} else {
 		store, err = database.Open(s.cfg.Database.Driver, s.cfg.Database.DSN)


### PR DESCRIPTION
## Summary

- Adds `kubernetes` as an alternative Vault auth method alongside the existing `approle` flow, so ghp pods on Kubernetes can authenticate to Vault directly using their projected service account JWT — no role-id/secret-id provisioning and no Vault Secret Operator dependency on the auth path.
- New config fields: `vault_auth_method` (default `approle`), `vault_k8s_role`, `vault_k8s_mount` (default `kubernetes`), `vault_k8s_token_path` (default `/var/run/secrets/kubernetes.io/serviceaccount/token`). Backwards compatible — unset or `approle` preserves today's behavior.
- The existing 403→relogin retry path now re-reads the JWT from disk before each kubernetes login, so kubelet-rotated projected tokens are picked up automatically without restarting the pod.
- Hardens both auth methods at construction: AppRole now fails fast when `role_id`/`secret_id` are missing, kubernetes rejects mount paths that trim to empty (e.g. `/`) and stores a normalized form, and `withRelogin` surfaces re-authentication failures (previously hidden behind the original `permission denied`) so misconfigurations are diagnosable from logs.
- Documents the new method in `docs/admin/vault.md` (tabs for AppRole vs Kubernetes covering backend setup, role binding, SA wiring, and YAML/env-var configuration), `docs/admin/configuration.md` (env-var table + full YAML reference), and `docs/how-it-works.md` (storage backend overview).

Closes #179

## Test plan

- [x] `make check` (unit tests + `go vet`)
- [x] New unit tests in `internal/database/vault_k8s_test.go` cover: kubernetes login round-trip against an `httptest` Vault stub, default mount path resolution, missing-role and missing-AppRole-credential rejection, missing/empty token-file errors, invalid and whitespace-laden mount-path handling, unsupported auth method rejection, relogin error surfacing when re-authentication itself fails, and JWT re-read on relogin (kubelet rotation)
- [x] New config tests in `internal/config/config_test.go` cover defaults (asserted hermetically against `Defaults()`) and full env-var loading for `GHP_DATABASE_VAULT_AUTH_METHOD` / `GHP_DATABASE_VAULT_K8S_*`
- [ ] End-to-end smoke test against a real Vault + cluster with kubernetes auth configured (left for the operator rollout)