### PR TITLE
feat(proxy): redirect `codeload.github.com` archives to a caching mirror

### DIFF
--- a/docs/admin/configuration.md
+++ b/docs/admin/configuration.md
@@ -133,6 +133,16 @@ See [Token Type Border Policy](../features/border-policy.md) for details.
 
 See [Release Download Controls](../features/release-controls.md) for details.
 
+### Codeload Redirect
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `GHP_CODELOAD_REDIRECT_TO` | Base URL to redirect codeload.github.com archive requests to (must be absolute). When unset, requests are forwarded transparently to upstream. | |
+| `GHP_CODELOAD_ALLOW` | Comma-separated org or org/repo entries that bypass the redirect (passthrough to upstream) | |
+| `GHP_CODELOAD_ALLOW_COUNT` | Number of indexed allow entries (use with `GHP_CODELOAD_ALLOW_0`, `GHP_CODELOAD_ALLOW_1`, ...) | |
+
+See [Codeload Redirect](../features/codeload.md) for details.
+
 ### Git Cache
 
 | Variable | Description | Default |
@@ -236,6 +246,11 @@ releases:
   allow:                       # org or org/repo entries exempt from policy
     - "myorg"
     - "trusted/tool"
+
+codeload:
+  redirect_to: ""              # absolute URL base for redirecting codeload archive requests; passthrough when empty
+  allow:                       # org or org/repo entries that pass through to upstream codeload
+    - "myorg"
 
 cache:
   enabled: false               # enable git clone/fetch caching

--- a/docs/admin/monitoring.md
+++ b/docs/admin/monitoring.md
@@ -25,7 +25,7 @@ Scrape the metrics endpoint at `http(s)://<ghp-server>:9136/metrics` (HTTPS when
 | `ghp_http_request_total` | Counter | Total HTTP requests (labels: `backend`, `method`, `status`) |
 
 The `backend` label distinguishes traffic by virtualhost: `api.github.com`,
-`github.com`, `copilot`, or `management`.
+`github.com`, `codeload.github.com`, `copilot`, or `management`.
 
 #### Proxy Metrics
 
@@ -180,7 +180,7 @@ See [Codeload Redirect](../features/codeload.md) for configuration details.
 
 ## Access Logs
 
-ghp writes structured JSON access logs for every request across all four
+ghp writes structured JSON access logs for every request across all
 virtualhosts. Each log entry typically includes:
 
 - HTTP method, host, URI/path, and status code

--- a/docs/admin/monitoring.md
+++ b/docs/admin/monitoring.md
@@ -163,6 +163,21 @@ availability probe adds to redirected release downloads.
 See [Release Download Controls](../features/release-controls.md) for
 configuration details.
 
+#### Codeload Redirect Metrics
+
+| Metric | Type | Description |
+|--------|------|-------------|
+| `ghp_codeload_redirect_total` | Counter | codeload.github.com archive requests handled by the codeload handler (labels: `owner`, `repo`, `archive`, `result`) |
+
+The `archive` label is one of `tar.gz`, `zip`, `legacy.tar.gz`, or
+`legacy.zip`. The `result` label is `redirect` (302 to the configured
+caching mirror) or `passthrough` (forwarded to upstream codeload because the
+org/repo is in the allow list or no `redirect_to` is configured). The full
+ref (SHA, branch, or tag) is intentionally omitted from labels to keep
+cardinality bounded; query the access log for per-ref breakdowns.
+
+See [Codeload Redirect](../features/codeload.md) for configuration details.
+
 ## Access Logs
 
 ghp writes structured JSON access logs for every request across all four

--- a/docs/features/codeload.md
+++ b/docs/features/codeload.md
@@ -54,8 +54,15 @@ straightforward:
 - On subsequent requests for the same `(owner, repo, ref)`, serve from
   storage.
 
-Because the (owner, repo, sha) tuple identifies an immutable archive, the
-mirror can cache aggressively — the user is on the hook for the cache policy.
+Cacheability depends on what `ref` resolves to. When `ref` is a **commit
+SHA** (the common case for `actions/checkout@<sha>` and any pinned action
+reference) the `(owner, repo, sha)` tuple identifies an immutable archive
+and the mirror can cache it indefinitely. When `ref` is a **branch or tag
+name**, GitHub resolves it on each fetch and the underlying commit can move
+— mirrors should treat those entries as mutable (e.g. apply a short TTL,
+revalidate against `codeload.github.com`, or serve only SHA refs from
+cache). The redirect itself is opaque to ghp; the cache policy is the
+mirror's responsibility.
 
 ## Configuration
 

--- a/docs/features/codeload.md
+++ b/docs/features/codeload.md
@@ -1,0 +1,132 @@
+# Codeload Redirect
+
+## The Problem
+
+GitHub serves repository archive downloads (the `tar.gz` and `zip` snapshots
+that workflows like `actions/checkout` resolve to) from a separate host:
+`codeload.github.com`. A request looks like
+
+```
+GET https://codeload.github.com/actions/checkout/tar.gz/34e114876b0b11c390a56381ad16ebd13914f8d5
+```
+
+For a CI pipeline that runs the same `actions/checkout@v4` reference thousands
+of times a day, every job ends up pulling the same tarball — keyed by an
+immutable commit SHA — across the corporate network egress. When that egress
+is constrained (proxy outages, bandwidth caps, rate limiting) builds either
+slow down or fail outright with errors like:
+
+```
+Failed to download action 'https://codeload.github.com/actions/checkout/tar.gz/<sha>'.
+Error: The proxy tunnel request to proxy 'http://proxy.example.com:3128/' failed
+with status code '503'.
+```
+
+Because the archive content for a given `(owner, repo, sha)` triple never
+changes, this traffic is highly cacheable. ghp can steer codeload requests to
+an internal caching mirror so the first request fetches once from GitHub and
+every subsequent request hits the mirror.
+
+## How It Works
+
+When `codeload.github.com` resolves to ghp (typically via DNS or an HTTP proxy
+configured to forward this host), ghp inspects each request:
+
+```
+/{owner}/{repo}/{format}/{ref}
+```
+
+where `format` is one of `tar.gz`, `zip`, `legacy.tar.gz`, or `legacy.zip`,
+and `ref` is a commit SHA, branch, or tag.
+
+When `codeload.redirect_to` is configured, a matching request is answered
+immediately with `302 Found` to `redirect_to + path`, preserving the original
+query string. Non-matching paths and requests for orgs or org/repo pairs in
+the allow list are forwarded transparently to upstream `codeload.github.com`
+so other tooling continues to work.
+
+ghp does **not** cache anything itself — it offloads the cache to a mirror you
+already operate on the corporate network. The expected mirror behaviour is
+straightforward:
+
+- On first request for `(owner, repo, ref)`, fetch the archive from
+  `codeload.github.com` and store it.
+- On subsequent requests for the same `(owner, repo, ref)`, serve from
+  storage.
+
+Because the (owner, repo, sha) tuple identifies an immutable archive, the
+mirror can cache aggressively — the user is on the hook for the cache policy.
+
+## Configuration
+
+```yaml
+codeload:
+  redirect_to: "https://codeload.cache.example.com/"
+  allow:
+    - "myorg"              # all repos under this org bypass the redirect
+    - "external/tool"      # only this specific repo bypasses
+```
+
+Or via environment variables:
+
+```bash
+GHP_CODELOAD_REDIRECT_TO=https://codeload.cache.example.com/
+GHP_CODELOAD_ALLOW=myorg,external/tool
+```
+
+Indexed allow lists are supported for orchestrators that cannot pass
+comma-separated values reliably:
+
+```bash
+GHP_CODELOAD_REDIRECT_TO=https://codeload.cache.example.com/
+GHP_CODELOAD_ALLOW_COUNT=2
+GHP_CODELOAD_ALLOW_0=myorg
+GHP_CODELOAD_ALLOW_1=external/tool
+```
+
+When `redirect_to` is empty the codeload handler is effectively a transparent
+proxy — every request is forwarded to upstream `codeload.github.com`. This
+means simply pointing `codeload.github.com` at ghp does not break anything
+even before the redirect is configured.
+
+The `redirect_to` value must be an absolute URL (scheme + host); a relative
+path causes ghp to log an error and fall back to passthrough. `redirect_to`
+and the allow list are reloaded on `SIGUSR1` along with the rest of the
+hot-reloadable configuration.
+
+## Monitoring
+
+Each archive request handled by the codeload handler increments the counter:
+
+- **`ghp_codeload_redirect_total`** — labeled by `owner`, `repo`, `archive`
+  (one of `tar.gz`, `zip`, `legacy.tar.gz`, `legacy.zip`), and `result`
+  (`redirect` or `passthrough`).
+
+The full `ref` (SHA, branch, or tag) is intentionally **not** a metric label:
+including a SHA would create unbounded label cardinality. The full request URL
+— and therefore the `ref` — is recorded in the JSON access log alongside the
+backend (`codeload.github.com`), so per-SHA analysis is still possible via log
+queries.
+
+Use this metric to validate cache hit rates against your mirror's own counters
+and to spot which `(owner, repo)` pairs dominate egress.
+
+## Limitations
+
+- **Detection is path-based.** The handler matches the URL pattern used by
+  GitHub's archive download mechanism. If GitHub changes its URL structure in
+  future, the regex would need updating.
+
+- **Authentication is not forwarded on redirect.** A 302 strips the
+  `Authorization` header in most clients, so private-repo archives served by
+  the mirror require the mirror to handle authentication itself or be on a
+  trusted internal network. The transparent passthrough path (allow list and
+  no `redirect_to`) preserves the original request, including its
+  Authorization header.
+
+- **No HEAD availability check.** Unlike the [release redirect feature](release-controls.md#head-check),
+  the codeload handler does not probe the mirror before redirecting. The
+  expected mirror is a transparent caching proxy — fetching from upstream on
+  cache miss — so a pre-flight check would always succeed and just add
+  latency. If you operate a selective mirror that only stores a curated subset
+  of archives, file an issue describing the use case.

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -31,7 +31,7 @@ For each request, the proxy:
 
 ## Virtualhost Routing
 
-ghp serves four distinct roles depending on which hostname the request arrives on:
+ghp serves several distinct roles depending on which hostname the request arrives on:
 
 | Hostname | Role |
 |----------|------|

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -37,6 +37,7 @@ ghp serves four distinct roles depending on which hostname the request arrives o
 |----------|------|
 | `api.github.com` | **API proxy** — validates tokens, enforces scopes, injects credentials, logs every request |
 | `github.com` | **Git passthrough** — transparent proxy for `git clone`, `git push`, etc. with token interception |
+| `codeload.github.com` | **Codeload redirect/passthrough** — optionally redirects repo archive downloads to a caching mirror (see [Codeload Redirect](features/codeload.md)); transparent passthrough otherwise |
 | `*.githubcopilot.com` | **Copilot passthrough** — forwards Copilot traffic transparently; all requests are logged |
 | Your management host | **Dashboard** — web UI, GitHub OAuth login (web), CLI device-authorization endpoints, token management API |
 

--- a/internal/backend/backend.go
+++ b/internal/backend/backend.go
@@ -18,6 +18,12 @@ const (
 	// controls (releases.mode) are configured.
 	GitHub = "github.com"
 
+	// Codeload handles requests to codeload.github.com — repository archive
+	// downloads (zip/tarball by ref). Traffic is forwarded transparently to
+	// upstream by default; archive download paths may be redirected to a
+	// configured caching mirror when codeload.redirect_to is set.
+	Codeload = "codeload.github.com"
+
 	// Copilot handles requests to *.githubcopilot.com. Traffic is forwarded
 	// transparently without token interception or scope enforcement; only access
 	// logging and metrics are applied.

--- a/internal/backend/backend.go
+++ b/internal/backend/backend.go
@@ -1,4 +1,4 @@
-// Package backend defines the four upstream backend identifiers that ghp routes
+// Package backend defines the upstream backend identifiers that ghp routes
 // traffic to. These constants are used as the canonical labels for host-based
 // request dispatch, Prometheus metric labelling, and structured access logs.
 // Every HTTP request with a recognized/handled Host header is attributed to

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -14,6 +14,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/knadh/koanf/parsers/yaml"
@@ -23,7 +24,22 @@ import (
 )
 
 // Config represents the complete server configuration.
+//
+// Hot-reloadable fields (Admins, Tokens, Logging, Metrics, Auth, Block,
+// Releases, Codeload, Cache) are protected by mu: ReloadFrom takes the
+// write lock and the accessor methods (IsAdmin, IsTokenBlocked,
+// IsReleaseAllowed, IsCodeloadAllowed, CodeloadSnapshot) take the read
+// lock. Request handlers must read these fields through the accessors —
+// reading the embedded structs directly under concurrent reload is a data
+// race that `go test -race` will flag. Static fields (GitHub, Database,
+// Server, TLS, EncryptionKey, DevMode) are populated once at startup and
+// never mutated, so they're safe to read directly.
 type Config struct {
+	// mu guards all hot-reloadable fields below. Held for the duration of
+	// ReloadFrom so a single SIGUSR1 either fully replaces the runtime
+	// fields or is invisible to a reader that has the read lock.
+	mu sync.RWMutex
+
 	GitHub   GitHubConfig   `koanf:"github"`
 	Database DatabaseConfig `koanf:"database"`
 	Server   ServerConfig   `koanf:"server"`
@@ -413,11 +429,18 @@ func Load(path string) (*Config, error) {
 // ReloadFrom re-reads a YAML config file and updates hot-reloadable fields
 // in-place. Fields that require a restart (database, server listen addresses,
 // TLS certificates) are not updated.
+//
+// The hot-reloadable field updates are serialised with the read locks held by
+// the accessor methods (IsAdmin, IsTokenBlocked, IsReleaseAllowed,
+// IsCodeloadAllowed, CodeloadSnapshot) so requests in flight either observe
+// the pre-reload or post-reload values consistently — never a torn mix.
 func (c *Config) ReloadFrom(path string) error {
 	fresh, err := Load(path)
 	if err != nil {
 		return err
 	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
 	c.Admins = fresh.Admins
 	c.Tokens = fresh.Tokens
 	c.Logging = fresh.Logging
@@ -446,7 +469,13 @@ func splitCommaSlice(ss []string) []string {
 }
 
 // IsAdmin returns true if the given GitHub username is in the admin list.
+//
+// Safe to call concurrently with ReloadFrom: the read lock is held for the
+// duration of the lookup, so an in-flight reload either fully precedes or
+// fully follows this call.
 func (c *Config) IsAdmin(username string) bool {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
 	for _, admin := range c.Admins {
 		if strings.EqualFold(admin, username) {
 			return true
@@ -458,7 +487,11 @@ func (c *Config) IsAdmin(username string) bool {
 // IsTokenBlocked returns true when the token string's type prefix is blocked by
 // the border policy. Only the five standard GitHub token prefixes are evaluated;
 // ghp's own managed token types (ghx_, gha_) are never considered here.
+//
+// Safe to call concurrently with ReloadFrom.
 func (c *Config) IsTokenBlocked(token string) bool {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
 	switch {
 	case strings.HasPrefix(token, "ghp_"):
 		return c.Block.GHP
@@ -478,7 +511,11 @@ func (c *Config) IsTokenBlocked(token string) bool {
 // appears in the releases allow list, meaning it is exempt from the releases
 // policy (block or redirect). Matching is case-insensitive. An org-only entry
 // (e.g. "goodtune") permits any repository under that org.
+//
+// Safe to call concurrently with ReloadFrom.
 func (c *Config) IsReleaseAllowed(org, repo string) bool {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
 	orgRepo := org + "/" + repo
 	for _, entry := range c.Releases.Allow {
 		if strings.EqualFold(entry, org) || strings.EqualFold(entry, orgRepo) {
@@ -493,7 +530,11 @@ func (c *Config) IsReleaseAllowed(org, repo string) bool {
 // are passed through to upstream rather than redirected to the configured
 // caching mirror. Matching is case-insensitive. An org-only entry (e.g.
 // "goodtune") exempts every repository under that org.
+//
+// Safe to call concurrently with ReloadFrom.
 func (c *Config) IsCodeloadAllowed(org, repo string) bool {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
 	orgRepo := org + "/" + repo
 	for _, entry := range c.Codeload.Allow {
 		if strings.EqualFold(entry, org) || strings.EqualFold(entry, orgRepo) {
@@ -501,6 +542,24 @@ func (c *Config) IsCodeloadAllowed(org, repo string) bool {
 		}
 	}
 	return false
+}
+
+// CodeloadSnapshot returns a deep copy of the codeload configuration safe to
+// read across hot-reload boundaries. Use this from request handlers that need
+// more than just the allow check (e.g. reading RedirectTo): reading
+// cfg.Codeload directly is a data race against ReloadFrom and will be flagged
+// by `go test -race`.
+//
+// The returned value's slice fields are copies, so callers cannot observe a
+// slice that ReloadFrom is about to replace.
+func (c *Config) CodeloadSnapshot() CodeloadConfig {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	cp := c.Codeload
+	if c.Codeload.Allow != nil {
+		cp.Allow = append([]string(nil), c.Codeload.Allow...)
+	}
+	return cp
 }
 
 // WarnInvalidBlockTargets logs a warning for any block configuration targeting

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -441,8 +441,14 @@ func Load(path string) (*Config, error) {
 //
 // The hot-reloadable field updates are serialised with the read locks held by
 // the accessor methods (IsAdmin, IsTokenBlocked, IsReleaseAllowed,
-// IsCodeloadAllowed, CodeloadSnapshot) so requests in flight either observe
-// the pre-reload or post-reload values consistently — never a torn mix.
+// IsCodeloadAllowed, CodeloadRedirectTo). The guarantee is per accessor call:
+// any single accessor invocation observes either the pre-reload or
+// post-reload value of the field it reads — never a torn read of a slice or
+// string. The guarantee does NOT extend across multiple accessor calls;
+// e.g. CodeloadRedirectTo() followed by IsCodeloadAllowed(...) may interleave
+// with a reload between them, so a handler that needs cross-field consistency
+// must add a snapshot accessor that takes the lock once and copies the
+// related fields together.
 func (c *Config) ReloadFrom(path string) error {
 	fresh, err := Load(path)
 	if err != nil {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -36,6 +36,7 @@ type Config struct {
 	Auth     AuthConfig     `koanf:"auth"`
 	Block    BlockConfig    `koanf:"block"`
 	Releases ReleasesConfig `koanf:"releases"`
+	Codeload CodeloadConfig `koanf:"codeload"`
 
 	Cache CacheConfig `koanf:"cache"`
 
@@ -100,6 +101,29 @@ type ReleasesConfig struct {
 	// Allow is a list of org or org/repo entries that are exempt from the policy.
 	// Entries may be bare org names (e.g. "goodtune") or org/repo pairs
 	// (e.g. "goodtune/ghp"). Matching is case-insensitive.
+	Allow []string `koanf:"allow"`
+}
+
+// CodeloadConfig controls how codeload.github.com archive download requests
+// are handled. The codeload service serves repository archives at paths of the
+// form /{owner}/{repo}/(tar.gz|zip|legacy.tar.gz|legacy.zip)/{ref} — these are
+// highly cacheable (the (org, repo, sha) tuple is immutable) and a common
+// hotspot for build agents that resolve actions like actions/checkout@v4.
+//
+// When RedirectTo is set, matching archive requests are redirected with a 302
+// to RedirectTo + the original path, allowing an internal caching mirror to
+// serve the archive. When RedirectTo is empty, all codeload.github.com traffic
+// is forwarded transparently to the upstream service.
+type CodeloadConfig struct {
+	// RedirectTo is the base URL prepended to the original path when
+	// redirecting archive requests. Must be an absolute URL with scheme + host
+	// (e.g. "https://codeload.cache.example.com/"). When empty, the codeload
+	// handler simply proxies requests through to upstream codeload.github.com.
+	RedirectTo string `koanf:"redirect_to"`
+	// Allow is a list of org or org/repo entries that are exempt from the
+	// redirect (passed through to upstream). Entries may be bare org names
+	// (e.g. "goodtune") or org/repo pairs (e.g. "goodtune/ghp"). Matching is
+	// case-insensitive.
 	Allow []string `koanf:"allow"`
 }
 
@@ -297,7 +321,7 @@ func Load(path string) (*Config, error) {
 			if i := strings.Index(s, "_"); i > 0 {
 				section, field := s[:i], s[i+1:]
 				switch section {
-				case "github", "database", "server", "tls", "tokens", "logging", "metrics", "otel", "auth", "block", "releases", "cache":
+				case "github", "database", "server", "tls", "tokens", "logging", "metrics", "otel", "auth", "block", "releases", "codeload", "cache":
 					// Handle 3-level nesting for logging.file.*
 					if section == "logging" && strings.HasPrefix(field, "file_") {
 						return "logging.file." + field[len("file_"):], v
@@ -321,6 +345,7 @@ func Load(path string) (*Config, error) {
 	cfg.Admins = splitCommaSlice(cfg.Admins)
 	cfg.Auth.AllowedRedirects = splitCommaSlice(cfg.Auth.AllowedRedirects)
 	cfg.Releases.Allow = splitCommaSlice(cfg.Releases.Allow)
+	cfg.Codeload.Allow = splitCommaSlice(cfg.Codeload.Allow)
 
 	// GHP_RELEASES_ALLOW_COUNT + GHP_RELEASES_ALLOW_N support indexed allow
 	// lists that cannot be expressed as comma-separated values. When set, the
@@ -343,6 +368,29 @@ func Load(path string) (*Config, error) {
 			entries = append(entries, v)
 		}
 		cfg.Releases.Allow = entries
+	}
+
+	// GHP_CODELOAD_ALLOW_COUNT + GHP_CODELOAD_ALLOW_N support indexed allow
+	// lists that cannot be expressed as comma-separated values. When set, the
+	// indexed entries replace any allow list loaded from YAML or other env vars.
+	if countStr := os.Getenv("GHP_CODELOAD_ALLOW_COUNT"); countStr != "" {
+		count, err := strconv.Atoi(countStr)
+		if err != nil {
+			return nil, fmt.Errorf("invalid GHP_CODELOAD_ALLOW_COUNT %q: %w", countStr, err)
+		}
+		if count < 0 {
+			return nil, fmt.Errorf("invalid GHP_CODELOAD_ALLOW_COUNT %q: must be non-negative", countStr)
+		}
+		entries := make([]string, 0, count)
+		for i := 0; i < count; i++ {
+			key := fmt.Sprintf("GHP_CODELOAD_ALLOW_%d", i)
+			v := strings.TrimSpace(os.Getenv(key))
+			if v == "" {
+				return nil, fmt.Errorf("%s not set or empty (GHP_CODELOAD_ALLOW_COUNT=%d)", key, count)
+			}
+			entries = append(entries, v)
+		}
+		cfg.Codeload.Allow = entries
 	}
 
 	// Convenience env vars for the common single-certificate case.
@@ -377,6 +425,7 @@ func (c *Config) ReloadFrom(path string) error {
 	c.Auth = fresh.Auth
 	c.Block = fresh.Block
 	c.Releases = fresh.Releases
+	c.Codeload = fresh.Codeload
 	c.Cache = fresh.Cache
 	return nil
 }
@@ -432,6 +481,21 @@ func (c *Config) IsTokenBlocked(token string) bool {
 func (c *Config) IsReleaseAllowed(org, repo string) bool {
 	orgRepo := org + "/" + repo
 	for _, entry := range c.Releases.Allow {
+		if strings.EqualFold(entry, org) || strings.EqualFold(entry, orgRepo) {
+			return true
+		}
+	}
+	return false
+}
+
+// IsCodeloadAllowed returns true when the given org or org/repo combination
+// appears in the codeload allow list, meaning archive download requests for it
+// are passed through to upstream rather than redirected to the configured
+// caching mirror. Matching is case-insensitive. An org-only entry (e.g.
+// "goodtune") exempts every repository under that org.
+func (c *Config) IsCodeloadAllowed(org, repo string) bool {
+	orgRepo := org + "/" + repo
+	for _, entry := range c.Codeload.Allow {
 		if strings.EqualFold(entry, org) || strings.EqualFold(entry, orgRepo) {
 			return true
 		}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -26,14 +26,23 @@ import (
 // Config represents the complete server configuration.
 //
 // Hot-reloadable fields (Admins, Tokens, Logging, Metrics, Auth, Block,
-// Releases, Codeload, Cache) are protected by mu: ReloadFrom takes the
-// write lock and the accessor methods (IsAdmin, IsTokenBlocked,
-// IsReleaseAllowed, IsCodeloadAllowed, CodeloadSnapshot) take the read
-// lock. Request handlers must read these fields through the accessors —
-// reading the embedded structs directly under concurrent reload is a data
-// race that `go test -race` will flag. Static fields (GitHub, Database,
-// Server, TLS, EncryptionKey, DevMode) are populated once at startup and
-// never mutated, so they're safe to read directly.
+// Releases, Codeload, Cache) are mutated in place by ReloadFrom on SIGUSR1.
+// To make per-request reads race-free with that mutation, an unexported mu
+// guards those fields; ReloadFrom takes the write lock for the duration of
+// the update.
+//
+// Reads on the hot request path should go through the locking accessor
+// methods on this type — IsAdmin, IsTokenBlocked, IsReleaseAllowed,
+// IsCodeloadAllowed, and CodeloadRedirectTo — which take the read lock and
+// return values that are safe to use after the lock is released. Reads of
+// the embedded structs (e.g. cfg.Releases.Mode) are NOT race-free; existing
+// call sites that pre-date this PR fall into that category and should be
+// migrated to accessor methods (or new ones added — see the CodeloadRedirectTo
+// pattern) as they're touched.
+//
+// Static fields (GitHub, Database, Server, TLS, EncryptionKey, DevMode) are
+// populated once at startup and never mutated, so they're safe to read
+// directly.
 type Config struct {
 	// mu guards all hot-reloadable fields below. Held for the duration of
 	// ReloadFrom so a single SIGUSR1 either fully replaces the runtime
@@ -544,22 +553,16 @@ func (c *Config) IsCodeloadAllowed(org, repo string) bool {
 	return false
 }
 
-// CodeloadSnapshot returns a deep copy of the codeload configuration safe to
-// read across hot-reload boundaries. Use this from request handlers that need
-// more than just the allow check (e.g. reading RedirectTo): reading
-// cfg.Codeload directly is a data race against ReloadFrom and will be flagged
-// by `go test -race`.
-//
-// The returned value's slice fields are copies, so callers cannot observe a
-// slice that ReloadFrom is about to replace.
-func (c *Config) CodeloadSnapshot() CodeloadConfig {
+// CodeloadRedirectTo returns the configured codeload redirect base URL. It
+// takes the read lock so callers on the request hot path can read it without
+// racing against ReloadFrom. Returning a string (rather than a snapshot
+// struct) keeps the per-request cost to a single lock + field copy with no
+// allocation, even when codeload.allow is set — the allow check has its own
+// race-free accessor in IsCodeloadAllowed.
+func (c *Config) CodeloadRedirectTo() string {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
-	cp := c.Codeload
-	if c.Codeload.Allow != nil {
-		cp.Allow = append([]string(nil), c.Codeload.Allow...)
-	}
-	return cp
+	return c.Codeload.RedirectTo
 }
 
 // WarnInvalidBlockTargets logs a warning for any block configuration targeting

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -231,6 +231,117 @@ func TestIsReleaseAllowed(t *testing.T) {
 	}
 }
 
+func TestLoadCodeloadFromEnv(t *testing.T) {
+	t.Setenv("GHP_CODELOAD_REDIRECT_TO", "https://codeload.cache.example.com/")
+	t.Setenv("GHP_CODELOAD_ALLOW", "actions,goodtune/ghp")
+
+	cfg, err := Load("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Codeload.RedirectTo != "https://codeload.cache.example.com/" {
+		t.Errorf("RedirectTo = %q, want %q", cfg.Codeload.RedirectTo, "https://codeload.cache.example.com/")
+	}
+	want := []string{"actions", "goodtune/ghp"}
+	if len(cfg.Codeload.Allow) != len(want) {
+		t.Fatalf("Allow = %v, want %v", cfg.Codeload.Allow, want)
+	}
+	for i, w := range want {
+		if cfg.Codeload.Allow[i] != w {
+			t.Errorf("Allow[%d] = %q, want %q", i, cfg.Codeload.Allow[i], w)
+		}
+	}
+}
+
+func TestLoadCodeloadAllowIndexed(t *testing.T) {
+	t.Setenv("GHP_CODELOAD_ALLOW_COUNT", "2")
+	t.Setenv("GHP_CODELOAD_ALLOW_0", "goodtune/ghp")
+	t.Setenv("GHP_CODELOAD_ALLOW_1", "actions")
+
+	cfg, err := Load("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{"goodtune/ghp", "actions"}
+	if len(cfg.Codeload.Allow) != len(want) {
+		t.Fatalf("Allow = %v, want %v", cfg.Codeload.Allow, want)
+	}
+	for i, w := range want {
+		if cfg.Codeload.Allow[i] != w {
+			t.Errorf("Allow[%d] = %q, want %q", i, cfg.Codeload.Allow[i], w)
+		}
+	}
+}
+
+func TestLoadCodeloadAllowIndexedMissingEntry(t *testing.T) {
+	t.Setenv("GHP_CODELOAD_ALLOW_COUNT", "2")
+	t.Setenv("GHP_CODELOAD_ALLOW_0", "actions")
+	// GHP_CODELOAD_ALLOW_1 is intentionally not set.
+
+	if _, err := Load(""); err == nil {
+		t.Fatal("expected error for missing indexed allow entry, got nil")
+	}
+}
+
+func TestLoadCodeloadAllowIndexedBadCount(t *testing.T) {
+	t.Setenv("GHP_CODELOAD_ALLOW_COUNT", "notanumber")
+
+	if _, err := Load(""); err == nil {
+		t.Fatal("expected error for invalid GHP_CODELOAD_ALLOW_COUNT, got nil")
+	}
+}
+
+func TestLoadCodeloadAllowIndexedNegativeCount(t *testing.T) {
+	t.Setenv("GHP_CODELOAD_ALLOW_COUNT", "-1")
+
+	if _, err := Load(""); err == nil {
+		t.Fatal("expected error for negative GHP_CODELOAD_ALLOW_COUNT, got nil")
+	}
+}
+
+func TestLoadCodeloadAllowIndexedOverridesEnv(t *testing.T) {
+	// Indexed entries should take precedence over the comma-separated env var.
+	t.Setenv("GHP_CODELOAD_ALLOW", "yaml-org")
+	t.Setenv("GHP_CODELOAD_ALLOW_COUNT", "1")
+	t.Setenv("GHP_CODELOAD_ALLOW_0", "indexed-org")
+
+	cfg, err := Load("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(cfg.Codeload.Allow) != 1 || cfg.Codeload.Allow[0] != "indexed-org" {
+		t.Errorf("Allow = %v, want [indexed-org]", cfg.Codeload.Allow)
+	}
+}
+
+func TestIsCodeloadAllowed(t *testing.T) {
+	tests := []struct {
+		name    string
+		allow   []string
+		org     string
+		repo    string
+		allowed bool
+	}{
+		{name: "org match", allow: []string{"actions"}, org: "actions", repo: "checkout", allowed: true},
+		{name: "org/repo match", allow: []string{"actions/checkout"}, org: "actions", repo: "checkout", allowed: true},
+		{name: "org no match", allow: []string{"other"}, org: "actions", repo: "checkout", allowed: false},
+		{name: "org/repo no match different repo", allow: []string{"actions/setup-node"}, org: "actions", repo: "checkout", allowed: false},
+		{name: "case insensitive org", allow: []string{"ACTIONS"}, org: "actions", repo: "checkout", allowed: true},
+		{name: "case insensitive org/repo", allow: []string{"Actions/Checkout"}, org: "actions", repo: "checkout", allowed: true},
+		{name: "empty allow list", allow: nil, org: "actions", repo: "checkout", allowed: false},
+		{name: "multiple entries second matches", allow: []string{"other", "actions"}, org: "actions", repo: "checkout", allowed: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &Config{Codeload: CodeloadConfig{Allow: tt.allow}}
+			got := cfg.IsCodeloadAllowed(tt.org, tt.repo)
+			if got != tt.allowed {
+				t.Errorf("IsCodeloadAllowed(%q, %q) = %v, want %v", tt.org, tt.repo, got, tt.allowed)
+			}
+		})
+	}
+}
+
 func TestIsTokenBlocked(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -103,6 +103,21 @@ var (
 		Help: "Total number of HEAD checks against the release redirect target, by result.",
 	}, []string{"result"})
 
+	// CodeloadRedirectTotal counts archive download requests handled by the
+	// codeload.github.com handler, labeled by owner, repo, archive format
+	// ("tar.gz", "zip", "legacy.tar.gz", "legacy.zip"), and result:
+	//   "redirect"    — 302 issued to the configured caching mirror
+	//   "passthrough" — request forwarded transparently to upstream codeload
+	//                   (allow list match or no redirect_to configured)
+	//
+	// The full ref (SHA, branch, or tag) is not included as a label to keep
+	// cardinality bounded; it is captured in access logs as part of the URL.
+	// Cardinality: bounded by (cached repos × archive formats × results).
+	CodeloadRedirectTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "ghp_codeload_redirect_total",
+		Help: "Total codeload.github.com archive requests handled, by owner, repo, archive format, and result.",
+	}, []string{"owner", "repo", "archive", "result"})
+
 	// BlockAnonymousGitEnabled reflects whether the anonymous git blocking
 	// feature is currently active (1) or inactive (0). Set at server startup
 	// and on config reload (SIGUSR1); not updated per-request.

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -246,6 +246,37 @@ func TestReleasesRedirectHeadCheckTotal(t *testing.T) {
 	}
 }
 
+func TestCodeloadRedirectTotal(t *testing.T) {
+	tests := []struct {
+		name    string
+		owner   string
+		repo    string
+		archive string
+		result  string
+	}{
+		{"redirect tar.gz", "actions", "checkout", "tar.gz", "redirect"},
+		{"redirect zip", "actions", "checkout", "zip", "redirect"},
+		{"passthrough legacy.tar.gz", "goodtune", "ghp", "legacy.tar.gz", "passthrough"},
+		{"passthrough legacy.zip", "goodtune", "ghp", "legacy.zip", "passthrough"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			labels := prometheus.Labels{
+				"owner":   tt.owner,
+				"repo":    tt.repo,
+				"archive": tt.archive,
+				"result":  tt.result,
+			}
+			before := getCounterValue(t, CodeloadRedirectTotal, labels)
+			CodeloadRedirectTotal.WithLabelValues(tt.owner, tt.repo, tt.archive, tt.result).Inc()
+			after := getCounterValue(t, CodeloadRedirectTotal, labels)
+			if after-before != 1 {
+				t.Errorf("expected counter to increment by 1, got %f", after-before)
+			}
+		})
+	}
+}
+
 func TestObserveDecision_RedirectHeadCheck(t *testing.T) {
 	labels := prometheus.Labels{
 		"stage":      StageRedirectHeadCheck,

--- a/internal/proxy/codeload.go
+++ b/internal/proxy/codeload.go
@@ -99,10 +99,17 @@ func NewCodeloadHandler(cfg *config.Config, logger *slog.Logger, transport http.
 		// would be malformed (e.g. "file:///tmp/<path>") or unreachable from
 		// a browser — so log and fall back to passthrough rather than
 		// emitting a redirect that's guaranteed to break the client.
+		// Also reject values that already carry a query string or fragment:
+		// the redirect target is built by appending the request path/query,
+		// which would produce something like ".../base?x=y/owner/repo/..."
+		// — clearly broken — so make the misconfiguration loud.
 		u, err := url.Parse(base)
-		if err != nil || !u.IsAbs() || u.Host == "" || (u.Scheme != "http" && u.Scheme != "https") {
+		switch {
+		case err != nil, !u.IsAbs(), u.Host == "",
+			u.Scheme != "http" && u.Scheme != "https",
+			u.RawQuery != "", u.Fragment != "":
 			if logger != nil {
-				logger.Error("codeload redirect_to must be an absolute http(s) URL with a host; falling back to passthrough",
+				logger.Error("codeload redirect_to must be an absolute http(s) URL with a host and no query/fragment; falling back to passthrough",
 					"redirect_to", raw)
 			}
 			cachedOk = false
@@ -124,7 +131,15 @@ func NewCodeloadHandler(cfg *config.Config, logger *slog.Logger, transport http.
 			return
 		}
 
-		owner, repo, archive := m[1], m[2], m[3]
+		// Normalise owner/repo to lowercase before using as Prometheus
+		// labels. GitHub is case-insensitive on owner and repo, so
+		// "Actions/Checkout" and "actions/checkout" must resolve to the
+		// same time series — otherwise clients with inconsistent casing
+		// would split the counter and inflate cardinality. Pattern matches
+		// internal/gitcache/middleware.go.
+		owner := strings.ToLower(m[1])
+		repo := strings.ToLower(m[2])
+		archive := m[3]
 
 		redirectBase := resolveRedirectBase()
 		if redirectBase == "" || cfg.IsCodeloadAllowed(owner, repo) {

--- a/internal/proxy/codeload.go
+++ b/internal/proxy/codeload.go
@@ -7,6 +7,7 @@ import (
 	"net/url"
 	"regexp"
 	"strings"
+	"sync"
 
 	"github.com/goodtune/ghp/internal/config"
 	"github.com/goodtune/ghp/internal/metrics"
@@ -40,49 +41,100 @@ func mustParseCodeloadURL(s string) *url.URL {
 // are answered with a 302 to RedirectTo + the original path (and query string).
 // Requests for orgs or org/repo pairs in cfg.Codeload.Allow bypass the redirect
 // and are forwarded to the upstream codeload service. Non-archive paths are
-// always forwarded. When RedirectTo is empty, every request is forwarded
-// transparently to upstream codeload.github.com.
+// always forwarded. When RedirectTo is empty, every archive request is still
+// counted as result="passthrough" before forwarding so operators can see total
+// archive volume even before a mirror is configured.
 //
-// transport is optional; when nil the default RoundTripper is used. It exists
-// to allow tests to intercept upstream requests without making real network
-// calls.
+// cfg is read on every request so SIGUSR1 hot-reload of codeload.redirect_to
+// and codeload.allow takes effect without a server restart. transport is
+// optional; when nil the default RoundTripper is used. It exists to allow
+// tests to intercept upstream requests without making real network calls.
 func NewCodeloadHandler(cfg *config.Config, logger *slog.Logger, transport http.RoundTripper) http.Handler {
 	passthrough := newCodeloadPassthrough(transport)
 
-	// Pre-validate and normalise the redirect base URL once so the per-request
-	// handler avoids repeated TrimRight + url.Parse work.
-	redirectBase := strings.TrimRight(cfg.Codeload.RedirectTo, "/")
-	if redirectBase != "" {
-		if u, err := url.Parse(redirectBase); err != nil || !u.IsAbs() {
+	// Cache the parsed redirect_to keyed by the raw config string so we don't
+	// re-validate the URL on every request, but still pick up changes when
+	// codeload.redirect_to is updated via hot-reload. The "" key represents
+	// "no redirect configured".
+	var (
+		mu       sync.RWMutex
+		cachedIn string
+		cachedOk bool
+		cachedTo string
+	)
+
+	resolveRedirectBase := func() string {
+		raw := cfg.Codeload.RedirectTo
+
+		mu.RLock()
+		if raw == cachedIn {
+			out := cachedTo
+			ok := cachedOk
+			mu.RUnlock()
+			if ok {
+				return out
+			}
+			return ""
+		}
+		mu.RUnlock()
+
+		mu.Lock()
+		defer mu.Unlock()
+		// Re-check under the write lock in case another goroutine populated it.
+		if raw == cachedIn {
+			if cachedOk {
+				return cachedTo
+			}
+			return ""
+		}
+		cachedIn = raw
+		base := strings.TrimRight(raw, "/")
+		if base == "" {
+			cachedOk = false
+			cachedTo = ""
+			return ""
+		}
+		if u, err := url.Parse(base); err != nil || !u.IsAbs() {
 			if logger != nil {
 				logger.Error("codeload redirect_to must be an absolute URL; falling back to passthrough",
-					"redirect_to", cfg.Codeload.RedirectTo)
+					"redirect_to", raw)
 			}
-			redirectBase = ""
+			cachedOk = false
+			cachedTo = ""
+			return ""
 		}
+		cachedOk = true
+		cachedTo = base
+		return base
 	}
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if redirectBase == "" {
-			passthrough.ServeHTTP(w, r)
-			return
-		}
-
 		m := codeloadArchiveRe.FindStringSubmatch(r.URL.Path)
 		if m == nil {
+			// Non-archive paths: always passthrough, never counted (the
+			// counter is scoped to archive requests so cardinality stays
+			// predictable).
 			passthrough.ServeHTTP(w, r)
 			return
 		}
 
 		owner, repo, archive := m[1], m[2], m[3]
 
-		if cfg.IsCodeloadAllowed(owner, repo) {
+		redirectBase := resolveRedirectBase()
+		if redirectBase == "" || cfg.IsCodeloadAllowed(owner, repo) {
 			metrics.CodeloadRedirectTotal.WithLabelValues(owner, repo, archive, "passthrough").Inc()
 			passthrough.ServeHTTP(w, r)
 			return
 		}
 
-		target := redirectBase + r.URL.RequestURI()
+		// Build the redirect target from the URL's escaped path and raw query
+		// rather than r.URL.RequestURI() so the result is unambiguous when the
+		// request arrives in absolute-form (e.g. through a forward proxy) — we
+		// only ever want the path/query component appended to redirectBase.
+		target := redirectBase + r.URL.EscapedPath()
+		if r.URL.RawQuery != "" {
+			target += "?" + r.URL.RawQuery
+		}
 		metrics.CodeloadRedirectTotal.WithLabelValues(owner, repo, archive, "redirect").Inc()
 		http.Redirect(w, r, target, http.StatusFound)
 	})

--- a/internal/proxy/codeload.go
+++ b/internal/proxy/codeload.go
@@ -64,9 +64,11 @@ func NewCodeloadHandler(cfg *config.Config, logger *slog.Logger, transport http.
 	)
 
 	resolveRedirectBase := func() string {
-		// CodeloadSnapshot copies under config.RWMutex so we can't race
-		// with a concurrent SIGUSR1 reload mutating cfg.Codeload.
-		raw := cfg.CodeloadSnapshot().RedirectTo
+		// CodeloadRedirectTo takes the config RWMutex so we can't race
+		// with a concurrent SIGUSR1 reload mutating cfg.Codeload, and
+		// avoids the slice copy of a full snapshot — the allow check has
+		// its own locked accessor (IsCodeloadAllowed) below.
+		raw := cfg.CodeloadRedirectTo()
 
 		mu.RLock()
 		if raw == cachedIn {

--- a/internal/proxy/codeload.go
+++ b/internal/proxy/codeload.go
@@ -64,7 +64,9 @@ func NewCodeloadHandler(cfg *config.Config, logger *slog.Logger, transport http.
 	)
 
 	resolveRedirectBase := func() string {
-		raw := cfg.Codeload.RedirectTo
+		// CodeloadSnapshot copies under config.RWMutex so we can't race
+		// with a concurrent SIGUSR1 reload mutating cfg.Codeload.
+		raw := cfg.CodeloadSnapshot().RedirectTo
 
 		mu.RLock()
 		if raw == cachedIn {

--- a/internal/proxy/codeload.go
+++ b/internal/proxy/codeload.go
@@ -1,0 +1,107 @@
+package proxy
+
+import (
+	"log/slog"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"regexp"
+	"strings"
+
+	"github.com/goodtune/ghp/internal/config"
+	"github.com/goodtune/ghp/internal/metrics"
+)
+
+// codeloadArchiveRe matches codeload.github.com archive download paths of the
+// form /{owner}/{repo}/{format}/{ref}, where format is one of "tar.gz", "zip",
+// "legacy.tar.gz", or "legacy.zip", and ref is a SHA, branch, or tag.
+//
+// The "legacy.*" alternatives must precede "tar.gz" / "zip" so the longer
+// prefix wins (Go's regexp is leftmost-first; we anchor the format segment to
+// avoid greedy mismatches by using grouped alternation).
+var codeloadArchiveRe = regexp.MustCompile(`^/+([^/]+)/([^/]+)/(legacy\.tar\.gz|legacy\.zip|tar\.gz|zip)/(.+)$`)
+
+// upstreamCodeload is the canonical upstream codeload URL used as the
+// passthrough target. Parsed once at package init.
+var upstreamCodeload = mustParseCodeloadURL("https://codeload.github.com")
+
+func mustParseCodeloadURL(s string) *url.URL {
+	u, err := url.Parse(s)
+	if err != nil {
+		panic(err)
+	}
+	return u
+}
+
+// NewCodeloadHandler returns an http.Handler for codeload.github.com requests.
+//
+// When cfg.Codeload.RedirectTo is set to an absolute URL, archive download
+// requests matching /{owner}/{repo}/(tar.gz|zip|legacy.tar.gz|legacy.zip)/{ref}
+// are answered with a 302 to RedirectTo + the original path (and query string).
+// Requests for orgs or org/repo pairs in cfg.Codeload.Allow bypass the redirect
+// and are forwarded to the upstream codeload service. Non-archive paths are
+// always forwarded. When RedirectTo is empty, every request is forwarded
+// transparently to upstream codeload.github.com.
+//
+// transport is optional; when nil the default RoundTripper is used. It exists
+// to allow tests to intercept upstream requests without making real network
+// calls.
+func NewCodeloadHandler(cfg *config.Config, logger *slog.Logger, transport http.RoundTripper) http.Handler {
+	passthrough := newCodeloadPassthrough(transport)
+
+	// Pre-validate and normalise the redirect base URL once so the per-request
+	// handler avoids repeated TrimRight + url.Parse work.
+	redirectBase := strings.TrimRight(cfg.Codeload.RedirectTo, "/")
+	if redirectBase != "" {
+		if u, err := url.Parse(redirectBase); err != nil || !u.IsAbs() {
+			if logger != nil {
+				logger.Error("codeload redirect_to must be an absolute URL; falling back to passthrough",
+					"redirect_to", cfg.Codeload.RedirectTo)
+			}
+			redirectBase = ""
+		}
+	}
+
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if redirectBase == "" {
+			passthrough.ServeHTTP(w, r)
+			return
+		}
+
+		m := codeloadArchiveRe.FindStringSubmatch(r.URL.Path)
+		if m == nil {
+			passthrough.ServeHTTP(w, r)
+			return
+		}
+
+		owner, repo, archive := m[1], m[2], m[3]
+
+		if cfg.IsCodeloadAllowed(owner, repo) {
+			metrics.CodeloadRedirectTotal.WithLabelValues(owner, repo, archive, "passthrough").Inc()
+			passthrough.ServeHTTP(w, r)
+			return
+		}
+
+		target := redirectBase + r.URL.RequestURI()
+		metrics.CodeloadRedirectTotal.WithLabelValues(owner, repo, archive, "redirect").Inc()
+		http.Redirect(w, r, target, http.StatusFound)
+	})
+}
+
+// newCodeloadPassthrough builds a transparent reverse proxy to upstream
+// codeload.github.com. It preserves the original Host header so tests and
+// access logs see the value the client sent.
+func newCodeloadPassthrough(transport http.RoundTripper) http.Handler {
+	rp := &httputil.ReverseProxy{
+		Director: func(req *http.Request) {
+			originalHost := req.Host
+			req.URL.Scheme = upstreamCodeload.Scheme
+			req.URL.Host = upstreamCodeload.Host
+			req.Host = originalHost
+		},
+	}
+	if transport != nil {
+		rp.Transport = transport
+	}
+	return rp
+}

--- a/internal/proxy/codeload.go
+++ b/internal/proxy/codeload.go
@@ -94,9 +94,15 @@ func NewCodeloadHandler(cfg *config.Config, logger *slog.Logger, transport http.
 			cachedTo = ""
 			return ""
 		}
-		if u, err := url.Parse(base); err != nil || !u.IsAbs() {
+		// Require a parseable absolute URL with an explicit host and an
+		// http(s) scheme. Without these, the synthesised Location header
+		// would be malformed (e.g. "file:///tmp/<path>") or unreachable from
+		// a browser — so log and fall back to passthrough rather than
+		// emitting a redirect that's guaranteed to break the client.
+		u, err := url.Parse(base)
+		if err != nil || !u.IsAbs() || u.Host == "" || (u.Scheme != "http" && u.Scheme != "https") {
 			if logger != nil {
-				logger.Error("codeload redirect_to must be an absolute URL; falling back to passthrough",
+				logger.Error("codeload redirect_to must be an absolute http(s) URL with a host; falling back to passthrough",
 					"redirect_to", raw)
 			}
 			cachedOk = false

--- a/internal/proxy/codeload_test.go
+++ b/internal/proxy/codeload_test.go
@@ -232,6 +232,8 @@ func TestCodeloadHandler_InvalidRedirectTo_FallsBackToPassthrough(t *testing.T) 
 		{"file scheme", "file:///tmp/cache"},
 		{"opaque scheme without host", "https:no-host"},
 		{"non-http scheme", "ftp://example.com/cache"},
+		{"with query string", "https://mirror.example.com/?token=abc"},
+		{"with fragment", "https://mirror.example.com/#section"},
 	}
 
 	for _, tc := range cases {
@@ -275,6 +277,50 @@ func TestCodeloadHandler_InvalidRedirectTo_FallsBackToPassthrough(t *testing.T) 
 				t.Errorf("passthrough counter increment = %f, want 1", after-before)
 			}
 		})
+	}
+}
+
+// TestCodeloadHandler_LowercasesOwnerAndRepoMetricLabels verifies that the
+// owner/repo Prometheus labels are lowercased before incrementing the counter.
+// GitHub treats owner and repo case-insensitively, so "Actions/Checkout" and
+// "actions/checkout" must collapse to a single time series rather than create
+// duplicate entries that inflate cardinality.
+func TestCodeloadHandler_LowercasesOwnerAndRepoMetricLabels(t *testing.T) {
+	cfg := &config.Config{
+		Codeload: config.CodeloadConfig{
+			RedirectTo: "https://codeload.cache.example.com/",
+		},
+	}
+	handler := NewCodeloadHandler(cfg, nil, failingTransport(t))
+
+	before := codeloadCounterValue(t, "actions", "checkout", "tar.gz", "redirect")
+
+	// Send the path with mixed-case owner/repo.
+	req := httptest.NewRequest(http.MethodGet, "/Actions/Checkout/tar.gz/abc123", nil)
+	req.Host = "codeload.github.com"
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusFound {
+		t.Fatalf("status = %d, want 302", w.Code)
+	}
+	// The Location header preserves the original casing — only the metric
+	// label is normalised.
+	want := "https://codeload.cache.example.com/Actions/Checkout/tar.gz/abc123"
+	if got := w.Header().Get("Location"); got != want {
+		t.Errorf("Location = %q, want %q", got, want)
+	}
+
+	after := codeloadCounterValue(t, "actions", "checkout", "tar.gz", "redirect")
+	if after-before != 1 {
+		t.Errorf("lowercase-labelled counter increment = %f, want 1", after-before)
+	}
+
+	// Confirm the mixed-case label series did not increment (i.e. we did
+	// not split into two time series).
+	mixedCase := codeloadCounterValue(t, "Actions", "Checkout", "tar.gz", "redirect")
+	if mixedCase != 0 {
+		t.Errorf("mixed-case counter has value %f; expected 0 (label should be normalised)", mixedCase)
 	}
 }
 

--- a/internal/proxy/codeload_test.go
+++ b/internal/proxy/codeload_test.go
@@ -4,8 +4,12 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 
@@ -458,4 +462,92 @@ func failingTransport(t *testing.T) http.RoundTripper {
 		t.Errorf("unexpected upstream request to %s %s", req.Method, req.URL)
 		return &http.Response{StatusCode: http.StatusInternalServerError, Body: io.NopCloser(strings.NewReader(""))}, nil
 	})
+}
+
+// TestCodeloadHandler_RaceFreeUnderConcurrentReload drives the handler from
+// many goroutines while ReloadFrom rewrites the codeload section in parallel.
+// Run under `go test -race`: any direct read of cfg.Codeload from the request
+// hot path would be flagged. The accessor (CodeloadSnapshot) and the
+// IsCodeloadAllowed helper take the config RWMutex, so this exercise must
+// stay race-free.
+func TestCodeloadHandler_RaceFreeUnderConcurrentReload(t *testing.T) {
+	transport := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader("ok")),
+			Header:     http.Header{},
+		}, nil
+	})
+
+	tmp := t.TempDir()
+	configA := filepath.Join(tmp, "a.yaml")
+	configB := filepath.Join(tmp, "b.yaml")
+	if err := os.WriteFile(configA, []byte("codeload:\n  redirect_to: \"https://a.example.com/\"\n  allow:\n    - \"actions\"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(configB, []byte("codeload:\n  redirect_to: \"https://b.example.com/\"\n  allow: []\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := config.Load(configA)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	handler := NewCodeloadHandler(cfg, nil, transport)
+
+	var wg sync.WaitGroup
+	stop := make(chan struct{})
+
+	// Reloader: alternate between the two configs.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		paths := []string{configA, configB}
+		for i := 0; ; i++ {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			if err := cfg.ReloadFrom(paths[i%2]); err != nil {
+				t.Errorf("reload: %v", err)
+				return
+			}
+		}
+	}()
+
+	// Readers: hammer the handler with both an allow-list candidate and a
+	// non-allow-list candidate so we exercise both the IsCodeloadAllowed
+	// path and the snapshot read.
+	const readers = 8
+	for i := 0; i < readers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 200; j++ {
+				select {
+				case <-stop:
+					return
+				default:
+				}
+				path := "/actions/checkout/tar.gz/abc123"
+				if j%2 == 0 {
+					path = "/goodtune/ghp/zip/main"
+				}
+				req := httptest.NewRequest(http.MethodGet, path, nil)
+				req.Host = "codeload.github.com"
+				w := httptest.NewRecorder()
+				handler.ServeHTTP(w, req)
+				if w.Code != http.StatusFound && w.Code != http.StatusOK {
+					t.Errorf("unexpected status %d", w.Code)
+					return
+				}
+			}
+		}()
+	}
+
+	// Let the readers run for a fixed window.
+	time.Sleep(50 * time.Millisecond)
+	close(stop)
+	wg.Wait()
 }

--- a/internal/proxy/codeload_test.go
+++ b/internal/proxy/codeload_test.go
@@ -179,7 +179,7 @@ func TestCodeloadHandler_AllowListPassesThrough(t *testing.T) {
 	}
 }
 
-func TestCodeloadHandler_NoRedirectToConfigured_AlwaysPassthrough(t *testing.T) {
+func TestCodeloadHandler_NoRedirectToConfigured_PassthroughIsCounted(t *testing.T) {
 	var upstreamHits int
 	transport := roundTripFunc(func(req *http.Request) (*http.Response, error) {
 		upstreamHits++
@@ -195,6 +195,8 @@ func TestCodeloadHandler_NoRedirectToConfigured_AlwaysPassthrough(t *testing.T) 
 	}
 	handler := NewCodeloadHandler(cfg, nil, transport)
 
+	before := codeloadCounterValue(t, "actions", "checkout", "tar.gz", "passthrough")
+
 	req := httptest.NewRequest(http.MethodGet, "/actions/checkout/tar.gz/abc123", nil)
 	req.Host = "codeload.github.com"
 	w := httptest.NewRecorder()
@@ -208,6 +210,11 @@ func TestCodeloadHandler_NoRedirectToConfigured_AlwaysPassthrough(t *testing.T) 
 	}
 	if w.Header().Get("Location") != "" {
 		t.Errorf("unexpected Location header on passthrough: %q", w.Header().Get("Location"))
+	}
+
+	after := codeloadCounterValue(t, "actions", "checkout", "tar.gz", "passthrough")
+	if after-before != 1 {
+		t.Errorf("passthrough counter increment = %f, want 1", after-before)
 	}
 }
 
@@ -229,6 +236,8 @@ func TestCodeloadHandler_InvalidRedirectTo_FallsBackToPassthrough(t *testing.T) 
 	}
 	handler := NewCodeloadHandler(cfg, nil, transport)
 
+	before := codeloadCounterValue(t, "actions", "checkout", "tar.gz", "passthrough")
+
 	req := httptest.NewRequest(http.MethodGet, "/actions/checkout/tar.gz/abc123", nil)
 	req.Host = "codeload.github.com"
 	w := httptest.NewRecorder()
@@ -239,6 +248,92 @@ func TestCodeloadHandler_InvalidRedirectTo_FallsBackToPassthrough(t *testing.T) 
 	}
 	if upstreamHits != 1 {
 		t.Errorf("upstream hits = %d, want 1", upstreamHits)
+	}
+
+	after := codeloadCounterValue(t, "actions", "checkout", "tar.gz", "passthrough")
+	if after-before != 1 {
+		t.Errorf("passthrough counter increment = %f, want 1", after-before)
+	}
+}
+
+// TestCodeloadHandler_HotReloadsRedirectTo verifies that mutating
+// cfg.Codeload.RedirectTo after the handler is constructed (as happens on
+// SIGUSR1) takes effect on the next request. This is the scenario described
+// in docs/features/codeload.md and must work without a server restart.
+func TestCodeloadHandler_HotReloadsRedirectTo(t *testing.T) {
+	transport := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader("ok")),
+			Header:     http.Header{},
+		}, nil
+	})
+
+	cfg := &config.Config{
+		Codeload: config.CodeloadConfig{},
+	}
+	handler := NewCodeloadHandler(cfg, nil, transport)
+
+	// Initially no redirect: archive path passes through.
+	req := httptest.NewRequest(http.MethodGet, "/actions/checkout/tar.gz/abc123", nil)
+	req.Host = "codeload.github.com"
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("pre-reload: status = %d, want 200 (passthrough)", w.Code)
+	}
+
+	// Simulate SIGUSR1 hot-reload mutating the config in-place.
+	cfg.Codeload.RedirectTo = "https://codeload.cache.example.com/"
+
+	req = httptest.NewRequest(http.MethodGet, "/actions/checkout/tar.gz/abc123", nil)
+	req.Host = "codeload.github.com"
+	w = httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	if w.Code != http.StatusFound {
+		t.Fatalf("post-reload: status = %d, want 302", w.Code)
+	}
+	want := "https://codeload.cache.example.com/actions/checkout/tar.gz/abc123"
+	if got := w.Header().Get("Location"); got != want {
+		t.Errorf("post-reload: Location = %q, want %q", got, want)
+	}
+
+	// Reload again to clear redirect_to and confirm we go back to passthrough.
+	cfg.Codeload.RedirectTo = ""
+
+	req = httptest.NewRequest(http.MethodGet, "/actions/checkout/tar.gz/abc123", nil)
+	req.Host = "codeload.github.com"
+	w = httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Errorf("post-clear: status = %d, want 200 (passthrough)", w.Code)
+	}
+}
+
+// TestCodeloadHandler_AbsoluteFormRequest verifies the redirect target is
+// built from the URL's path/query only, even when the request URL has scheme
+// and host populated (as happens when ghp acts as an HTTP forward proxy).
+func TestCodeloadHandler_AbsoluteFormRequest(t *testing.T) {
+	cfg := &config.Config{
+		Codeload: config.CodeloadConfig{
+			RedirectTo: "https://codeload.cache.example.com/",
+		},
+	}
+	handler := NewCodeloadHandler(cfg, nil, failingTransport(t))
+
+	req := httptest.NewRequest(http.MethodGet, "/actions/checkout/tar.gz/abc123?foo=bar", nil)
+	// Mimic the request shape produced by Go's net/http for an absolute-form
+	// request line (e.g. forward-proxy clients).
+	req.URL.Scheme = "https"
+	req.URL.Host = "codeload.github.com"
+	req.Host = "codeload.github.com"
+
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	want := "https://codeload.cache.example.com/actions/checkout/tar.gz/abc123?foo=bar"
+	if got := w.Header().Get("Location"); got != want {
+		t.Errorf("Location = %q, want %q (absolute-form must not leak scheme/host into target)", got, want)
 	}
 }
 

--- a/internal/proxy/codeload_test.go
+++ b/internal/proxy/codeload_test.go
@@ -1,0 +1,298 @@
+package proxy
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/goodtune/ghp/internal/config"
+	"github.com/goodtune/ghp/internal/metrics"
+)
+
+// codeloadCounterValue reads the current value of the CodeloadRedirectTotal
+// counter for the given label set.
+func codeloadCounterValue(t *testing.T, owner, repo, archive, result string) float64 {
+	t.Helper()
+	return getCounterValue(t, metrics.CodeloadRedirectTotal, prometheus.Labels{
+		"owner":   owner,
+		"repo":    repo,
+		"archive": archive,
+		"result":  result,
+	})
+}
+
+func TestCodeloadHandler_RedirectsArchiveRequests(t *testing.T) {
+	tests := []struct {
+		name        string
+		path        string
+		wantArchive string
+		wantOwner   string
+		wantRepo    string
+		wantLoc     string
+	}{
+		{
+			name:        "tar.gz with sha",
+			path:        "/actions/checkout/tar.gz/34e114876b0b11c390a56381ad16ebd13914f8d5",
+			wantArchive: "tar.gz",
+			wantOwner:   "actions",
+			wantRepo:    "checkout",
+			wantLoc:     "https://codeload.cache.example.com/actions/checkout/tar.gz/34e114876b0b11c390a56381ad16ebd13914f8d5",
+		},
+		{
+			name:        "zip with branch",
+			path:        "/actions/checkout/zip/main",
+			wantArchive: "zip",
+			wantOwner:   "actions",
+			wantRepo:    "checkout",
+			wantLoc:     "https://codeload.cache.example.com/actions/checkout/zip/main",
+		},
+		{
+			name:        "legacy.tar.gz with tag",
+			path:        "/goodtune/ghp/legacy.tar.gz/v1.0.0",
+			wantArchive: "legacy.tar.gz",
+			wantOwner:   "goodtune",
+			wantRepo:    "ghp",
+			wantLoc:     "https://codeload.cache.example.com/goodtune/ghp/legacy.tar.gz/v1.0.0",
+		},
+		{
+			name:        "legacy.zip preserves query string",
+			path:        "/goodtune/ghp/legacy.zip/abc123?foo=bar",
+			wantArchive: "legacy.zip",
+			wantOwner:   "goodtune",
+			wantRepo:    "ghp",
+			wantLoc:     "https://codeload.cache.example.com/goodtune/ghp/legacy.zip/abc123?foo=bar",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &config.Config{
+				Codeload: config.CodeloadConfig{
+					RedirectTo: "https://codeload.cache.example.com/",
+				},
+			}
+			handler := NewCodeloadHandler(cfg, nil, failingTransport(t))
+
+			before := codeloadCounterValue(t, tt.wantOwner, tt.wantRepo, tt.wantArchive, "redirect")
+
+			req := httptest.NewRequest(http.MethodGet, tt.path, nil)
+			req.Host = "codeload.github.com"
+			w := httptest.NewRecorder()
+			handler.ServeHTTP(w, req)
+
+			if w.Code != http.StatusFound {
+				t.Fatalf("status = %d, want 302", w.Code)
+			}
+			if got := w.Header().Get("Location"); got != tt.wantLoc {
+				t.Errorf("Location = %q, want %q", got, tt.wantLoc)
+			}
+
+			after := codeloadCounterValue(t, tt.wantOwner, tt.wantRepo, tt.wantArchive, "redirect")
+			if after-before != 1 {
+				t.Errorf("redirect counter increment = %f, want 1", after-before)
+			}
+		})
+	}
+}
+
+func TestCodeloadHandler_RedirectTrimsTrailingSlash(t *testing.T) {
+	cfg := &config.Config{
+		Codeload: config.CodeloadConfig{
+			RedirectTo: "https://codeload.cache.example.com",
+		},
+	}
+	handler := NewCodeloadHandler(cfg, nil, failingTransport(t))
+
+	req := httptest.NewRequest(http.MethodGet, "/actions/checkout/tar.gz/abc123", nil)
+	req.Host = "codeload.github.com"
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	want := "https://codeload.cache.example.com/actions/checkout/tar.gz/abc123"
+	if got := w.Header().Get("Location"); got != want {
+		t.Errorf("Location = %q, want %q", got, want)
+	}
+}
+
+func TestCodeloadHandler_AllowListPassesThrough(t *testing.T) {
+	var upstreamHits int
+	transport := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		upstreamHits++
+		if req.URL.Host != "codeload.github.com" {
+			t.Errorf("upstream Host = %q, want codeload.github.com", req.URL.Host)
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader("archive bytes")),
+			Header:     http.Header{},
+		}, nil
+	})
+
+	tests := []struct {
+		name  string
+		allow []string
+		owner string
+		repo  string
+	}{
+		{"org-level allow", []string{"actions"}, "actions", "checkout"},
+		{"org/repo allow", []string{"actions/checkout"}, "actions", "checkout"},
+		{"case insensitive", []string{"ACTIONS/Checkout"}, "actions", "checkout"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &config.Config{
+				Codeload: config.CodeloadConfig{
+					RedirectTo: "https://codeload.cache.example.com/",
+					Allow:      tt.allow,
+				},
+			}
+			handler := NewCodeloadHandler(cfg, nil, transport)
+
+			before := codeloadCounterValue(t, tt.owner, tt.repo, "tar.gz", "passthrough")
+
+			upstreamHits = 0
+			req := httptest.NewRequest(http.MethodGet, "/"+tt.owner+"/"+tt.repo+"/tar.gz/abc123", nil)
+			req.Host = "codeload.github.com"
+			w := httptest.NewRecorder()
+			handler.ServeHTTP(w, req)
+
+			if w.Code != http.StatusOK {
+				t.Errorf("status = %d, want 200 (passthrough)", w.Code)
+			}
+			if upstreamHits != 1 {
+				t.Errorf("upstream hits = %d, want 1", upstreamHits)
+			}
+			if w.Header().Get("Location") != "" {
+				t.Errorf("unexpected Location header: %q", w.Header().Get("Location"))
+			}
+
+			after := codeloadCounterValue(t, tt.owner, tt.repo, "tar.gz", "passthrough")
+			if after-before != 1 {
+				t.Errorf("passthrough counter increment = %f, want 1", after-before)
+			}
+		})
+	}
+}
+
+func TestCodeloadHandler_NoRedirectToConfigured_AlwaysPassthrough(t *testing.T) {
+	var upstreamHits int
+	transport := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		upstreamHits++
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader("ok")),
+			Header:     http.Header{},
+		}, nil
+	})
+
+	cfg := &config.Config{
+		Codeload: config.CodeloadConfig{},
+	}
+	handler := NewCodeloadHandler(cfg, nil, transport)
+
+	req := httptest.NewRequest(http.MethodGet, "/actions/checkout/tar.gz/abc123", nil)
+	req.Host = "codeload.github.com"
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if upstreamHits != 1 {
+		t.Errorf("upstream hits = %d, want 1", upstreamHits)
+	}
+	if w.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200", w.Code)
+	}
+	if w.Header().Get("Location") != "" {
+		t.Errorf("unexpected Location header on passthrough: %q", w.Header().Get("Location"))
+	}
+}
+
+func TestCodeloadHandler_InvalidRedirectTo_FallsBackToPassthrough(t *testing.T) {
+	var upstreamHits int
+	transport := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		upstreamHits++
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader("ok")),
+			Header:     http.Header{},
+		}, nil
+	})
+
+	cfg := &config.Config{
+		Codeload: config.CodeloadConfig{
+			RedirectTo: "/relative/not-absolute",
+		},
+	}
+	handler := NewCodeloadHandler(cfg, nil, transport)
+
+	req := httptest.NewRequest(http.MethodGet, "/actions/checkout/tar.gz/abc123", nil)
+	req.Host = "codeload.github.com"
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200 (fallback to passthrough)", w.Code)
+	}
+	if upstreamHits != 1 {
+		t.Errorf("upstream hits = %d, want 1", upstreamHits)
+	}
+}
+
+func TestCodeloadHandler_NonArchivePathPassesThrough(t *testing.T) {
+	var upstreamHits int
+	transport := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		upstreamHits++
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader("ok")),
+			Header:     http.Header{},
+		}, nil
+	})
+
+	cfg := &config.Config{
+		Codeload: config.CodeloadConfig{
+			RedirectTo: "https://codeload.cache.example.com/",
+		},
+	}
+	handler := NewCodeloadHandler(cfg, nil, transport)
+
+	// Codeload only serves archive paths in practice, but anything that
+	// doesn't match the archive pattern should fall through to upstream
+	// rather than being redirected (avoid sending unrelated traffic to a
+	// mirror that only knows how to serve archives).
+	for _, path := range []string{
+		"/",
+		"/actions/checkout",
+		"/actions/checkout/blob/main/README.md",
+		"/actions/checkout/refs", // archive format must come right after repo
+	} {
+		t.Run(path, func(t *testing.T) {
+			upstreamHits = 0
+			req := httptest.NewRequest(http.MethodGet, path, nil)
+			req.Host = "codeload.github.com"
+			w := httptest.NewRecorder()
+			handler.ServeHTTP(w, req)
+
+			if upstreamHits != 1 {
+				t.Errorf("upstream hits = %d, want 1", upstreamHits)
+			}
+			if w.Header().Get("Location") != "" {
+				t.Errorf("unexpected Location header: %q", w.Header().Get("Location"))
+			}
+		})
+	}
+}
+
+// failingTransport returns a RoundTripper that fails the test if invoked. Used
+// in redirect tests where no upstream call should happen.
+func failingTransport(t *testing.T) http.RoundTripper {
+	t.Helper()
+	return roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		t.Errorf("unexpected upstream request to %s %s", req.Method, req.URL)
+		return &http.Response{StatusCode: http.StatusInternalServerError, Body: io.NopCloser(strings.NewReader(""))}, nil
+	})
+}

--- a/internal/proxy/codeload_test.go
+++ b/internal/proxy/codeload_test.go
@@ -467,9 +467,10 @@ func failingTransport(t *testing.T) http.RoundTripper {
 // TestCodeloadHandler_RaceFreeUnderConcurrentReload drives the handler from
 // many goroutines while ReloadFrom rewrites the codeload section in parallel.
 // Run under `go test -race`: any direct read of cfg.Codeload from the request
-// hot path would be flagged. The accessor (CodeloadSnapshot) and the
-// IsCodeloadAllowed helper take the config RWMutex, so this exercise must
-// stay race-free.
+// hot path would be flagged. The accessors used by the handler —
+// Config.CodeloadRedirectTo (per-request redirect base) and
+// Config.IsCodeloadAllowed (allow-list check) — both take the config
+// RWMutex, so this exercise must stay race-free.
 func TestCodeloadHandler_RaceFreeUnderConcurrentReload(t *testing.T) {
 	transport := roundTripFunc(func(req *http.Request) (*http.Response, error) {
 		return &http.Response{

--- a/internal/proxy/codeload_test.go
+++ b/internal/proxy/codeload_test.go
@@ -219,40 +219,62 @@ func TestCodeloadHandler_NoRedirectToConfigured_PassthroughIsCounted(t *testing.
 }
 
 func TestCodeloadHandler_InvalidRedirectTo_FallsBackToPassthrough(t *testing.T) {
-	var upstreamHits int
-	transport := roundTripFunc(func(req *http.Request) (*http.Response, error) {
-		upstreamHits++
-		return &http.Response{
-			StatusCode: http.StatusOK,
-			Body:       io.NopCloser(strings.NewReader("ok")),
-			Header:     http.Header{},
-		}, nil
-	})
-
-	cfg := &config.Config{
-		Codeload: config.CodeloadConfig{
-			RedirectTo: "/relative/not-absolute",
-		},
-	}
-	handler := NewCodeloadHandler(cfg, nil, transport)
-
-	before := codeloadCounterValue(t, "actions", "checkout", "tar.gz", "passthrough")
-
-	req := httptest.NewRequest(http.MethodGet, "/actions/checkout/tar.gz/abc123", nil)
-	req.Host = "codeload.github.com"
-	w := httptest.NewRecorder()
-	handler.ServeHTTP(w, req)
-
-	if w.Code != http.StatusOK {
-		t.Errorf("status = %d, want 200 (fallback to passthrough)", w.Code)
-	}
-	if upstreamHits != 1 {
-		t.Errorf("upstream hits = %d, want 1", upstreamHits)
+	// Anything that isn't a fully-qualified http(s) URL should be rejected at
+	// validation time and the handler should fall back to transparent
+	// passthrough. Each case is independent — the cache that backs
+	// resolveRedirectBase is per-handler, so a fresh handler is constructed
+	// per row.
+	cases := []struct {
+		name       string
+		redirectTo string
+	}{
+		{"relative path", "/relative/not-absolute"},
+		{"file scheme", "file:///tmp/cache"},
+		{"opaque scheme without host", "https:no-host"},
+		{"non-http scheme", "ftp://example.com/cache"},
 	}
 
-	after := codeloadCounterValue(t, "actions", "checkout", "tar.gz", "passthrough")
-	if after-before != 1 {
-		t.Errorf("passthrough counter increment = %f, want 1", after-before)
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var upstreamHits int
+			transport := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+				upstreamHits++
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(strings.NewReader("ok")),
+					Header:     http.Header{},
+				}, nil
+			})
+
+			cfg := &config.Config{
+				Codeload: config.CodeloadConfig{
+					RedirectTo: tc.redirectTo,
+				},
+			}
+			handler := NewCodeloadHandler(cfg, nil, transport)
+
+			before := codeloadCounterValue(t, "actions", "checkout", "tar.gz", "passthrough")
+
+			req := httptest.NewRequest(http.MethodGet, "/actions/checkout/tar.gz/abc123", nil)
+			req.Host = "codeload.github.com"
+			w := httptest.NewRecorder()
+			handler.ServeHTTP(w, req)
+
+			if w.Code != http.StatusOK {
+				t.Errorf("status = %d, want 200 (fallback to passthrough)", w.Code)
+			}
+			if upstreamHits != 1 {
+				t.Errorf("upstream hits = %d, want 1", upstreamHits)
+			}
+			if loc := w.Header().Get("Location"); loc != "" {
+				t.Errorf("unexpected Location header on rejected redirect_to %q: %q", tc.redirectTo, loc)
+			}
+
+			after := codeloadCounterValue(t, "actions", "checkout", "tar.gz", "passthrough")
+			if after-before != 1 {
+				t.Errorf("passthrough counter increment = %f, want 1", after-before)
+			}
+		})
 	}
 }
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -450,6 +450,8 @@ func (s *Server) Run(ctx context.Context) error {
 		githubInner, tokenSvc, proxyTokenResolver, usernameResolver, s.logger, s.cfg)
 	githubPassthrough = proxy.NewReleasesHandler(githubPassthrough, s.cfg, s.logger)
 
+	codeloadHandler := proxy.NewCodeloadHandler(s.cfg, s.logger, nil)
+
 	copilotPassthrough := proxy.NewCopilotPassthroughHandler(
 		"https://copilot-proxy.githubusercontent.com", s.cfg.GitHub.EnterpriseSlug, s.logger, nil)
 
@@ -458,11 +460,12 @@ func (s *Server) Run(ctx context.Context) error {
 
 	// Build host dispatch with access logging on all handlers.
 	dispatch := newHostDispatch(hostDispatchConfig{
-		apiHandler:     accessLogHandler(backend.API, proxyHandler, aw),
-		githubHandler:  accessLogHandler(backend.GitHub, githubPassthrough, aw),
-		copilotHandler: accessLogHandler(backend.Copilot, copilotPassthrough, aw),
-		mgmtHandler:    accessLogHandler(backend.Mgmt, web.SessionUsernameMiddleware(authHandler)(web.SecurityHeadersMiddleware(mux)), aw),
-		managementHost: s.cfg.Server.ManagementHost,
+		apiHandler:      accessLogHandler(backend.API, proxyHandler, aw),
+		githubHandler:   accessLogHandler(backend.GitHub, githubPassthrough, aw),
+		codeloadHandler: accessLogHandler(backend.Codeload, codeloadHandler, aw),
+		copilotHandler:  accessLogHandler(backend.Copilot, copilotPassthrough, aw),
+		mgmtHandler:     accessLogHandler(backend.Mgmt, web.SessionUsernameMiddleware(authHandler)(web.SecurityHeadersMiddleware(mux)), aw),
+		managementHost:  s.cfg.Server.ManagementHost,
 	})
 
 	// Wrap dispatch with the Server response header middleware so that every
@@ -732,11 +735,12 @@ func systemdListeners() ([]net.Listener, error) {
 }
 
 type hostDispatchConfig struct {
-	apiHandler     http.Handler
-	githubHandler  http.Handler
-	copilotHandler http.Handler
-	mgmtHandler    http.Handler
-	managementHost string
+	apiHandler      http.Handler
+	githubHandler   http.Handler
+	codeloadHandler http.Handler
+	copilotHandler  http.Handler
+	mgmtHandler     http.Handler
+	managementHost  string
 }
 
 // newHostDispatch creates a handler that routes requests by Host header.
@@ -752,6 +756,8 @@ func newHostDispatch(cfg hostDispatchConfig) http.Handler {
 			cfg.apiHandler.ServeHTTP(w, r)
 		case host == backend.GitHub:
 			cfg.githubHandler.ServeHTTP(w, r)
+		case host == backend.Codeload:
+			cfg.codeloadHandler.ServeHTTP(w, r)
 		case host == "githubcopilot.com" || strings.HasSuffix(host, ".githubcopilot.com"):
 			cfg.copilotHandler.ServeHTTP(w, r)
 		case cfg.managementHost == "" || strings.EqualFold(host, cfg.managementHost):

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -745,12 +745,18 @@ type hostDispatchConfig struct {
 }
 
 // newHostDispatch creates a handler that routes requests by Host header.
+//
+// The Host header is normalised to lowercase before comparison: hostnames are
+// case-insensitive (RFC 1035 §2.3.3) and net/http does not lowercase r.Host
+// for us, so without this a client sending "API.GitHub.com" would 404 even
+// though it resolves to the same backend as "api.github.com".
 func newHostDispatch(cfg hostDispatchConfig) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		host := r.Host
 		if h, _, err := net.SplitHostPort(host); err == nil {
 			host = h
 		}
+		host = strings.ToLower(host)
 
 		switch {
 		case host == backend.API:

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -4,8 +4,9 @@
 //   - Opening the database and running/checking migrations
 //   - Initializing encryption, token services, and the GitHub App provider
 //   - Building the host-dispatch handler that routes requests by Host header
-//     to the appropriate backend (API proxy, github.com passthrough, Copilot
-//     passthrough, or management UI)
+//     to the appropriate backend (API proxy, github.com passthrough,
+//     codeload.github.com redirect/passthrough, Copilot passthrough, or
+//     management UI)
 //   - Starting TLS and/or plain HTTP listeners (including systemd socket
 //     activation support)
 //   - Running the dedicated Prometheus metrics server on a separate port

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -40,15 +40,20 @@ func TestHostDispatch(t *testing.T) {
 	}{
 		{"api.github.com", "api"},
 		{"api.github.com:443", "api"},
+		{"API.GitHub.COM", "api"}, // hostnames are case-insensitive (RFC 1035 §2.3.3)
 		{"github.com", "github"},
 		{"github.com:443", "github"},
+		{"GitHub.com:443", "github"},
 		{"codeload.github.com", "codeload"},
 		{"codeload.github.com:443", "codeload"},
+		{"CodeLoad.GitHub.com", "codeload"},
 		{"api.githubcopilot.com", "copilot"},
 		{"copilot.githubcopilot.com", "copilot"},
 		{"githubcopilot.com", "copilot"},
+		{"API.GitHubCopilot.com", "copilot"},
 		{"ghp.example.com", "mgmt"},
 		{"ghp.example.com:443", "mgmt"},
+		{"GHP.Example.COM", "mgmt"},
 		{"unknown.example.com", ""}, // 404 when managementHost is set
 	}
 

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -73,8 +73,8 @@ func TestHostDispatch(t *testing.T) {
 }
 
 // TestServerHeaderAllBackends verifies that the Server and X-GitHub-Proxy-Version
-// response headers are set on all backends (api, github, copilot, mgmt) when
-// ServerHeaderMiddleware wraps the host dispatch handler.
+// response headers are set on all backends (api, github, codeload, copilot, mgmt)
+// when ServerHeaderMiddleware wraps the host dispatch handler.
 func TestServerHeaderAllBackends(t *testing.T) {
 	const version = "1.2.3"
 
@@ -111,6 +111,7 @@ func TestServerHeaderAllBackends(t *testing.T) {
 	}{
 		{"api backend", "api.github.com", "api"},
 		{"github backend", "github.com", "github"},
+		{"codeload backend", "codeload.github.com", "codeload"},
 		{"copilot backend", "api.githubcopilot.com", "copilot"},
 		{"mgmt backend", "ghp.example.com", "mgmt"},
 	}

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -15,6 +15,9 @@ func TestHostDispatch(t *testing.T) {
 	githubHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Write([]byte("github"))
 	})
+	codeloadHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("codeload"))
+	})
 	copilotHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Write([]byte("copilot"))
 	})
@@ -23,11 +26,12 @@ func TestHostDispatch(t *testing.T) {
 	})
 
 	dispatch := newHostDispatch(hostDispatchConfig{
-		apiHandler:     apiHandler,
-		githubHandler:  githubHandler,
-		copilotHandler: copilotHandler,
-		mgmtHandler:    mgmtHandler,
-		managementHost: "ghp.example.com",
+		apiHandler:      apiHandler,
+		githubHandler:   githubHandler,
+		codeloadHandler: codeloadHandler,
+		copilotHandler:  copilotHandler,
+		mgmtHandler:     mgmtHandler,
+		managementHost:  "ghp.example.com",
 	})
 
 	tests := []struct {
@@ -38,6 +42,8 @@ func TestHostDispatch(t *testing.T) {
 		{"api.github.com:443", "api"},
 		{"github.com", "github"},
 		{"github.com:443", "github"},
+		{"codeload.github.com", "codeload"},
+		{"codeload.github.com:443", "codeload"},
 		{"api.githubcopilot.com", "copilot"},
 		{"copilot.githubcopilot.com", "copilot"},
 		{"githubcopilot.com", "copilot"},
@@ -78,6 +84,9 @@ func TestServerHeaderAllBackends(t *testing.T) {
 	githubHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Write([]byte("github"))
 	})
+	codeloadHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("codeload"))
+	})
 	copilotHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Write([]byte("copilot"))
 	})
@@ -86,11 +95,12 @@ func TestServerHeaderAllBackends(t *testing.T) {
 	})
 
 	dispatch := newHostDispatch(hostDispatchConfig{
-		apiHandler:     apiHandler,
-		githubHandler:  githubHandler,
-		copilotHandler: copilotHandler,
-		mgmtHandler:    mgmtHandler,
-		managementHost: "ghp.example.com",
+		apiHandler:      apiHandler,
+		githubHandler:   githubHandler,
+		codeloadHandler: codeloadHandler,
+		copilotHandler:  copilotHandler,
+		mgmtHandler:     mgmtHandler,
+		managementHost:  "ghp.example.com",
 	})
 	handler := web.ServerHeaderMiddleware(version)(dispatch)
 
@@ -131,11 +141,12 @@ func TestHostDispatch_EmptyManagementHost(t *testing.T) {
 	})
 
 	dispatch := newHostDispatch(hostDispatchConfig{
-		apiHandler:     http.NotFoundHandler(),
-		githubHandler:  http.NotFoundHandler(),
-		copilotHandler: http.NotFoundHandler(),
-		mgmtHandler:    mgmtHandler,
-		managementHost: "", // empty = catch-all fallback
+		apiHandler:      http.NotFoundHandler(),
+		githubHandler:   http.NotFoundHandler(),
+		codeloadHandler: http.NotFoundHandler(),
+		copilotHandler:  http.NotFoundHandler(),
+		mgmtHandler:     mgmtHandler,
+		managementHost:  "", // empty = catch-all fallback
 	})
 
 	tests := []struct {

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -34,6 +34,7 @@ nav:
     - Token Scoping: features/token-scoping.md
     - Token Type Border Policy: features/border-policy.md
     - Release Download Controls: features/release-controls.md
+    - Codeload Redirect: features/codeload.md
     - OAuth Broker: features/oauth-broker.md
   - Administration:
     - Installation: admin/installation.md


### PR DESCRIPTION
## Summary

Adds `codeload.github.com` as a first-class backend so ghp can offload repo archive downloads (the tarballs `actions/checkout` and friends fetch by SHA) to an internal caching mirror. Motivated by transient proxy/egress failures on highly repetitive, cacheable traffic — the `(owner, repo, sha)` tuple is immutable, so a single corporate cache can serve every subsequent build.

## How it works

- New host case in the dispatcher routes `codeload.github.com` to a dedicated handler.
- `codeload.redirect_to` (absolute URL) → archive paths `/{owner}/{repo}/(tar.gz|zip|legacy.tar.gz|legacy.zip)/{ref}` get a `302` to `redirect_to + path` (query string preserved).
- `codeload.allow` exempts orgs / org-repos (case-insensitive) — those plus any non-archive paths are forwarded transparently to upstream `codeload.github.com`.
- When `redirect_to` is unset, every codeload request is forwarded transparently — adding the host to ghp's DNS/forward-proxy config never breaks the build.
- ghp itself never caches; the mirror is responsible for fetch-and-store.

## Metrics

- `ghp_codeload_redirect_total{owner, repo, archive, result}` — `result` is `redirect` or `passthrough`. `archive` is one of `tar.gz`, `zip`, `legacy.tar.gz`, `legacy.zip`.
- The ref (SHA, branch, tag) is intentionally **not** a label — including pinned SHAs would blow up label cardinality. Per-ref analysis is available via the access-log URL field.

## Config

```yaml
codeload:
  redirect_to: "https://codeload.cache.example.com/"
  allow:
    - "myorg"
    - "external/tool"
```

Plus `GHP_CODELOAD_REDIRECT_TO`, `GHP_CODELOAD_ALLOW`, and indexed-list support (`GHP_CODELOAD_ALLOW_COUNT` + `GHP_CODELOAD_ALLOW_N`). Hot-reloaded on `SIGUSR1` along with the rest of the runtime config.

## Test plan

- [x] `go test ./internal/proxy/ ./internal/server/ ./internal/metrics/ ./internal/config/` (added `internal/proxy/codeload_test.go`, extended `metrics_test.go` and `server_test.go`)
- [x] `go vet ./...`
- [x] `make build`
- [ ] Manual smoke test against a real cache mirror (curl `codeload.github.com/...` through ghp, verify 302 + counter increments)
- [ ] Confirm SIGUSR1 hot-reload picks up codeload changes
- [ ] Verify access log records the full URL (and thus ref) for redirected requests

https://claude.ai/code/session_01M9uGYqz65tavEVCCBS6bKc