### PR TITLE
refactor: set global slog default to the configured logger

### DIFF
--- a/cmd/ghp/serve.go
+++ b/cmd/ghp/serve.go
@@ -37,6 +37,12 @@ be upgraded between restarts.`,
 			logger, logWriter, cleanupLogger := newLogger(cfg)
 			defer cleanupLogger()
 
+			// Make the configured logger the global slog default so background
+			// goroutines in internal packages (e.g. token.StartCleanup,
+			// gitcache.StartCleanup) that use bare slog.Info/Error calls route
+			// through the same handler as the rest of the server.
+			slog.SetDefault(logger)
+
 			migrate, _ := cmd.Flags().GetBool("migrate")
 
 			logger.Info("server_start", "msg", "starting ghp server", "version", version)


### PR DESCRIPTION
## Summary

Internal background goroutines (`token.StartCleanup`, `gitcache.StartCleanup`, plus the gitcache handler/repository code paths) emit logs via bare `slog.Info` / `slog.Error` calls. Until now the configured application logger was never installed as the `slog` default, so those calls bypassed the JSON handler and file output configured at startup and appeared unstructured on stderr — or not where operators expected them.

This applies option 1 from #156: a one-line `slog.SetDefault(logger)` during `serve` startup so every package that uses the package-level `slog` functions routes through the configured handler. No signature changes required.

## Affected sites

Bare `slog.*` calls that benefit immediately:
- `internal/token/cleanup.go` (4 calls)
- `internal/gitcache/cleanup.go` (5 calls)
- `internal/gitcache/handler.go` (12 calls)
- `internal/gitcache/repository.go` (3 calls)

## Test plan

- [x] `make vet`
- [x] `make build`
- [x] `go test ./cmd/ghp/... ./internal/token/... ./internal/gitcache/...`
- [x] `make test` (unrelated postgres/vault container tests skipped — Docker not available locally)

Fixes #156

---
_Generated by [Claude Code](https://claude.ai/code/session_018XkASw8KVyBLhZZgYBxyNH)_