### PR TITLE
fix(release): pin mkdocs-shadcn so Docker publish succeeds

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: astral-sh/setup-uv@v8.2.0
 
       - name: Build MkDocs site
-        run: uvx --with mkdocs-shadcn mkdocs build
+        run: uvx --with mkdocs-shadcn==0.10.2 mkdocs build
 
       - name: Setup Pages
         uses: actions/configure-pages@v6

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -2,7 +2,7 @@ version: 2
 
 before:
   hooks:
-    - uvx --with mkdocs-shadcn mkdocs build --site-dir internal/docs/site
+    - uvx --with mkdocs-shadcn==0.10.2 mkdocs build --site-dir internal/docs/site
 
 builds:
   - main: ./cmd/ghp

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM python:3.14 AS docs
 WORKDIR /src
 COPY mkdocs.yml ./
 COPY docs/ docs/
-RUN pip install uv && uvx --with mkdocs-shadcn mkdocs build --site-dir internal/docs/site
+RUN pip install uv && uvx --with mkdocs-shadcn==0.10.2 mkdocs build --site-dir internal/docs/site
 
 FROM golang:1.26 AS build
 WORKDIR /src


### PR DESCRIPTION
## Root cause

The `0.18.0` Release workflow ([run 26345495018](https://github.com/goodtune/ghp/actions/runs/26345495018)) **failed before the Docker image was ever built or pushed to GHCR**.

GoReleaser runs a `before` hook — `uvx --with mkdocs-shadcn mkdocs build` — to generate the embedded docs. That dependency was **unpinned**, so it resolved to a newer `mkdocs-shadcn` release. The newer theme removed the `components/icon.html` template that our override `docs/overrides/templates/header.html` still `{% include %}`s, so the build aborted with:

```
jinja2.exceptions.TemplateNotFound: 'components/icon.html' not found in search paths: ...
⨯ release failed after 1s  error=hook failed: command failed  cmd=uvx
```

Because the hook failed, GoReleaser never reached the `dockers_v2` stage — so **no image was published for 0.18.0**. The failure had nothing to do with GHCR auth or the Docker config; it was purely the docs pre-build hook.

I reproduced the failure locally with the latest theme, and confirmed the build succeeds (exit 0, warnings only) when pinned to `0.10.2` — the version that was current when the overrides were authored (2026-03-23).

## Fix

Pin `mkdocs-shadcn==0.10.2` in all three places that build the docs, so the build is reproducible and a future theme release can't silently break a release again:

- `.goreleaser.yml` — the GoReleaser `before` hook (the one that broke the release)
- `Dockerfile` — the runtime image's docs build stage (would have hit the same break)
- `.github/workflows/pages.yml` — the GitHub Pages deploy

## Follow-up notes

- This repo uses Renovate. A future automated bump of this pin could reintroduce the break, but it would only surface at release/pages time (the `test` workflow doesn't build docs). A longer-term option is to update the `docs/overrides/` templates to match a current theme version, or add a docs-build smoke check to CI.

## Verification

- [x] Reproduced the `TemplateNotFound` failure with the unpinned (latest) theme
- [x] Confirmed `mkdocs build` succeeds with `mkdocs-shadcn==0.10.2`
- [ ] Cut a new release and confirm the GHCR image publishes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lda3e3eGmVJUj4t1V98mQx

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lda3e3eGmVJUj4t1V98mQx)_