### PR TITLE
feat(web): surface build version in login UI and version header

### DIFF
--- a/docs/admin/monitoring.md
+++ b/docs/admin/monitoring.md
@@ -199,11 +199,25 @@ logging:
     path: "/var/log/ghp/ghp.log"
 ```
 
-## Server Response Header
+## Server Response Headers
 
-Every response from ghp includes a `Server: GitHub Proxy <version>` header.
-This makes it easy to verify that traffic is flowing through ghp rather than
-directly to GitHub, and to identify which version of ghp is running.
+Every response from ghp includes two identifying headers, set by a
+server-wide middleware regardless of which backend served the request:
+
+- `Server: GitHub Proxy` — a fixed value that overrides any upstream
+  `Server` header (e.g. GitHub's own `server: github.com`), making it easy to
+  verify that traffic is flowing through ghp rather than directly to GitHub.
+- `X-GitHub-Proxy-Version: <version>` — the build version of the running ghp
+  binary, so operators can identify exactly which image a deployment is
+  serving. The header is omitted when no version was compiled in.
+
+You can confirm the deployed version from the command line:
+
+    curl -sI https://ghp.example.com/docs/ | grep -i x-github-proxy-version
+
+The same version string is also displayed beneath the login form in the web
+UI, so managers rolling out a new image can identify the running version at a
+glance without inspecting headers.
 
 ## Health Check
 

--- a/e2e/tests/login.spec.ts
+++ b/e2e/tests/login.spec.ts
@@ -19,6 +19,18 @@ test.describe("Login page", () => {
     });
   });
 
+  test("displays the build version beneath the login form", async ({
+    page,
+  }) => {
+    await page.goto("/login");
+
+    // The version string helps managers identify which image is deployed.
+    // In dev/CI builds the version defaults to "dev".
+    const version = page.locator(".version");
+    await expect(version).toBeVisible();
+    await expect(version).toContainText("version");
+  });
+
   test("has a Sign in with GitHub button linking to OAuth", async ({
     page,
   }) => {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -382,7 +382,7 @@ func (s *Server) Run(ctx context.Context) error {
 		}
 	}
 	api := NewAPI(lifecycleCtx, s.cfg, store, tokenSvc, authHandler, enc, concreteATP, appRegistry, proxyTokenResolver, usernameResolver, s.logger, auditWriter)
-	webUI := web.NewHandler(authHandler, store, s.cfg.DevMode, s.logger)
+	webUI := web.NewHandler(authHandler, store, s.cfg.DevMode, s.version, s.logger)
 
 	// Build HTTP mux.
 	mux := http.NewServeMux()

--- a/internal/web/handler.go
+++ b/internal/web/handler.go
@@ -27,17 +27,21 @@ type Handler struct {
 	auth      *auth.Handler
 	store     database.Store
 	devMode   bool
+	version   string
 	logger    *slog.Logger
 	templates *template.Template
 }
 
-// NewHandler creates a new web UI handler.
-func NewHandler(ah *auth.Handler, store database.Store, devMode bool, logger *slog.Logger) *Handler {
+// NewHandler creates a new web UI handler. version is the build version string
+// surfaced in the UI (e.g. beneath the login form) so operators can identify
+// which image a deployment is running.
+func NewHandler(ah *auth.Handler, store database.Store, devMode bool, version string, logger *slog.Logger) *Handler {
 	tmpl := template.Must(template.ParseFS(templateFS, "templates/*.html"))
 	return &Handler{
 		auth:      ah,
 		store:     store,
 		devMode:   devMode,
+		version:   version,
 		logger:    logger,
 		templates: tmpl,
 	}
@@ -136,7 +140,10 @@ func (h *Handler) handleLogin(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := h.templates.ExecuteTemplate(w, "login.html", nil); err != nil {
+	data := map[string]interface{}{
+		"Version": h.version,
+	}
+	if err := h.templates.ExecuteTemplate(w, "login.html", data); err != nil {
 		h.logger.Error("template execution failed", "error", err)
 		http.Error(w, "Internal error", http.StatusInternalServerError)
 	}

--- a/internal/web/handler_test.go
+++ b/internal/web/handler_test.go
@@ -1,0 +1,81 @@
+package web
+
+import (
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/goodtune/ghp/internal/auth"
+	"github.com/goodtune/ghp/internal/config"
+	"github.com/goodtune/ghp/internal/crypto"
+)
+
+// newTestWebHandler builds a web.Handler backed by an in-memory SQLite store,
+// with the given build version string.
+func newTestWebHandler(t *testing.T, version string) *Handler {
+	t.Helper()
+	key, err := crypto.GenerateKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+	enc, err := crypto.NewEncryptor(key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg := &config.Config{DevMode: true}
+	ah := auth.NewHandler(cfg, newTestAuthStore(t), enc, slog.Default())
+	return NewHandler(ah, newTestAuthStore(t), true, version, slog.Default())
+}
+
+// TestHandleLoginRendersVersion verifies that the build version is surfaced on
+// the login page so operators can identify which image is deployed.
+func TestHandleLoginRendersVersion(t *testing.T) {
+	tests := []struct {
+		name       string
+		version    string
+		wantInBody string // substring expected in the response body
+		wantAbsent bool   // when true, the version block must not be rendered
+	}{
+		{
+			name:       "release version",
+			version:    "1.2.3",
+			wantInBody: "version 1.2.3",
+		},
+		{
+			name:       "dev version",
+			version:    "dev",
+			wantInBody: "version dev",
+		},
+		{
+			name:       "empty version omits the block",
+			version:    "",
+			wantAbsent: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			h := newTestWebHandler(t, tc.version)
+
+			rr := httptest.NewRecorder()
+			h.handleLogin(rr, httptest.NewRequest("GET", "/login", nil))
+
+			if rr.Code != http.StatusOK {
+				t.Fatalf("status: got %d, want 200; body: %s", rr.Code, rr.Body.String())
+			}
+
+			body := rr.Body.String()
+			if tc.wantAbsent {
+				if strings.Contains(body, `class="version"`) {
+					t.Errorf("expected no version block for empty version, got body:\n%s", body)
+				}
+				return
+			}
+			if !strings.Contains(body, tc.wantInBody) {
+				t.Errorf("login body missing %q; body:\n%s", tc.wantInBody, body)
+			}
+		})
+	}
+}

--- a/internal/web/templates/login.html
+++ b/internal/web/templates/login.html
@@ -13,14 +13,18 @@
         .btn { display: inline-block; background: #238636; color: #fff; padding: 0.75rem 1.5rem; border-radius: 6px; text-decoration: none; font-weight: 600; border: none; cursor: pointer; font-size: 1rem; }
         .btn:hover { background: #2ea043; }
         .logo { font-size: 2rem; margin-bottom: 1rem; }
+        .version { margin-top: 1rem; color: #484f58; font-size: 0.75rem; text-align: center; font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace; }
     </style>
 </head>
 <body>
-    <div class="card">
-        <div class="logo">&#128274;</div>
-        <h1>ghp</h1>
-        <p>GitHub Proxy for Autonomous Coding Agents</p>
-        <a href="/auth/github" class="btn">Sign in with GitHub</a>
+    <div>
+        <div class="card">
+            <div class="logo">&#128274;</div>
+            <h1>ghp</h1>
+            <p>GitHub Proxy for Autonomous Coding Agents</p>
+            <a href="/auth/github" class="btn">Sign in with GitHub</a>
+        </div>
+        {{if .Version}}<div class="version">version {{.Version}}</div>{{end}}
     </div>
 </body>
 </html>


### PR DESCRIPTION
## Summary

Makes the build version visible to operators in two complementary ways so managers deploying a new image can tell which version they're hitting:

- **Login UI** — the build version now renders as a short, muted string beneath the login form bounding box (e.g. `version 1.2.3`). The web `Handler` takes the version string and passes it to the login template; the block is omitted when no version is compiled in.
- **Response header** — `X-GitHub-Proxy-Version: <version>` is emitted on every response to complement the existing `Server: GitHub Proxy` header. This was already implemented by `ServerHeaderMiddleware`; this PR documents it and corrects the docs.

## Changes

- `internal/web/handler.go` — `NewHandler` now accepts a `version` string; `handleLogin` passes it to the template.
- `internal/web/templates/login.html` — renders the version beneath the card (conditional on a non-empty version).
- `internal/server/server.go` — wires `s.version` into the web handler.
- `internal/web/handler_test.go` — new unit tests covering release/dev/empty version rendering.
- `e2e/tests/login.spec.ts` — asserts the version string is visible on the login page.
- `docs/admin/monitoring.md` — corrects the Server-header section (the version lives in `X-GitHub-Proxy-Version`, not embedded in `Server`) and documents the login-page version display.

## Notes

The `X-GitHub-Proxy-Version` middleware already existed and was tested; the docs previously claimed `Server: GitHub Proxy <version>`, which didn't match the code. That's now corrected.

## Testing

- `go build ./...`, `go vet ./...`
- `go test ./internal/web/ ./internal/server/` — pass (Postgres/Vault container tests are skipped locally — Docker unavailable — and are unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hz64c58xoWuuQKmFnmbZ3s

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hz64c58xoWuuQKmFnmbZ3s)_