### PR TITLE
Fix ghp token list: show real token ID, drop unimplemented REQUESTS column

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -136,7 +136,7 @@ Labels: `stage`, `token_type` (`proxy` for `ghx_` tokens, `agent` for `gha_` tok
 
 ### Sentinel Errors
 
-New `Store` interface methods that look up a record by ID should return `database.ErrNotFound` (wrapped via `fmt.Errorf("...: %w", database.ErrNotFound)`) when the record does not exist. Prefer this over plain `fmt.Errorf("not found")` strings. API handlers should map `ErrNotFound` → 404 and other store errors → 500. Some older methods (e.g. `RevokeProxyToken`, `UpdateProxyTokenUsage`) predate this convention and use different patterns; align them as they are touched.
+New `Store` interface methods that look up a record by ID should return `database.ErrNotFound` (wrapped via `fmt.Errorf("...: %w", database.ErrNotFound)`) when the record does not exist. Prefer this over plain `fmt.Errorf("not found")` strings. API handlers should map `ErrNotFound` → 404 and other store errors → 500. Some older methods (e.g. `RevokeProxyToken`) predate this convention and use different patterns; align them as they are touched.
 
 ### API Input Validation
 

--- a/cmd/ghp/main_test.go
+++ b/cmd/ghp/main_test.go
@@ -1221,6 +1221,9 @@ func TestTokenListCmd(t *testing.T) {
 	if strings.Contains(output, "ghx_abcd") {
 		t.Errorf("expected token prefix NOT to appear as the ID column, got: %q", output)
 	}
+	if strings.Contains(output, "REQUESTS") {
+		t.Errorf("expected REQUESTS column to be removed, got: %q", output)
+	}
 }
 
 // TestTokenListCmd_Empty verifies that token list handles empty results gracefully.

--- a/cmd/ghp/main_test.go
+++ b/cmd/ghp/main_test.go
@@ -1190,12 +1190,12 @@ func TestTokenListCmd(t *testing.T) {
 		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode([]map[string]interface{}{
 			{
-				"token_prefix":  "ghx_abcd",
-				"token_type":    "proxy",
-				"repositories":  []interface{}{"owner/repo"},
-				"session_id":    "sess1",
-				"expires_at":    "2099-01-01T00:00:00Z",
-				"request_count": float64(5),
+				"id":           "11111111-1111-1111-1111-111111111111",
+				"token_prefix": "ghx_abcd",
+				"token_type":   "proxy",
+				"repositories": []interface{}{"owner/repo"},
+				"session_id":   "sess1",
+				"expires_at":   "2099-01-01T00:00:00Z",
 			},
 		})
 	}))
@@ -1215,8 +1215,11 @@ func TestTokenListCmd(t *testing.T) {
 		t.Fatalf("token list error: %v", err)
 	}
 	output := buf.String()
-	if !strings.Contains(output, "ghx_abcd") {
-		t.Errorf("expected token prefix in output, got: %q", output)
+	if !strings.Contains(output, "11111111-1111-1111-1111-111111111111") {
+		t.Errorf("expected token id in output, got: %q", output)
+	}
+	if strings.Contains(output, "ghx_abcd") {
+		t.Errorf("expected token prefix NOT to appear as the ID column, got: %q", output)
 	}
 }
 

--- a/cmd/ghp/main_test.go
+++ b/cmd/ghp/main_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -1215,14 +1216,20 @@ func TestTokenListCmd(t *testing.T) {
 		t.Fatalf("token list error: %v", err)
 	}
 	output := buf.String()
-	if !strings.Contains(output, "11111111-1111-1111-1111-111111111111") {
-		t.Errorf("expected token id in output, got: %q", output)
+	lines := strings.Split(strings.TrimRight(output, "\n"), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("expected a header line and one data line, got: %q", output)
+	}
+	wantHeader := []string{"ID", "TYPE", "REPOS", "SCOPES", "SESSION", "EXPIRES"}
+	if gotHeader := strings.Fields(lines[0]); !slices.Equal(gotHeader, wantHeader) {
+		t.Errorf("expected header %v, got: %v", wantHeader, gotHeader)
+	}
+	fields := strings.Fields(lines[1])
+	if len(fields) == 0 || fields[0] != "11111111-1111-1111-1111-111111111111" {
+		t.Errorf("expected ID column to be the token id, got row: %q", lines[1])
 	}
 	if strings.Contains(output, "ghx_abcd") {
-		t.Errorf("expected token prefix NOT to appear as the ID column, got: %q", output)
-	}
-	if strings.Contains(output, "REQUESTS") {
-		t.Errorf("expected REQUESTS column to be removed, got: %q", output)
+		t.Errorf("expected token prefix NOT to appear anywhere in output, got: %q", output)
 	}
 }
 

--- a/cmd/ghp/token.go
+++ b/cmd/ghp/token.go
@@ -211,9 +211,9 @@ func newTokenCmd() *cobra.Command {
 			}
 
 			w := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 0, 2, ' ', 0)
-			fmt.Fprintln(w, "ID\tTYPE\tREPOS\tSCOPES\tSESSION\tEXPIRES\tREQUESTS")
+			fmt.Fprintln(w, "ID\tTYPE\tREPOS\tSCOPES\tSESSION\tEXPIRES")
 			for _, t := range tokens {
-				prefix := fmt.Sprint(t["token_prefix"])
+				id := fmt.Sprint(t["id"])
 				tokenType := fmt.Sprint(t["token_type"])
 
 				reposStr := ""
@@ -250,13 +250,8 @@ func newTokenCmd() *cobra.Command {
 					}
 				}
 
-				requests := "0"
-				if n, ok := t["request_count"].(float64); ok {
-					requests = fmt.Sprintf("%.0f", n)
-				}
-
-				fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
-					prefix, tokenType, reposStr, scopeStr, session, expiresStr, requests)
+				fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\n",
+					id, tokenType, reposStr, scopeStr, session, expiresStr)
 			}
 			w.Flush()
 			return nil

--- a/docs/cli/token.md
+++ b/docs/cli/token.md
@@ -63,8 +63,8 @@ can be omitted and the installation will be resolved against the default app.
 
     ghp token list
 
-List your active tokens with type, repositories, scopes, session, expiry, and
-request count.
+List your active tokens with ID, type, repositories, scopes, session, and
+expiry.
 
 ### ghp token revoke
 

--- a/docs/web-ui.md
+++ b/docs/web-ui.md
@@ -15,7 +15,7 @@ directly — no GitHub OAuth required.
 
 After signing in, the dashboard shows:
 
-- **Your Tokens** — active tokens with repository, scopes, expiry, and request count
+- **Your Tokens** — active tokens with repository, scopes, and expiry
 - **Create Token** — form to create a new scoped `ghx_` token
 - **Revoke** — revoke any of your tokens immediately
 


### PR DESCRIPTION
## Summary

- The `ID` column in `ghp token list` showed `token_prefix` instead of the actual token ID, so copying it into `ghp token revoke <id>` never worked. Now reads the `id` field the API already returns.
- The `REQUESTS` column always showed `0` because `request_count`/`last_used_at` were dropped from the schema in migration `005_drop_usage_columns` and never wired back up anywhere (no DB column, no `Store` method, no proxy-side write). Rather than restore that (which would require a synchronous store write on every proxied request — including a KV round-trip to Vault for Vault-backed deployments — for a value with no atomic-increment story there), the column is dropped from the CLI output. Aggregate request observability already exists via the `ghp_proxy_request_total` Prometheus metric.
- Corrected a stale `CLAUDE.md` reference to `UpdateProxyTokenUsage` as an "older method" — it never actually existed in the current codebase.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` (all pass except pre-existing Postgres/Vault contract tests that require Docker, unavailable in this sandbox and unrelated to this change)
- [x] Updated `cmd/ghp/main_test.go` to assert the ID column shows the real token ID (not the prefix) and that the REQUESTS column is gone


---
_Generated by [Claude Code](https://claude.ai/code/session_01TMbJoAifat1AgdmvjyAobk)_