### PR TITLE
ci: allow go, make, curl in the @claude workflow

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -46,5 +46,6 @@ jobs:
           # Optional: Add claude_args to customize behavior and configuration
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
-          # claude_args: '--allowed-tools Bash(gh pr:*)'
+          claude_args: |
+            --allowed-tools "Bash(go:*),Bash(make:*),Bash(curl:*)"
 


### PR DESCRIPTION
## Summary

Addresses [this comment](https://github.com/goodtune/ghp/pull/218#issuecomment-4910733492) on PR #218: the free-form `@claude` workflow (`.github/workflows/claude.yml`) has no `claude_args` configured, so Bash commands like `go`, `make`, and `curl` fall outside the default allowlist and require interactive approval — which never arrives in a non-interactive CI run, so those commands fail closed.

- Add `claude_args: --allowed-tools "Bash(go:*),Bash(make:*),Bash(curl:*)"` to `.github/workflows/claude.yml`, matching the narrower-allowlist approach recommended in the linked comment (as opposed to `--dangerously-skip-permissions`, which `claude-review-response.yml` uses for its narrower, skill-driven flow).
- No egress/network changes needed — `ubuntu-latest` runners already have outbound internet access; the blocker was purely the tool permission gate.

This unblocks future `@claude` runs (e.g. dependency-bump PRs) from running `go mod tidy`, `make check`, etc. directly instead of stopping short and asking a maintainer to apply a patch.

## Test plan

- [x] Validated YAML syntax (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [ ] Confirm a subsequent `@claude` comment on a PR can now run `go`/`make`/`curl` without an approval prompt


---
_Generated by [Claude Code](https://claude.ai/code/session_01JyKRScZ5XMRvdBkSPN2fRJ)_