### PR TITLE
feat: proxy raw.githubusercontent.com

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -147,7 +147,7 @@ Labels: `stage`, `token_type` (`proxy` for `ghx_` tokens, `agent` for `gha_` tok
 - `ghp_cache_request_total` — per-repository git requests with cache outcome (`owner`, `repo`, `result` labels)
 - `ghp_cache_eviction_total` — protocol response files evicted by size-limit cleanup (`owner`, `repo` labels)
 - `ghp_cache_response_size_bytes` — current total cached protocol response file size per repo (`owner`, `repo` labels)
-- `ghp_raw_request_total` — `raw.githubusercontent.com` requests by classification result (`owner`, `repo`, `result` labels; `authenticated`, `query_token`, `anonymous`, `denied_policy`, `denied_method`, `denied_scope`)
+- `ghp_raw_request_total` — `raw.githubusercontent.com` requests by classification result (`owner`, `repo`, `result` labels; `authenticated`, `query_token`, `foreign_credential`, `anonymous`, `denied_policy`, `denied_border`, `denied_method`, `denied_scope`, `denied_token`, `error`)
 
 ## Coding Conventions
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,6 +4,29 @@
 
 GHP is a GitHub API reverse proxy that issues scoped, auditable tokens (`ghx_`-prefixed) to autonomous coding agents. Single static Go binary, self-hosted.
 
+## Enforcement vs Telemetry
+
+**GHP is an enforcement point for tokens it issued and a telemetry point for
+everything else.**
+
+Handlers may forward traffic GHP cannot attribute or scope-check, provided it
+is logged and counted. This is deliberate, not a gap. Two rules follow:
+
+- **Never imply enforcement that isn't happening.** When a handler observes
+  without enforcing, say so in the docs, and give operators a config switch to
+  refuse the unenforceable traffic if they would rather break clients than
+  allow it. `raw.allow_query_token` is the reference example.
+- **A credential GHP did not issue is never forwarded alongside one it did.**
+  If a request carries both, strip the foreign credential — otherwise it can
+  satisfy a request the scope check denied.
+
+Some GitHub hosts are outside enterprise network policy entirely.
+`raw.githubusercontent.com` accepts `Authorization` headers but is exempt from
+the `sec-GitHub-allowed-enterprise` corporate proxy restriction, which GitHub
+scopes to `github.com`, `api.github.com`, and `*.githubcopilot.com` only. That
+exemption is why proxying these hosts is worth the effort: GHP is the only
+place the traffic can be seen.
+
 ## Tech Stack
 
 - **Language:** Go 1.24
@@ -124,6 +147,7 @@ Labels: `stage`, `token_type` (`proxy` for `ghx_` tokens, `agent` for `gha_` tok
 - `ghp_cache_request_total` — per-repository git requests with cache outcome (`owner`, `repo`, `result` labels)
 - `ghp_cache_eviction_total` — protocol response files evicted by size-limit cleanup (`owner`, `repo` labels)
 - `ghp_cache_response_size_bytes` — current total cached protocol response file size per repo (`owner`, `repo` labels)
+- `ghp_raw_request_total` — `raw.githubusercontent.com` requests by classification result (`owner`, `repo`, `result` labels; `authenticated`, `query_token`, `anonymous`, `denied_policy`, `denied_method`, `denied_scope`)
 
 ## Coding Conventions
 

--- a/docs/admin/configuration.md
+++ b/docs/admin/configuration.md
@@ -146,6 +146,14 @@ See [Release Download Controls](../features/release-controls.md) for details.
 
 See [Codeload Redirect](../features/codeload.md) for details.
 
+### Raw Content
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `GHP_RAW_ALLOW_QUERY_TOKEN` | Forward `raw.githubusercontent.com` requests carrying a GitHub-issued `?token=` query parameter when no `ghx_`/`gha_` token is present; `false` rejects them with 403 | `true` |
+
+See [How It Works](../how-it-works.md#rawgithubusercontentcom) for details.
+
 ### Git Cache
 
 | Variable | Description | Default |
@@ -254,6 +262,19 @@ codeload:
   redirect_to: ""              # absolute URL base for redirecting codeload archive requests; passthrough when empty
   allow:                       # org or org/repo entries that pass through to upstream codeload
     - "myorg"
+
+raw:
+  # Whether to forward raw.githubusercontent.com requests carrying a
+  # GitHub-issued ?token= query parameter when no ghx_/gha_ token is present.
+  #
+  # The GitHub contents API returns download_url values containing such a
+  # token. It is opaque to GHP: it cannot be attributed to an agent,
+  # scope-checked, or revoked, and remains valid for days.
+  #
+  # true (default) forwards and logs these requests, trading attribution for
+  # compatibility and visibility. false rejects them with 403, at the cost of
+  # breaking clients that follow download_url without sending their own token.
+  allow_query_token: true
 
 cache:
   enabled: false               # enable git clone/fetch caching

--- a/docs/admin/deployment.md
+++ b/docs/admin/deployment.md
@@ -10,6 +10,7 @@ each virtualhost. This is the recommended production mode.
 You need certificates covering:
 
 - `api.github.com` and `github.com`
+- `raw.githubusercontent.com`
 - `*.githubcopilot.com`
 - Your management host (e.g. `ghp.example.com`)
 
@@ -34,9 +35,10 @@ agents run. This can be done via split-horizon DNS, `/etc/hosts`, or a local
 DNS resolver:
 
 ```
-api.github.com      → <ghp-server-ip>
-github.com          → <ghp-server-ip>
-*.githubcopilot.com → <ghp-server-ip>
+api.github.com             → <ghp-server-ip>
+github.com                 → <ghp-server-ip>
+raw.githubusercontent.com  → <ghp-server-ip>
+*.githubcopilot.com        → <ghp-server-ip>
 ```
 
 Agents then connect to ghp transparently — no client configuration beyond

--- a/docs/admin/local-tls.md
+++ b/docs/admin/local-tls.md
@@ -13,6 +13,7 @@ The certificate covers:
 | `localhost` | Direct access to the local proxy |
 | `api.github.com` | Proxied GitHub API traffic |
 | `github.com` | Proxied GitHub web traffic |
+| `raw.githubusercontent.com` | Proxied raw file content |
 
 ## Generate the certificate
 
@@ -29,7 +30,7 @@ openssl ecparam -genkey -name prime256v1 -out local.key
 # 3. Create a CSR with the required SANs
 openssl req -new -key local.key -out local.csr \
   -subj "/CN=localhost" \
-  -addext "subjectAltName=DNS:localhost,DNS:api.github.com,DNS:github.com"
+  -addext "subjectAltName=DNS:localhost,DNS:api.github.com,DNS:github.com,DNS:raw.githubusercontent.com"
 
 # 4. Sign the CSR with the CA (valid 1 year)
 openssl x509 -req -in local.csr \

--- a/docs/admin/monitoring.md
+++ b/docs/admin/monitoring.md
@@ -25,7 +25,8 @@ Scrape the metrics endpoint at `http(s)://<ghp-server>:9136/metrics` (HTTPS when
 | `ghp_http_request_total` | Counter | Total HTTP requests (labels: `backend`, `method`, `status`) |
 
 The `backend` label distinguishes traffic by virtualhost: `api.github.com`,
-`github.com`, `codeload.github.com`, `copilot`, or `management`.
+`github.com`, `codeload.github.com`, `raw.githubusercontent.com`, `copilot`,
+or `management`.
 
 #### Proxy Metrics
 
@@ -178,6 +179,42 @@ cardinality bounded; query the access log for per-ref breakdowns.
 
 See [Codeload Redirect](../features/codeload.md) for configuration details.
 
+#### Raw Content Metrics
+
+| Metric | Type | Description |
+|--------|------|-------------|
+| `ghp_raw_request_total` | Counter | raw.githubusercontent.com requests handled by the raw handler (labels: `owner`, `repo`, `result`) |
+
+The `result` label records how the request was classified:
+
+| `result` | Meaning |
+|---|---|
+| `authenticated` | ghp-issued token present; scope enforced; forwarded with the resolved GitHub credential |
+| `query_token` | GitHub-issued `?token=` present, no ghp token; forwarded unmodified and unattributed |
+| `foreign_credential` | An `Authorization` credential ghp did not issue (e.g. `ghp_`, `ghs_`) that the border policy permits; forwarded intact and unattributed |
+| `anonymous` | No credential at all; forwarded unmodified |
+| `denied_scope` | ghp token not scoped to the requested repository, or lacking `contents:read` |
+| `denied_token` | ghp token could not be resolved (revoked, expired, unknown), or its GitHub credential could not be resolved |
+| `denied_policy` | Query token rejected because `raw.allow_query_token` is `false` |
+| `denied_border` | Credential rejected by the [token type border policy](../features/border-policy.md) |
+| `denied_method` | Method other than GET or HEAD |
+| `error` | ghp-side fault (corrupt token scope JSON) |
+
+Requests whose path has fewer than three segments are forwarded without being
+counted — they are not repository content paths, so there is no meaningful
+`owner`/`repo` to label them with.
+
+!!! warning "Cardinality is client-controlled"
+    `owner` and `repo` are taken from the request path, and the `anonymous`,
+    `foreign_credential`, and `query_token` classifications require no
+    ghp-issued credential. Any client that can reach the raw virtualhost can
+    therefore create a new time series per invented `/owner/repo`. Budget
+    metric storage accordingly, or restrict network access to the raw
+    virtualhost.
+
+See [How It Works — raw.githubusercontent.com](../how-it-works.md#rawgithubusercontentcom)
+for the classification rules.
+
 ## Logging
 
 ghp treats **OpenTelemetry log records** as its first-class logging primitive.
@@ -218,6 +255,15 @@ body `handled request`. Attributes use HTTP semantic conventions:
 | `http.request.header.<name>` / `http.response.header.<name>` | Selected headers (sensitive values such as `authorization` and `set-cookie` are `REDACTED`) |
 | `ghp.backend` | Backend identifier (same values as the `backend` metric label) |
 | `ghp.cache.state` / `ghp.cache.repo` | Git cache outcome, when applicable |
+| `ghp.raw.auth` | How a raw.githubusercontent.com request authenticated, when applicable |
+
+`ghp.raw.auth` takes one of `proxy_token`, `query_token`, `foreign_credential`,
+`anonymous`, or a denial reason (`denied_method`, `denied_border`,
+`denied_policy`, `denied_scope`, `denied_token`, `error`). These match the
+`ghp_raw_request_total` `result` values with one exception: a request
+authenticated with a ghp-issued token logs `ghp.raw.auth=proxy_token` but is
+counted as `result="authenticated"` — the log records the kind of credential
+presented, the metric the outcome of the decision.
 
 Records for responses with a 5xx status are emitted at `Error` severity; all
 others at `Info`.

--- a/docs/features/border-policy.md
+++ b/docs/features/border-policy.md
@@ -11,6 +11,23 @@ When a request arrives with a token that is not a ghp-managed token (`ghx_` or
 is blocked in the configuration, the request is rejected with `403 Forbidden`
 before it reaches GitHub.
 
+### Where the policy is enforced
+
+The policy is applied per virtualhost. It is **not** a blanket filter across
+every host ghp serves:
+
+| Virtualhost | Border policy enforced? |
+|---|---|
+| `api.github.com` | Yes |
+| `github.com` | Yes |
+| `raw.githubusercontent.com` | Yes |
+| `codeload.github.com` | **No** — archive downloads are forwarded with their credential intact |
+| `*.githubcopilot.com` | **No** — Copilot clients manage their own credentials, which ghp forwards verbatim |
+
+An agent holding a blocked token type can therefore still use it against
+`codeload.github.com` and `*.githubcopilot.com`. Those requests are logged and
+counted, but not rejected.
+
 GitHub uses these token prefixes:
 
 | Prefix | Token Type | Config Key |
@@ -61,8 +78,11 @@ block:
   anonymous_git: true
 ```
 
-This ensures all agent traffic is subject to ghp's scoping, auditing, and
-expiration controls.
+This ensures agent traffic on the enforcing virtualhosts (`api.github.com`,
+`github.com`, and `raw.githubusercontent.com`) is subject to ghp's scoping,
+auditing, and expiration controls. Traffic to `codeload.github.com` and
+`*.githubcopilot.com` is logged and counted but not rejected — see
+[Where the policy is enforced](#where-the-policy-is-enforced).
 
 ## Hot Reloading
 

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -38,6 +38,7 @@ ghp serves several distinct roles depending on which hostname the request arrive
 | `api.github.com` | **API proxy** — validates tokens, enforces scopes, injects credentials, logs every request |
 | `github.com` | **Git passthrough** — transparent proxy for `git clone`, `git push`, etc. with token interception |
 | `codeload.github.com` | **Codeload redirect/passthrough** — optionally redirects repo archive downloads to a caching mirror (see [Codeload Redirect](features/codeload.md)); transparent passthrough otherwise |
+| `raw.githubusercontent.com` | **Raw content proxy** — enforces scopes on ghp-issued tokens, forwards and counts everything else (see [raw.githubusercontent.com](#rawgithubusercontentcom)) |
 | `*.githubcopilot.com` | **Copilot passthrough** — forwards Copilot traffic transparently; all requests are logged |
 | Your management host | **Dashboard** — web UI, GitHub OAuth login (web), CLI device-authorization endpoints, token management API |
 
@@ -137,19 +138,30 @@ Requests are classified in order:
 | Case | Behaviour | Metric result |
 |---|---|---|
 | GHP-issued token (`ghx_`/`gha_`) in `Authorization` | Resolved, checked against the token's repository allowlist and `contents:read` (unless the token is open-scoped or the corresponding list is empty, in which case that check is skipped), forwarded with the real GitHub credential. Any GitHub-issued `?token=` is stripped first. A failed check is rejected with 403 (`denied_scope`). | `authenticated` or `denied_scope` |
+| A credential ghp did not issue in `Authorization` (e.g. `ghp_`, `ghs_`) whose type is blocked by the [token type border policy](features/border-policy.md) | Rejected with 403 before it reaches raw. | `denied_border` |
 | GitHub-issued `?token=`, no GHP token | Forwarded unmodified when `raw.allow_query_token` is `true` (default); rejected with 403 when `false`. | `query_token` or `denied_policy` |
-| Neither a GHP token nor `?token=` | Forwarded unmodified, including any other credential already present. | `anonymous` |
+| A credential ghp did not issue in `Authorization`, not blocked by the border policy | Forwarded intact and unattributed. | `foreign_credential` |
+| No credential at all | Forwarded unmodified. | `anonymous` |
 
-A GitHub credential GHP did not issue — a personal access token or
+A GitHub credential ghp did not issue — a personal access token or
 installation token placed directly in `Authorization` rather than a
-`ghx_`/`gha_` token — also falls into the third row: ghp only recognises
-the `ghx_`/`gha_` prefixes, so it cannot resolve or scope-check anything
-else, and forwards it unmodified, counted `anonymous`. There is no config
-switch for this case; unlike the query-token path, it is not something
-`raw.allow_query_token` (or any other setting) can close.
+`ghx_`/`gha_` token — is subject to the token type border policy: if
+`block.ghp` (or the equivalent for its prefix) is set, the request is
+rejected with 403 before it reaches raw. Otherwise ghp forwards it intact:
+it only recognises the `ghx_`/`gha_` prefixes, so it cannot resolve or
+scope-check anything else. Such requests are counted `foreign_credential`,
+kept separate from `anonymous` so operators can see credentialled traffic
+ghp cannot attribute. `raw.allow_query_token` does not affect this path.
 
 Non-matching paths (fewer than three path segments) pass through uncounted.
-Non-GET/HEAD methods on a matching path are rejected with 403 (`denied_method`).
+Non-GET/HEAD methods on a matching path are rejected with 403
+(`denied_method`). A ghp-issued token that cannot be resolved — revoked,
+expired, or forged — is rejected with 401 and counted `denied_token`; a
+token whose stored scope JSON is corrupt yields 500 and is counted `error`.
+
+Every outcome is also recorded in the access log as `ghp.raw.auth`. See
+[Monitoring](admin/monitoring.md#raw-content-metrics) for the full result
+and attribute vocabulary.
 
 **Limitation 1 — the query-token path is unenforced.** A token scoped to
 repository A can still fetch repository B's private content through this

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -136,9 +136,17 @@ Requests are classified in order:
 
 | Case | Behaviour | Metric result |
 |---|---|---|
-| GHP-issued token (`ghx_`/`gha_`) in `Authorization` | Resolved, checked against the token's repository allowlist and `contents:read`, forwarded with the real GitHub credential. Any GitHub-issued `?token=` is stripped first. | `authenticated` |
+| GHP-issued token (`ghx_`/`gha_`) in `Authorization` | Resolved, checked against the token's repository allowlist and `contents:read` (unless the token is open-scoped or the corresponding list is empty, in which case that check is skipped), forwarded with the real GitHub credential. Any GitHub-issued `?token=` is stripped first. A failed check is rejected with 403 (`denied_scope`). | `authenticated` or `denied_scope` |
 | GitHub-issued `?token=`, no GHP token | Forwarded unmodified when `raw.allow_query_token` is `true` (default); rejected with 403 when `false`. | `query_token` or `denied_policy` |
-| Neither | Forwarded anonymously. | `anonymous` |
+| Neither a GHP token nor `?token=` | Forwarded unmodified, including any other credential already present. | `anonymous` |
+
+A GitHub credential GHP did not issue — a personal access token or
+installation token placed directly in `Authorization` rather than a
+`ghx_`/`gha_` token — also falls into the third row: ghp only recognises
+the `ghx_`/`gha_` prefixes, so it cannot resolve or scope-check anything
+else, and forwards it unmodified, counted `anonymous`. There is no config
+switch for this case; unlike the query-token path, it is not something
+`raw.allow_query_token` (or any other setting) can close.
 
 Non-matching paths (fewer than three path segments) pass through uncounted.
 Non-GET/HEAD methods on a matching path are rejected with 403 (`denied_method`).

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -119,6 +119,51 @@ manage their own credentials, so ghp does not intercept tokens or enforce
 scopes on this traffic. All Copilot requests are still logged and counted
 in metrics for full visibility.
 
+### raw.githubusercontent.com
+
+GitHub's `sec-GitHub-allowed-enterprise` header — the mechanism corporate
+network policy uses to restrict which host a GitHub credential may be sent
+to — is scoped by GitHub to `github.com`, `api.github.com`, and
+`*.githubcopilot.com` only. `raw.githubusercontent.com` is on GitHub's own
+list of "Endpoints that don't require restriction," so an `Authorization`
+header can reach it regardless of enterprise policy. Raw also returns no
+`X-RateLimit-*` headers. Left unproxied, this traffic is invisible to both
+enterprise network policy and ghp's telemetry — proxying it is how ghp
+becomes the enforcement and observability point that raw itself is exempt
+from.
+
+Requests are classified in order:
+
+| Case | Behaviour | Metric result |
+|---|---|---|
+| GHP-issued token (`ghx_`/`gha_`) in `Authorization` | Resolved, checked against the token's repository allowlist and `contents:read`, forwarded with the real GitHub credential. Any GitHub-issued `?token=` is stripped first. | `authenticated` |
+| GitHub-issued `?token=`, no GHP token | Forwarded unmodified when `raw.allow_query_token` is `true` (default); rejected with 403 when `false`. | `query_token` or `denied_policy` |
+| Neither | Forwarded anonymously. | `anonymous` |
+
+Non-matching paths (fewer than three path segments) pass through uncounted.
+Non-GET/HEAD methods on a matching path are rejected with 403 (`denied_method`).
+
+**Limitation 1 — the query-token path is unenforced.** A token scoped to
+repository A can still fetch repository B's private content through this
+handler if the agent holds a GitHub-issued `?token=` for it — such tokens
+come from the contents API's `download_url` field and are opaque to ghp:
+they cannot be attributed to an agent, scope-checked, or revoked, and stay
+valid for days. Setting `raw.allow_query_token: false` closes this path,
+at the cost of breaking clients that follow `download_url` without
+supplying their own token. For post-hoc attribution instead of blocking,
+operators can correlate a recent REST API request with a subsequent raw
+request from the same user-agent and source IP, using the
+`x-github-request-id` response header as a join key against GitHub's audit
+log.
+
+**Limitation 2 — no rate-limit visibility.** Raw returns no
+`X-RateLimit-*` headers, so this traffic never appears in
+`ghp_github_ratelimit_*`. Quota consumed via raw is invisible to ghp by
+construction.
+
+See [Configuration](admin/configuration.md#raw-content) for the
+`raw.allow_query_token` setting.
+
 ### Git Cache
 
 For frequently-cloned repositories, ghp can cache git objects locally and serve

--- a/docs/superpowers/plans/2026-07-26-raw-githubusercontent-proxy.md
+++ b/docs/superpowers/plans/2026-07-26-raw-githubusercontent-proxy.md
@@ -544,9 +544,9 @@ attributable traffic from traffic GHP only observed."
 
 ---
 
-### Task 5: Raw handler — routing, path parsing, and the unattributed paths
+### Task 5: Raw handler — routing, path parsing, classification, and scope enforcement
 
-Builds the handler covering the two paths that carry no GHP credential. The GHP-token path is added in Task 6, so this task's handler treats a GHP token as `anonymous` for now — Task 6 replaces that branch.
+Builds the complete handler: path parsing, all three classification paths, and `contents:read` enforcement on the GHP-token path.
 
 **Files:**
 - Modify: `internal/backend/backend.go` (add `Raw` const)
@@ -554,8 +554,10 @@ Builds the handler covering the two paths that carry no GHP credential. The GHP-
 - Test: `internal/proxy/raw_test.go`
 
 **Interfaces:**
-- Consumes: `config.RawAllowQueryToken()` (Task 2), `metrics.RawRequestTotal` (Task 3), `proxy.SetRawAuth` (Task 4).
+- Consumes: `config.RawAllowQueryToken()` (Task 2), `metrics.RawRequestTotal` (Task 3), `proxy.SetRawAuth` (Task 4). Existing in `internal/proxy`: `ScopeEnforcer.Resolve`, `TokenResolver.ResolveToGitHubToken`, `extractClientToken`, `parseScopeInfo`, `si.isOpenScoped()`, `si.repoAllowed(repo)`, `si.Scopes.HasPermission(permission, level)`, `writeError`, `SetUserID`, `SetUsername`.
 - Produces: `backend.Raw = "raw.githubusercontent.com"`. `func NewRawHandler(cfg *config.Config, enforcer ScopeEnforcer, resolver TokenResolver, ur *UsernameResolver, logger *slog.Logger, transport http.RoundTripper) http.Handler`. `func parseRawPath(p string) (owner, repo string, ok bool)` — lowercases owner and repo; returns `ok=false` when fewer than three non-empty segments.
+
+The permission enforced is `contents:read`, matching `GET /repos/{owner}/{repo}/contents/…` at `internal/proxy/scope.go:29`. Follow the flow in `NewScopedPassthroughHandler` (`passthrough.go:210-300`) — same ordering, same decision stages.
 
 - [ ] **Step 1: Write the failing path-parsing test**
 
@@ -856,8 +858,7 @@ func NewRawHandler(cfg *config.Config, enforcer ScopeEnforcer, resolver TokenRes
 
 		clientTok, _, _ := extractClientToken(r)
 		if clientTok != "" {
-			// Enforced path — implemented in Task 6.
-			serveRawAuthenticated(w, r, passthrough, cfg, enforcer, resolver, ur, logger, owner, repo, clientTok)
+			serveRawAuthenticated(w, r, passthrough, enforcer, resolver, ur, logger, owner, repo, clientTok)
 			return
 		}
 
@@ -881,82 +882,125 @@ func NewRawHandler(cfg *config.Config, enforcer ScopeEnforcer, resolver TokenRes
 }
 ```
 
-For this task only, add a temporary stub so the package compiles — Task 6 replaces its body:
+- [ ] **Step 9: Implement the enforced path**
+
+Append to `internal/proxy/raw.go`:
 
 ```go
-// serveRawAuthenticated handles the GHP-token path. Implemented in Task 6.
-func serveRawAuthenticated(w http.ResponseWriter, r *http.Request, passthrough http.Handler, cfg *config.Config, enforcer ScopeEnforcer, resolver TokenResolver, ur *UsernameResolver, logger *slog.Logger, owner, repo, clientTok string) {
-	metrics.RawRequestTotal.WithLabelValues(owner, repo, "anonymous").Inc()
-	SetRawAuth(r, "anonymous")
+// serveRawAuthenticated handles requests bearing a GHP-issued token. The
+// token's repository allowlist and contents:read permission are enforced
+// before the request is forwarded with the resolved GitHub credential.
+//
+// Any GitHub-issued ?token= is stripped before forwarding: carrying both a
+// GHP-resolved credential and an independent GitHub capability would let the
+// latter satisfy a request the former was denied.
+func serveRawAuthenticated(w http.ResponseWriter, r *http.Request, passthrough http.Handler, enforcer ScopeEnforcer, resolver TokenResolver, ur *UsernameResolver, logger *slog.Logger, owner, repo, clientTok string) {
+	decisionStart := time.Now()
+	repoFull := owner + "/" + repo
+
+	resolveTokenType := ""
+	if tt, ok := token.TokenTypeFromPrefix(clientTok); ok {
+		resolveTokenType = string(tt)
+	}
+
+	resolveStart := time.Now()
+	pt, err := enforcer.Resolve(r.Context(), clientTok)
+	metrics.ObserveDecision(metrics.StageTokenResolution, resolveTokenType, time.Since(resolveStart))
+	if err != nil || pt == nil {
+		if err != nil && logger != nil {
+			logger.Warn("raw scope enforcement: token resolution failed", "error", err)
+		}
+		metrics.ObserveDecision(metrics.StageTotal, resolveTokenType, time.Since(decisionStart))
+		writeError(w, http.StatusUnauthorized, "Invalid token")
+		return
+	}
+
+	tokenType := pt.TokenType
+	if pt.UserID != nil {
+		SetUserID(r, *pt.UserID)
+	}
+
+	scopeParseStart := time.Now()
+	si, err := parseScopeInfo(pt)
+	metrics.ObserveDecision(metrics.StageScopeParsing, tokenType, time.Since(scopeParseStart))
+	if err != nil {
+		if logger != nil {
+			logger.Error("raw scope enforcement: failed to parse token scope", "error", err)
+		}
+		metrics.ObserveDecision(metrics.StageTotal, tokenType, time.Since(decisionStart))
+		writeError(w, http.StatusInternalServerError, "Internal error")
+		return
+	}
+
+	if !si.isOpenScoped() {
+		scopeEnforceStart := time.Now()
+		if len(si.Repos) > 0 && !si.repoAllowed(repoFull) {
+			metrics.ObserveDecision(metrics.StageScopeEnforcement, tokenType, time.Since(scopeEnforceStart))
+			metrics.ObserveDecision(metrics.StageTotal, tokenType, time.Since(decisionStart))
+			metrics.RawRequestTotal.WithLabelValues(owner, repo, "denied_scope").Inc()
+			writeError(w, http.StatusForbidden, fmt.Sprintf("Token is not scoped to %s", repoFull))
+			return
+		}
+		if len(si.Scopes) > 0 && !si.Scopes.HasPermission("contents", "read") {
+			metrics.ObserveDecision(metrics.StageScopeEnforcement, tokenType, time.Since(scopeEnforceStart))
+			metrics.ObserveDecision(metrics.StageTotal, tokenType, time.Since(decisionStart))
+			metrics.RawRequestTotal.WithLabelValues(owner, repo, "denied_scope").Inc()
+			writeError(w, http.StatusForbidden,
+				fmt.Sprintf("Token does not have permission for contents:read on %s", repoFull))
+			return
+		}
+		metrics.ObserveDecision(metrics.StageScopeEnforcement, tokenType, time.Since(scopeEnforceStart))
+	}
+
+	ghTokenStart := time.Now()
+	realToken, err := resolver.ResolveToGitHubToken(r.Context(), clientTok)
+	metrics.ObserveDecision(metrics.StageGitHubTokenResolution, tokenType, time.Since(ghTokenStart))
+	if err != nil {
+		if logger != nil {
+			logger.Warn("raw scope enforcement: GitHub token resolution failed", "error", err)
+		}
+		metrics.ObserveDecision(metrics.StageTotal, tokenType, time.Since(decisionStart))
+		writeError(w, http.StatusUnauthorized, "Token resolution failed")
+		return
+	}
+
+	usernameStart := time.Now()
+	if ur != nil {
+		if u := ur.ResolveFromGitHubToken(r.Context(), realToken); u != "" {
+			SetUsername(r, u)
+		}
+	}
+	metrics.ObserveDecision(metrics.StageUsernameResolution, tokenType, time.Since(usernameStart))
+
+	// Strip the GitHub-issued capability before forwarding our own credential.
+	if q := r.URL.Query(); q.Get("token") != "" {
+		q.Del("token")
+		r.URL.RawQuery = q.Encode()
+	}
+
+	_, _, rewriteAuth := extractClientToken(r)
+	if rewriteAuth != nil {
+		r.Header.Set("Authorization", rewriteAuth(realToken))
+	}
+
+	metrics.RawRequestTotal.WithLabelValues(owner, repo, "authenticated").Inc()
+	SetRawAuth(r, "proxy_token")
+	metrics.ObserveDecision(metrics.StageTotal, tokenType, time.Since(decisionStart))
+
+	upstreamStart := time.Now()
 	passthrough.ServeHTTP(w, r)
+	metrics.ObserveDecision(metrics.StageUpstreamRoundtrip, tokenType, time.Since(upstreamStart))
 }
 ```
 
-- [ ] **Step 9: Run test to verify it passes**
+Add `"fmt"`, `"time"`, and `"github.com/goodtune/ghp/internal/token"` to the imports in `raw.go`.
 
-Run: `go test ./internal/proxy/ -run TestRawHandler -v`
+- [ ] **Step 10: Run the unattributed-path tests**
+
+Run: `go test ./internal/proxy/ -run TestRawHandler_UnattributedPaths -v`
 Expected: PASS (all six subtests)
 
-- [ ] **Step 10: Add the metrics assertions test**
-
-Add to `internal/proxy/raw_test.go`:
-
-```go
-func TestRawHandler_CountsResults(t *testing.T) {
-	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
-	}))
-	defer upstream.Close()
-
-	cfg := &config.Config{}
-	cfg.Raw.AllowQueryToken = false
-	h := NewRawHandler(cfg, nil, nil, nil, nil, rewriteTransport(t, upstream.URL))
-
-	before := rawCounterValue(t, "metricsowner", "metricsrepo", "denied_policy")
-	req := httptest.NewRequest(http.MethodGet, "/MetricsOwner/MetricsRepo/main/f.txt?token=X", nil)
-	h.ServeHTTP(httptest.NewRecorder(), req)
-	after := rawCounterValue(t, "metricsowner", "metricsrepo", "denied_policy")
-
-	if after != before+1 {
-		t.Errorf("denied_policy counter = %v, want %v", after, before+1)
-	}
-}
-```
-
-Add `rawCounterValue` mirroring `codeloadCounterValue` (`codeload_test.go:22`) — copy that helper's implementation and change the label arity to `(owner, repo, result)`.
-
-- [ ] **Step 11: Run the full proxy suite**
-
-Run: `make check`
-Expected: PASS
-
-- [ ] **Step 12: Commit**
-
-```bash
-git add internal/backend/backend.go internal/proxy/raw.go internal/proxy/raw_test.go
-git commit -m "feat(proxy): add raw.githubusercontent.com handler
-
-Parses owner/repo from the first two path segments, which keeps both
-the classic /{owner}/{repo}/{ref}/{path} and the newer refs/heads form
-unambiguous. Handles the query-token and anonymous paths; the enforced
-GHP-token path follows."
-```
-
----
-
-### Task 6: Raw handler — the enforced GHP-token path
-
-**Files:**
-- Modify: `internal/proxy/raw.go` (replace the `serveRawAuthenticated` stub)
-- Test: `internal/proxy/raw_test.go`
-
-**Interfaces:**
-- Consumes: `serveRawAuthenticated` signature from Task 5; `ScopeEnforcer.Resolve`, `TokenResolver.ResolveToGitHubToken`, `parseScopeInfo`, `si.isOpenScoped()`, `si.repoAllowed(repo)`, `si.Scopes.HasPermission(permission, level)` (all existing in `internal/proxy`).
-- Produces: nothing new; completes the handler.
-
-The permission enforced is `contents:read`, matching `GET /repos/{owner}/{repo}/contents/…` at `internal/proxy/scope.go:29`. Follow the flow in `NewScopedPassthroughHandler` (`passthrough.go:210-300`) — same ordering, same decision stages.
-
-- [ ] **Step 1: Write the failing test**
+- [ ] **Step 11: Write the failing scope enforcement test**
 
 Add to `internal/proxy/raw_test.go`. Use whatever `ScopeEnforcer` / `TokenResolver` fakes already exist in the package's test files (`passthrough_test.go` has them); if their names differ, use theirs rather than defining duplicates.
 
@@ -1068,149 +1112,64 @@ func TestRawHandler_StripsQueryTokenOnAuthenticatedPath(t *testing.T) {
 
 Stripping matters: forwarding both a GHP-resolved credential and a GitHub-issued capability means the enforcement decision could be bypassed by the query token if the two disagree.
 
-- [ ] **Step 2: Run test to verify it fails**
+- [ ] **Step 12: Run test to verify it fails**
 
 Run: `go test ./internal/proxy/ -run TestRawHandler_Scope -v`
-Expected: FAIL — assertions fail (the stub forwards unconditionally without enforcement)
+Expected: FAIL if enforcement is missing or misordered
 
-- [ ] **Step 3: Implement the enforced path**
+- [ ] **Step 13: Add the metrics assertions test**
 
-Replace the `serveRawAuthenticated` stub in `internal/proxy/raw.go`:
+Add to `internal/proxy/raw_test.go`:
 
 ```go
-// serveRawAuthenticated handles requests bearing a GHP-issued token. The
-// token's repository allowlist and contents:read permission are enforced
-// before the request is forwarded with the resolved GitHub credential.
-//
-// Any GitHub-issued ?token= is stripped before forwarding: carrying both a
-// GHP-resolved credential and an independent GitHub capability would let the
-// latter satisfy a request the former was denied.
-func serveRawAuthenticated(w http.ResponseWriter, r *http.Request, passthrough http.Handler, cfg *config.Config, enforcer ScopeEnforcer, resolver TokenResolver, ur *UsernameResolver, logger *slog.Logger, owner, repo, clientTok string) {
-	decisionStart := time.Now()
-	repoFull := owner + "/" + repo
+func TestRawHandler_CountsResults(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
 
-	resolveTokenType := ""
-	if tt, ok := token.TokenTypeFromPrefix(clientTok); ok {
-		resolveTokenType = string(tt)
+	cfg := &config.Config{}
+	cfg.Raw.AllowQueryToken = false
+	h := NewRawHandler(cfg, nil, nil, nil, nil, rewriteTransport(t, upstream.URL))
+
+	before := rawCounterValue(t, "metricsowner", "metricsrepo", "denied_policy")
+	req := httptest.NewRequest(http.MethodGet, "/MetricsOwner/MetricsRepo/main/f.txt?token=X", nil)
+	h.ServeHTTP(httptest.NewRecorder(), req)
+	after := rawCounterValue(t, "metricsowner", "metricsrepo", "denied_policy")
+
+	if after != before+1 {
+		t.Errorf("denied_policy counter = %v, want %v", after, before+1)
 	}
-
-	resolveStart := time.Now()
-	pt, err := enforcer.Resolve(r.Context(), clientTok)
-	metrics.ObserveDecision(metrics.StageTokenResolution, resolveTokenType, time.Since(resolveStart))
-	if err != nil || pt == nil {
-		if err != nil && logger != nil {
-			logger.Warn("raw scope enforcement: token resolution failed", "error", err)
-		}
-		metrics.ObserveDecision(metrics.StageTotal, resolveTokenType, time.Since(decisionStart))
-		writeError(w, http.StatusUnauthorized, "Invalid token")
-		return
-	}
-
-	tokenType := pt.TokenType
-	if pt.UserID != nil {
-		SetUserID(r, *pt.UserID)
-	}
-
-	scopeParseStart := time.Now()
-	si, err := parseScopeInfo(pt)
-	metrics.ObserveDecision(metrics.StageScopeParsing, tokenType, time.Since(scopeParseStart))
-	if err != nil {
-		if logger != nil {
-			logger.Error("raw scope enforcement: failed to parse token scope", "error", err)
-		}
-		metrics.ObserveDecision(metrics.StageTotal, tokenType, time.Since(decisionStart))
-		writeError(w, http.StatusInternalServerError, "Internal error")
-		return
-	}
-
-	if !si.isOpenScoped() {
-		scopeEnforceStart := time.Now()
-		if len(si.Repos) > 0 && !si.repoAllowed(repoFull) {
-			metrics.ObserveDecision(metrics.StageScopeEnforcement, tokenType, time.Since(scopeEnforceStart))
-			metrics.ObserveDecision(metrics.StageTotal, tokenType, time.Since(decisionStart))
-			metrics.RawRequestTotal.WithLabelValues(owner, repo, "denied_scope").Inc()
-			writeError(w, http.StatusForbidden, fmt.Sprintf("Token is not scoped to %s", repoFull))
-			return
-		}
-		if len(si.Scopes) > 0 && !si.Scopes.HasPermission("contents", "read") {
-			metrics.ObserveDecision(metrics.StageScopeEnforcement, tokenType, time.Since(scopeEnforceStart))
-			metrics.ObserveDecision(metrics.StageTotal, tokenType, time.Since(decisionStart))
-			metrics.RawRequestTotal.WithLabelValues(owner, repo, "denied_scope").Inc()
-			writeError(w, http.StatusForbidden,
-				fmt.Sprintf("Token does not have permission for contents:read on %s", repoFull))
-			return
-		}
-		metrics.ObserveDecision(metrics.StageScopeEnforcement, tokenType, time.Since(scopeEnforceStart))
-	}
-
-	ghTokenStart := time.Now()
-	realToken, err := resolver.ResolveToGitHubToken(r.Context(), clientTok)
-	metrics.ObserveDecision(metrics.StageGitHubTokenResolution, tokenType, time.Since(ghTokenStart))
-	if err != nil {
-		if logger != nil {
-			logger.Warn("raw scope enforcement: GitHub token resolution failed", "error", err)
-		}
-		metrics.ObserveDecision(metrics.StageTotal, tokenType, time.Since(decisionStart))
-		writeError(w, http.StatusUnauthorized, "Token resolution failed")
-		return
-	}
-
-	usernameStart := time.Now()
-	if ur != nil {
-		if u := ur.ResolveFromGitHubToken(r.Context(), realToken); u != "" {
-			SetUsername(r, u)
-		}
-	}
-	metrics.ObserveDecision(metrics.StageUsernameResolution, tokenType, time.Since(usernameStart))
-
-	// Strip the GitHub-issued capability before forwarding our own credential.
-	if q := r.URL.Query(); q.Get("token") != "" {
-		q.Del("token")
-		r.URL.RawQuery = q.Encode()
-	}
-
-	_, _, rewriteAuth := extractClientToken(r)
-	if rewriteAuth != nil {
-		r.Header.Set("Authorization", rewriteAuth(realToken))
-	}
-
-	metrics.RawRequestTotal.WithLabelValues(owner, repo, "authenticated").Inc()
-	SetRawAuth(r, "proxy_token")
-	metrics.ObserveDecision(metrics.StageTotal, tokenType, time.Since(decisionStart))
-
-	upstreamStart := time.Now()
-	passthrough.ServeHTTP(w, r)
-	metrics.ObserveDecision(metrics.StageUpstreamRoundtrip, tokenType, time.Since(upstreamStart))
 }
 ```
 
-Add `"fmt"`, `"time"`, and `"github.com/goodtune/ghp/internal/token"` to the imports in `raw.go`.
+Add `rawCounterValue` mirroring `codeloadCounterValue` (`codeload_test.go:22`) — copy that helper's implementation and change the label arity to `(owner, repo, result)`.
 
-- [ ] **Step 4: Run test to verify it passes**
-
-Run: `go test ./internal/proxy/ -run TestRawHandler -v`
-Expected: PASS
-
-- [ ] **Step 5: Run the full suite**
+- [ ] **Step 14: Run the full suite**
 
 Run: `make check`
 Expected: PASS
 
-- [ ] **Step 6: Commit**
+- [ ] **Step 15: Commit**
 
 ```bash
-git add internal/proxy/raw.go internal/proxy/raw_test.go
-git commit -m "feat(proxy): enforce contents:read on authenticated raw requests
+git add internal/backend/backend.go internal/proxy/raw.go internal/proxy/raw_test.go
+git commit -m "feat(proxy): add raw.githubusercontent.com handler
 
-Resolves the GHP token, checks the repository allowlist and
-contents:read permission, and forwards with the real credential. Any
-GitHub-issued ?token= is stripped so it cannot satisfy a request the
-scope check denied."
+Parses owner/repo from the first two path segments, which keeps both
+the classic /{owner}/{repo}/{ref}/{path} and the newer refs/heads form
+unambiguous.
+
+Requests bearing a GHP token are scope-enforced against the repository
+allowlist and contents:read, then forwarded with the resolved
+credential; any GitHub-issued ?token= is stripped so it cannot satisfy
+a request the scope check denied. Query-token and anonymous requests
+are forwarded unmodified and counted, but not attributed."
 ```
 
 ---
 
-### Task 7: Wire into host dispatch, document, and record the principle
+### Task 6: Wire into host dispatch, document, and record the principle
 
 **Files:**
 - Modify: `internal/server/server.go` (`hostDispatchConfig`, `newHostDispatch`, handler construction)
@@ -1220,7 +1179,7 @@ scope check denied."
 - Test: `internal/server/server_test.go`
 
 **Interfaces:**
-- Consumes: `backend.Raw`, `proxy.NewRawHandler` (Tasks 5-6).
+- Consumes: `backend.Raw`, `proxy.NewRawHandler` (Task 5).
 - Produces: nothing new.
 
 - [ ] **Step 1: Write the failing dispatch test**

--- a/docs/superpowers/plans/2026-07-26-raw-githubusercontent-proxy.md
+++ b/docs/superpowers/plans/2026-07-26-raw-githubusercontent-proxy.md
@@ -1,0 +1,1406 @@
+# raw.githubusercontent.com Proxy Handler Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a `raw.githubusercontent.com` backend handler that enforces `contents:read` scope for GHP-issued tokens and passes through query-token and anonymous requests for observability.
+
+**Architecture:** A new host-dispatch case routes `raw.githubusercontent.com` to `internal/proxy/raw.go`. The handler parses `owner`/`repo` from the first two path segments, then classifies each request into one of three paths — GHP-token (resolve, enforce, swap credential), GitHub query-token (policy-gated passthrough), or anonymous (passthrough). All three are logged and counted; only the first is enforced.
+
+**Tech Stack:** Go 1.24, `httputil.ReverseProxy`, koanf config, Prometheus `promauto`, OpenTelemetry structured access logs.
+
+## Global Constraints
+
+- Spec: `docs/superpowers/specs/2026-07-26-raw-githubusercontent-proxy-design.md`. Read it before starting.
+- Guiding principle: **GHP is an enforcement point for tokens it issued and a telemetry point for everything else.**
+- Go formatting via `gofmt`. Table-driven tests using `t.Run()`. Explicit `if err != nil`.
+- Prometheus label values for `owner`/`repo` MUST be lowercased (GitHub is case-insensitive; mixed casing splits time series).
+- Every new metric requires a test in `internal/metrics/metrics_test.go`.
+- Run `make check` (tests + `go vet`) before each commit.
+- Branch: `feat/raw-githubusercontent-proxy` (already created, spec already committed).
+
+---
+
+### Task 1: Redact sensitive query parameters in access logs
+
+Currently `accesslog.go:126` emits `r.URL.RawQuery` verbatim. Once raw passthrough lands, this would write live GitHub blob capabilities (valid ~7 days) into the access log. This is a general fix benefiting every backend, so it ships first and independently.
+
+**Files:**
+- Modify: `internal/server/accesslog.go` (add `redactQueryParam` + `redactedQuery`; change line 126)
+- Test: `internal/server/accesslog_test.go`
+
+**Interfaces:**
+- Consumes: nothing from earlier tasks.
+- Produces: `func redactedQuery(rawQuery string) string` — returns the query string with sensitive parameter values replaced by `REDACTED`, preserving parameter order and non-sensitive values. `func redactQueryParam(name string) bool`.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `internal/server/accesslog_test.go`:
+
+```go
+func TestRedactedQuery(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"empty", "", ""},
+		{"no sensitive params", "ref=main&path=README.md", "ref=main&path=README.md"},
+		{"github blob token", "token=AACGATXPAI3FK7WLHZDREQLKMR6GLAA", "token=REDACTED"},
+		{"access_token", "access_token=abc123", "access_token=REDACTED"},
+		{"client_secret", "client_secret=shhh", "client_secret=REDACTED"},
+		{"mixed", "ref=main&token=abc&page=2", "ref=main&token=REDACTED&page=2"},
+		{"case insensitive name", "TOKEN=abc", "TOKEN=REDACTED"},
+		{"repeated param", "token=a&token=b", "token=REDACTED&token=REDACTED"},
+		{"valueless param", "token", "token=REDACTED"},
+		{"unparseable is redacted wholesale", "%zz&token=abc", "REDACTED"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := redactedQuery(tt.in); got != tt.want {
+				t.Errorf("redactedQuery(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+```
+
+Note the `unparseable` case: if `url.ParseQuery` errors we must NOT fall back to emitting the raw string, because a malformed query could still contain a token. Fail closed.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/server/ -run TestRedactedQuery -v`
+Expected: FAIL — `undefined: redactedQuery`
+
+- [ ] **Step 3: Write the implementation**
+
+In `internal/server/accesslog.go`, add below `redactResponseHeader`:
+
+```go
+// redactQueryParam reports whether a URL query parameter's value must be
+// redacted from access logs. GitHub's contents API returns download_url
+// values carrying a ?token= blob capability that remains valid for days —
+// logging it verbatim would persist a usable credential in the log stream.
+func redactQueryParam(name string) bool {
+	switch strings.ToLower(name) {
+	case "token", "access_token", "client_secret":
+		return true
+	default:
+		return false
+	}
+}
+
+// redactedQuery returns rawQuery with the values of sensitive parameters
+// replaced by the same placeholder used for headers. Parameter order is
+// preserved so the logged value stays comparable to the request.
+//
+// If rawQuery cannot be parsed, the entire query is redacted rather than
+// emitted verbatim: a malformed query may still carry a credential, and
+// failing closed is cheaper than leaking one.
+func redactedQuery(rawQuery string) string {
+	if rawQuery == "" {
+		return ""
+	}
+	if _, err := url.ParseQuery(rawQuery); err != nil {
+		return "REDACTED"
+	}
+	parts := strings.Split(rawQuery, "&")
+	for i, part := range parts {
+		name, _, _ := strings.Cut(part, "=")
+		decoded, err := url.QueryUnescape(name)
+		if err != nil {
+			decoded = name
+		}
+		if redactQueryParam(decoded) {
+			parts[i] = name + "=REDACTED"
+		}
+	}
+	return strings.Join(parts, "&")
+}
+```
+
+Add `"net/url"` to the imports if not already present.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./internal/server/ -run TestRedactedQuery -v`
+Expected: PASS
+
+- [ ] **Step 5: Wire it into the access log emission**
+
+In `internal/server/accesslog.go`, replace lines 125-127:
+
+```go
+		if q := r.URL.RawQuery; q != "" {
+			attrs = append(attrs, otellog.String(attrURLQuery, q))
+		}
+```
+
+with:
+
+```go
+		if q := r.URL.RawQuery; q != "" {
+			attrs = append(attrs, otellog.String(attrURLQuery, redactedQuery(q)))
+		}
+```
+
+- [ ] **Step 6: Write the integration test**
+
+Add to `internal/server/accesslog_test.go`:
+
+```go
+func TestAccessLogHandler_RedactsQueryToken(t *testing.T) {
+	rec, aw := newTestAccessLogRecorder(t)
+	h := accessLogHandler(backend.Codeload, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}), aw)
+
+	req := httptest.NewRequest(http.MethodGet, "/o/r/main/README.md?token=SECRETVALUE123", nil)
+	h.ServeHTTP(httptest.NewRecorder(), req)
+
+	got := rec.str(t, attrURLQuery)
+	if strings.Contains(got, "SECRETVALUE123") {
+		t.Errorf("%s = %q, must not contain the token value", attrURLQuery, got)
+	}
+	if got != "token=REDACTED" {
+		t.Errorf("%s = %q, want %q", attrURLQuery, got, "token=REDACTED")
+	}
+}
+```
+
+Reuse whatever recorder helper the existing tests in this file use (see `TestAccessLogHandler_*` around `accesslog_test.go:81` for the established pattern and the `rec.str(t, attr)` accessor); if the helper is named differently, match the existing name rather than introducing `newTestAccessLogRecorder`.
+
+- [ ] **Step 7: Run the full server test suite**
+
+Run: `go test ./internal/server/ -v -run TestAccessLog`
+Expected: PASS, including pre-existing access log tests.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add internal/server/accesslog.go internal/server/accesslog_test.go
+git commit -m "fix(accesslog): redact sensitive query parameters
+
+Query strings were logged verbatim while headers were redacted. GitHub
+contents download_url values carry a ?token= blob capability valid for
+days; logging it persisted a usable credential in the log stream.
+
+Fails closed on unparseable queries."
+```
+
+---
+
+### Task 2: Add the `raw.allow_query_token` config field
+
+**Files:**
+- Modify: `internal/config/config.go` (add `RawConfig`, field on `Config`, `ReloadFrom` entry, accessor)
+- Test: `internal/config/config_test.go`
+
+**Interfaces:**
+- Consumes: nothing from earlier tasks.
+- Produces: `type RawConfig struct { AllowQueryToken bool \`koanf:"allow_query_token"\` }`, field `Raw RawConfig \`koanf:"raw"\`` on `Config`, and method `func (c *Config) RawAllowQueryToken() bool` (read-lock protected, safe against concurrent `ReloadFrom`).
+
+**Important:** the default is `true`. A bare `bool` zero-values to `false`, so it must be set explicitly in `Defaults()` (`config.go:291`), which `Load` uses as the base struct before koanf unmarshals the YAML and env overrides on top. `Metrics.Enabled: true` is the existing precedent for a bool defaulting to true. `ReloadFrom` calls `Load`, so a reload also picks the default back up when the field is absent — do not rely on the zero value anywhere.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `internal/config/config_test.go`:
+
+```go
+func TestRawAllowQueryToken(t *testing.T) {
+	t.Run("defaults to true", func(t *testing.T) {
+		cfg, err := Load("")
+		if err != nil {
+			t.Fatalf("Load: %v", err)
+		}
+		if !cfg.RawAllowQueryToken() {
+			t.Error("RawAllowQueryToken() = false, want true by default")
+		}
+	})
+
+	t.Run("honours explicit false", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "cfg.yaml")
+		if err := os.WriteFile(path, []byte("raw:\n  allow_query_token: false\n"), 0o600); err != nil {
+			t.Fatalf("WriteFile: %v", err)
+		}
+		cfg, err := Load(path)
+		if err != nil {
+			t.Fatalf("Load: %v", err)
+		}
+		if cfg.RawAllowQueryToken() {
+			t.Error("RawAllowQueryToken() = true, want false")
+		}
+	})
+
+	t.Run("hot reload picks up change", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "cfg.yaml")
+		if err := os.WriteFile(path, []byte("raw:\n  allow_query_token: true\n"), 0o600); err != nil {
+			t.Fatalf("WriteFile: %v", err)
+		}
+		cfg, err := Load(path)
+		if err != nil {
+			t.Fatalf("Load: %v", err)
+		}
+		if !cfg.RawAllowQueryToken() {
+			t.Fatal("precondition: want true before reload")
+		}
+		if err := os.WriteFile(path, []byte("raw:\n  allow_query_token: false\n"), 0o600); err != nil {
+			t.Fatalf("WriteFile: %v", err)
+		}
+		if err := cfg.ReloadFrom(path); err != nil {
+			t.Fatalf("ReloadFrom: %v", err)
+		}
+		if cfg.RawAllowQueryToken() {
+			t.Error("RawAllowQueryToken() = true after reload, want false")
+		}
+	})
+}
+```
+
+Match the existing `Load` signature in this package — if it takes different arguments (e.g. a flag set or an options struct), adapt these calls to the established pattern used by the neighbouring config tests rather than changing `Load`.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/config/ -run TestRawAllowQueryToken -v`
+Expected: FAIL — `cfg.RawAllowQueryToken undefined`
+
+- [ ] **Step 3: Add the config struct and field**
+
+In `internal/config/config.go`, add after `CodeloadConfig`:
+
+```go
+// RawConfig controls how raw.githubusercontent.com requests are handled.
+//
+// raw.githubusercontent.com accepts GitHub credentials via the Authorization
+// header, and is explicitly exempt from the sec-GitHub-allowed-enterprise
+// corporate proxy restriction (GitHub scopes that header to github.com,
+// api.github.com and *.githubcopilot.com only). It also returns no
+// X-RateLimit-* headers, so the traffic is invisible to both enterprise
+// network policy and GHP's rate limit telemetry unless proxied.
+type RawConfig struct {
+	// AllowQueryToken controls whether requests carrying a GitHub-issued
+	// ?token= query parameter (as returned in the contents API download_url)
+	// are forwarded when no GHP token is present.
+	//
+	// Such tokens are opaque to GHP: they cannot be attributed to an agent,
+	// scope-checked, or revoked, and remain valid for days. When true
+	// (the default) they are forwarded and logged, trading attribution for
+	// compatibility and visibility. When false they are rejected with 403.
+	AllowQueryToken bool `koanf:"allow_query_token"`
+}
+```
+
+Add to the `Config` struct next to `Codeload`:
+
+```go
+	Raw RawConfig `koanf:"raw"`
+```
+
+- [ ] **Step 4: Set the default and wire hot reload**
+
+In `Defaults()` (`config.go:291`), add to the returned struct literal:
+
+```go
+		Raw: RawConfig{
+			AllowQueryToken: true,
+		},
+```
+
+In `ReloadFrom` (`config.go:466` area), add to the in-place mutation set, after `c.Codeload = fresh.Codeload`:
+
+```go
+	c.Raw = fresh.Raw
+```
+
+Also add `RawAllowQueryToken` to the accessor list in the `ReloadFrom` doc comment (`config.go:444`), which enumerates the accessors whose reads are serialised against reload.
+
+- [ ] **Step 5: Add the accessor**
+
+Add near `CodeloadRedirectTo` (`config.go:568`):
+
+```go
+// RawAllowQueryToken reports whether raw.githubusercontent.com requests
+// carrying a GitHub-issued ?token= query parameter are forwarded when no GHP
+// token is present. It takes the read lock so callers on the request hot path
+// can read it without racing against ReloadFrom.
+func (c *Config) RawAllowQueryToken() bool {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.Raw.AllowQueryToken
+}
+```
+
+- [ ] **Step 6: Run test to verify it passes**
+
+Run: `go test ./internal/config/ -run TestRawAllowQueryToken -v`
+Expected: PASS (all three subtests)
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add internal/config/config.go internal/config/config_test.go
+git commit -m "feat(config): add raw.allow_query_token
+
+Gates whether raw.githubusercontent.com requests carrying a
+GitHub-issued ?token= are forwarded when no GHP token is present.
+Defaults to true. Hot-reloadable via SIGUSR1."
+```
+
+---
+
+### Task 3: Add the `ghp_raw_request_total` metric
+
+**Files:**
+- Modify: `internal/metrics/metrics.go`
+- Test: `internal/metrics/metrics_test.go`
+
+**Interfaces:**
+- Consumes: nothing from earlier tasks.
+- Produces: `metrics.RawRequestTotal` — a `*prometheus.CounterVec` with labels `owner`, `repo`, `result`. Valid `result` values: `authenticated`, `query_token`, `anonymous`, `denied_scope`, `denied_policy`, `denied_method`.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `internal/metrics/metrics_test.go`, following the existing counter test pattern in that file:
+
+```go
+func TestRawRequestTotal(t *testing.T) {
+	results := []string{
+		"authenticated", "query_token", "anonymous",
+		"denied_scope", "denied_policy", "denied_method",
+	}
+	for _, result := range results {
+		t.Run(result, func(t *testing.T) {
+			owner, repo := "testowner", "testrepo-"+result
+			before := testutil.ToFloat64(RawRequestTotal.WithLabelValues(owner, repo, result))
+			RawRequestTotal.WithLabelValues(owner, repo, result).Inc()
+			after := testutil.ToFloat64(RawRequestTotal.WithLabelValues(owner, repo, result))
+			if after != before+1 {
+				t.Errorf("RawRequestTotal[%s] = %v, want %v", result, after, before+1)
+			}
+		})
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/metrics/ -run TestRawRequestTotal -v`
+Expected: FAIL — `undefined: RawRequestTotal`
+
+- [ ] **Step 3: Add the counter**
+
+In `internal/metrics/metrics.go`, add after `CodeloadRedirectTotal`:
+
+```go
+	// RawRequestTotal counts raw.githubusercontent.com requests handled,
+	// labeled by owner, repo, and result:
+	//   "authenticated" — GHP token present; scope enforced; forwarded with
+	//                     the resolved GitHub credential
+	//   "query_token"   — GitHub-issued ?token= present, no GHP token;
+	//                     forwarded unmodified and unattributed
+	//   "anonymous"     — no credential; forwarded unmodified
+	//   "denied_scope"  — GHP token not scoped to the requested repository,
+	//                     or lacking contents:read
+	//   "denied_policy" — query token rejected by raw.allow_query_token=false
+	//   "denied_method" — method other than GET or HEAD
+	//
+	// The ref and file path are not included as labels to keep cardinality
+	// bounded; they are captured in access logs as part of the URL.
+	// Cardinality: bounded by (repos seen × results).
+	RawRequestTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "ghp_raw_request_total",
+		Help: "Total raw.githubusercontent.com requests handled, by owner, repo, and result.",
+	}, []string{"owner", "repo", "result"})
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./internal/metrics/ -run TestRawRequestTotal -v`
+Expected: PASS (all six subtests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/metrics/metrics.go internal/metrics/metrics_test.go
+git commit -m "feat(metrics): add ghp_raw_request_total
+
+Counts raw.githubusercontent.com requests by owner, repo, and
+classification result."
+```
+
+---
+
+### Task 4: Add the raw auth attribution access-log slot
+
+**Files:**
+- Modify: `internal/proxy/context.go` (new context key, slot, setter)
+- Modify: `internal/server/semconv.go` (new attribute const)
+- Modify: `internal/server/accesslog.go` (emit the attribute)
+- Test: `internal/proxy/context_test.go`, `internal/server/accesslog_test.go`
+
+**Interfaces:**
+- Consumes: nothing from earlier tasks.
+- Produces: `proxy.SetRawAuth(r *http.Request, v string)` — stores the classification in the request's context slot, no-op when no slot was prepared. `AccessLogSlots.RawAuth *string`. Attribute name `ghp.raw.auth`.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `internal/proxy/context_test.go`:
+
+```go
+func TestRawAuthSlot(t *testing.T) {
+	t.Run("round trips through the slot", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/o/r/main/f.txt", nil)
+		req, slots := PrepareAccessLogSlots(req)
+		SetRawAuth(req, "query_token")
+		if *slots.RawAuth != "query_token" {
+			t.Errorf("RawAuth = %q, want %q", *slots.RawAuth, "query_token")
+		}
+	})
+
+	t.Run("no-op without a prepared slot", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/o/r/main/f.txt", nil)
+		SetRawAuth(req, "anonymous") // must not panic
+	})
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/proxy/ -run TestRawAuthSlot -v`
+Expected: FAIL — `undefined: SetRawAuth`
+
+- [ ] **Step 3: Add the slot**
+
+In `internal/proxy/context.go`:
+
+Add the key alongside the others:
+
+```go
+var rawAuthCtxKey = &contextKey{"raw-auth"}
+```
+
+Add the field to `AccessLogSlots`:
+
+```go
+	RawAuth *string // "proxy_token", "query_token", "anonymous", or "" for non-raw backends
+```
+
+In `PrepareAccessLogSlots`, allocate and thread it through exactly as `cacheRepoSlot` is:
+
+```go
+	rawAuthSlot := new(string)
+	// ... ctx = context.WithValue(ctx, rawAuthCtxKey, rawAuthSlot)
+	// ... RawAuth: rawAuthSlot,
+```
+
+Add the setter next to `SetUsername`:
+
+```go
+// SetRawAuth records how a raw.githubusercontent.com request authenticated,
+// so the access-log middleware can partition attributable traffic from
+// traffic GHP only observed. It is a no-op if no slot was prepared.
+func SetRawAuth(r *http.Request, v string) {
+	if slot, ok := r.Context().Value(rawAuthCtxKey).(*string); ok && slot != nil {
+		*slot = v
+	}
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./internal/proxy/ -run TestRawAuthSlot -v`
+Expected: PASS
+
+- [ ] **Step 5: Emit the attribute**
+
+In `internal/server/semconv.go`, add next to `attrGHPCacheRepo`:
+
+```go
+	attrGHPRawAuth = "ghp.raw.auth"
+```
+
+In `internal/server/accesslog.go`, after the `slots.CacheRepo` block (line ~138):
+
+```go
+		if *slots.RawAuth != "" {
+			attrs = append(attrs, otellog.String(attrGHPRawAuth, *slots.RawAuth))
+		}
+```
+
+- [ ] **Step 6: Verify the whole package still builds and passes**
+
+Run: `make check`
+Expected: PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add internal/proxy/context.go internal/proxy/context_test.go internal/server/semconv.go internal/server/accesslog.go
+git commit -m "feat(accesslog): add ghp.raw.auth attribution slot
+
+Records whether a raw request authenticated via a GHP token, a
+GitHub-issued query token, or not at all, so log queries can separate
+attributable traffic from traffic GHP only observed."
+```
+
+---
+
+### Task 5: Raw handler — routing, path parsing, and the unattributed paths
+
+Builds the handler covering the two paths that carry no GHP credential. The GHP-token path is added in Task 6, so this task's handler treats a GHP token as `anonymous` for now — Task 6 replaces that branch.
+
+**Files:**
+- Modify: `internal/backend/backend.go` (add `Raw` const)
+- Create: `internal/proxy/raw.go`
+- Test: `internal/proxy/raw_test.go`
+
+**Interfaces:**
+- Consumes: `config.RawAllowQueryToken()` (Task 2), `metrics.RawRequestTotal` (Task 3), `proxy.SetRawAuth` (Task 4).
+- Produces: `backend.Raw = "raw.githubusercontent.com"`. `func NewRawHandler(cfg *config.Config, enforcer ScopeEnforcer, resolver TokenResolver, ur *UsernameResolver, logger *slog.Logger, transport http.RoundTripper) http.Handler`. `func parseRawPath(p string) (owner, repo string, ok bool)` — lowercases owner and repo; returns `ok=false` when fewer than three non-empty segments.
+
+- [ ] **Step 1: Write the failing path-parsing test**
+
+Create `internal/proxy/raw_test.go`:
+
+```go
+package proxy
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/goodtune/ghp/internal/config"
+)
+
+func TestParseRawPath(t *testing.T) {
+	tests := []struct {
+		name              string
+		path              string
+		wantOwner         string
+		wantRepo          string
+		wantOK            bool
+	}{
+		{"classic ref form", "/goodtune/ghp/main/README.md", "goodtune", "ghp", true},
+		{"explicit refs form", "/goodtune/ghp/refs/heads/main/README.md", "goodtune", "ghp", true},
+		{"ref containing slashes", "/goodtune/ghp/feature/x/y/file.txt", "goodtune", "ghp", true},
+		{"nested file path", "/goodtune/ghp/main/a/b/c/d.yaml", "goodtune", "ghp", true},
+		{"casing normalised", "/GoodTune/GHP/main/README.md", "goodtune", "ghp", true},
+		{"leading double slash", "//goodtune/ghp/main/README.md", "goodtune", "ghp", true},
+		{"owner and repo only", "/goodtune/ghp", "", "", false},
+		{"owner only", "/goodtune", "", "", false},
+		{"root", "/", "", "", false},
+		{"empty", "", "", "", false},
+		{"trailing slash no file", "/goodtune/ghp/", "", "", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			owner, repo, ok := parseRawPath(tt.path)
+			if ok != tt.wantOK || owner != tt.wantOwner || repo != tt.wantRepo {
+				t.Errorf("parseRawPath(%q) = (%q, %q, %v), want (%q, %q, %v)",
+					tt.path, owner, repo, ok, tt.wantOwner, tt.wantRepo, tt.wantOK)
+			}
+		})
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/proxy/ -run TestParseRawPath -v`
+Expected: FAIL — `undefined: parseRawPath`
+
+- [ ] **Step 3: Add the backend const**
+
+In `internal/backend/backend.go`, add after `Codeload`:
+
+```go
+	// Raw handles requests to raw.githubusercontent.com — direct file content
+	// downloads at /{owner}/{repo}/{ref}/{path}. Requests bearing a GHP-issued
+	// token are scope-enforced and forwarded with the resolved credential.
+	// Requests bearing a GitHub-issued ?token= query parameter, and anonymous
+	// requests, are forwarded unmodified — GHP observes and logs them but
+	// cannot attribute or enforce them. This host is exempt from the
+	// sec-GitHub-allowed-enterprise corporate proxy restriction, which is why
+	// proxying it is worthwhile in the first place.
+	Raw = "raw.githubusercontent.com"
+```
+
+- [ ] **Step 4: Create the handler with path parsing**
+
+Create `internal/proxy/raw.go`:
+
+```go
+package proxy
+
+import (
+	"log/slog"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"regexp"
+	"strings"
+
+	"github.com/goodtune/ghp/internal/config"
+	"github.com/goodtune/ghp/internal/metrics"
+)
+
+// rawPathRe matches raw.githubusercontent.com content paths and captures the
+// owner and repository. The remainder is deliberately left unparsed: refs may
+// contain slashes, and both /{owner}/{repo}/{ref}/{path} and the newer
+// /{owner}/{repo}/refs/heads/{branch}/{path} form must yield the same
+// owner/repo. Only the first two segments participate in enforcement.
+var rawPathRe = regexp.MustCompile(`^/+([^/]+)/([^/]+)/(.+)$`)
+
+// upstreamRaw is the canonical upstream URL used as the passthrough target.
+var upstreamRaw = mustParseRawURL("https://raw.githubusercontent.com")
+
+func mustParseRawURL(s string) *url.URL {
+	u, err := url.Parse(s)
+	if err != nil {
+		panic(err)
+	}
+	return u
+}
+
+// parseRawPath extracts the owner and repository from a raw content path.
+// Owner and repo are lowercased: GitHub treats them case-insensitively, so
+// leaving the client's casing intact would split Prometheus time series.
+func parseRawPath(p string) (owner, repo string, ok bool) {
+	m := rawPathRe.FindStringSubmatch(p)
+	if m == nil {
+		return "", "", false
+	}
+	return strings.ToLower(m[1]), strings.ToLower(m[2]), true
+}
+
+// newRawPassthrough builds a transparent reverse proxy to upstream
+// raw.githubusercontent.com, preserving the client's Host header so tests and
+// access logs see the value that was sent.
+func newRawPassthrough(transport http.RoundTripper) http.Handler {
+	rp := &httputil.ReverseProxy{
+		Director: func(req *http.Request) {
+			originalHost := req.Host
+			req.URL.Scheme = upstreamRaw.Scheme
+			req.URL.Host = upstreamRaw.Host
+			req.Host = originalHost
+		},
+	}
+	if transport != nil {
+		rp.Transport = transport
+	}
+	return rp
+}
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `go test ./internal/proxy/ -run TestParseRawPath -v`
+Expected: PASS
+
+- [ ] **Step 6: Write the failing classification test**
+
+Add to `internal/proxy/raw_test.go`:
+
+```go
+func TestRawHandler_UnattributedPaths(t *testing.T) {
+	tests := []struct {
+		name            string
+		method          string
+		target          string
+		allowQueryToken bool
+		wantStatus      int
+		wantForwarded   bool
+		wantQueryOnUpstream string
+	}{
+		{
+			name: "anonymous request is forwarded",
+			method: http.MethodGet, target: "/goodtune/ghp/main/README.md",
+			allowQueryToken: true, wantStatus: http.StatusOK, wantForwarded: true,
+		},
+		{
+			name: "query token forwarded unmodified when allowed",
+			method: http.MethodGet, target: "/goodtune/ghp/main/README.md?token=ABC123",
+			allowQueryToken: true, wantStatus: http.StatusOK, wantForwarded: true,
+			wantQueryOnUpstream: "token=ABC123",
+		},
+		{
+			name: "query token rejected when policy disallows",
+			method: http.MethodGet, target: "/goodtune/ghp/main/README.md?token=ABC123",
+			allowQueryToken: false, wantStatus: http.StatusForbidden, wantForwarded: false,
+		},
+		{
+			name: "HEAD is allowed",
+			method: http.MethodHead, target: "/goodtune/ghp/main/README.md",
+			allowQueryToken: true, wantStatus: http.StatusOK, wantForwarded: true,
+		},
+		{
+			name: "POST is rejected",
+			method: http.MethodPost, target: "/goodtune/ghp/main/README.md",
+			allowQueryToken: true, wantStatus: http.StatusForbidden, wantForwarded: false,
+		},
+		{
+			name: "non-matching path is forwarded uncounted",
+			method: http.MethodGet, target: "/goodtune/ghp",
+			allowQueryToken: true, wantStatus: http.StatusOK, wantForwarded: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var forwarded bool
+			var upstreamQuery string
+			upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				forwarded = true
+				upstreamQuery = r.URL.RawQuery
+				w.WriteHeader(http.StatusOK)
+			}))
+			defer upstream.Close()
+
+			cfg := &config.Config{}
+			cfg.Raw.AllowQueryToken = tt.allowQueryToken
+
+			h := NewRawHandler(cfg, nil, nil, nil, nil, rewriteTransport(t, upstream.URL))
+
+			req := httptest.NewRequest(tt.method, tt.target, nil)
+			rec := httptest.NewRecorder()
+			h.ServeHTTP(rec, req)
+
+			if rec.Code != tt.wantStatus {
+				t.Errorf("status = %d, want %d", rec.Code, tt.wantStatus)
+			}
+			if forwarded != tt.wantForwarded {
+				t.Errorf("forwarded = %v, want %v", forwarded, tt.wantForwarded)
+			}
+			if tt.wantQueryOnUpstream != "" && upstreamQuery != tt.wantQueryOnUpstream {
+				t.Errorf("upstream query = %q, want %q", upstreamQuery, tt.wantQueryOnUpstream)
+			}
+		})
+	}
+}
+```
+
+`rewriteTransport` is a helper that redirects the reverse proxy to the test server. Check `codeload_test.go` first — it already passes a `transport` for exactly this purpose. Reuse that helper if one exists; otherwise add:
+
+```go
+// rewriteTransport returns a RoundTripper that redirects every request to the
+// given test server, so the reverse proxy under test never makes a real
+// network call.
+func rewriteTransport(t *testing.T, target string) http.RoundTripper {
+	t.Helper()
+	u, err := url.Parse(target)
+	if err != nil {
+		t.Fatalf("parse target: %v", err)
+	}
+	return &rewriteRoundTripper{host: u.Host, scheme: u.Scheme}
+}
+
+type rewriteRoundTripper struct{ host, scheme string }
+
+func (rt *rewriteRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	req = req.Clone(req.Context())
+	req.URL.Scheme = rt.scheme
+	req.URL.Host = rt.host
+	return http.DefaultTransport.RoundTrip(req)
+}
+```
+
+- [ ] **Step 7: Run test to verify it fails**
+
+Run: `go test ./internal/proxy/ -run TestRawHandler_UnattributedPaths -v`
+Expected: FAIL — `undefined: NewRawHandler`
+
+- [ ] **Step 8: Implement the handler**
+
+Append to `internal/proxy/raw.go`:
+
+```go
+// NewRawHandler returns an http.Handler for raw.githubusercontent.com requests.
+//
+// Requests are classified into three paths, evaluated in order:
+//
+//   - A GHP-issued token (ghx_/gha_) in the Authorization header: the token is
+//     resolved, contents:read is enforced against the repository allowlist, any
+//     GitHub-issued ?token= is stripped, and the request is forwarded with the
+//     real credential. This is the only enforced path.
+//   - A GitHub-issued ?token= with no GHP token: forwarded unmodified when
+//     raw.allow_query_token is true (the default), rejected with 403 otherwise.
+//     GHP cannot attribute, scope-check, or revoke such tokens.
+//   - Neither: forwarded anonymously. Anonymous requests cannot reach private
+//     content — GitHub returns 404 without a credential — so blocking them buys
+//     no confidentiality and breaks ordinary public-content tooling.
+//
+// This asymmetry is deliberate: GHP is an enforcement point for tokens it
+// issued and a telemetry point for everything else.
+//
+// cfg is read on every request so SIGUSR1 hot-reload of raw.allow_query_token
+// takes effect without a server restart. transport is optional; when nil the
+// default RoundTripper is used.
+func NewRawHandler(cfg *config.Config, enforcer ScopeEnforcer, resolver TokenResolver, ur *UsernameResolver, logger *slog.Logger, transport http.RoundTripper) http.Handler {
+	passthrough := newRawPassthrough(transport)
+
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		owner, repo, ok := parseRawPath(r.URL.Path)
+		if !ok {
+			// Not a content path. Forward and leave it to upstream; not
+			// counted, so label cardinality stays bounded by real requests.
+			passthrough.ServeHTTP(w, r)
+			return
+		}
+
+		if r.Method != http.MethodGet && r.Method != http.MethodHead {
+			metrics.RawRequestTotal.WithLabelValues(owner, repo, "denied_method").Inc()
+			writeError(w, http.StatusForbidden, "Only GET and HEAD are permitted for raw content")
+			return
+		}
+
+		clientTok, _, _ := extractClientToken(r)
+		if clientTok != "" {
+			// Enforced path — implemented in Task 6.
+			serveRawAuthenticated(w, r, passthrough, cfg, enforcer, resolver, ur, logger, owner, repo, clientTok)
+			return
+		}
+
+		if r.URL.Query().Get("token") != "" {
+			if !cfg.RawAllowQueryToken() {
+				metrics.RawRequestTotal.WithLabelValues(owner, repo, "denied_policy").Inc()
+				writeError(w, http.StatusForbidden,
+					"GitHub-issued query tokens are not permitted (raw.allow_query_token is disabled)")
+				return
+			}
+			metrics.RawRequestTotal.WithLabelValues(owner, repo, "query_token").Inc()
+			SetRawAuth(r, "query_token")
+			passthrough.ServeHTTP(w, r)
+			return
+		}
+
+		metrics.RawRequestTotal.WithLabelValues(owner, repo, "anonymous").Inc()
+		SetRawAuth(r, "anonymous")
+		passthrough.ServeHTTP(w, r)
+	})
+}
+```
+
+For this task only, add a temporary stub so the package compiles — Task 6 replaces its body:
+
+```go
+// serveRawAuthenticated handles the GHP-token path. Implemented in Task 6.
+func serveRawAuthenticated(w http.ResponseWriter, r *http.Request, passthrough http.Handler, cfg *config.Config, enforcer ScopeEnforcer, resolver TokenResolver, ur *UsernameResolver, logger *slog.Logger, owner, repo, clientTok string) {
+	metrics.RawRequestTotal.WithLabelValues(owner, repo, "anonymous").Inc()
+	SetRawAuth(r, "anonymous")
+	passthrough.ServeHTTP(w, r)
+}
+```
+
+- [ ] **Step 9: Run test to verify it passes**
+
+Run: `go test ./internal/proxy/ -run TestRawHandler -v`
+Expected: PASS (all six subtests)
+
+- [ ] **Step 10: Add the metrics assertions test**
+
+Add to `internal/proxy/raw_test.go`:
+
+```go
+func TestRawHandler_CountsResults(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	cfg := &config.Config{}
+	cfg.Raw.AllowQueryToken = false
+	h := NewRawHandler(cfg, nil, nil, nil, nil, rewriteTransport(t, upstream.URL))
+
+	before := rawCounterValue(t, "metricsowner", "metricsrepo", "denied_policy")
+	req := httptest.NewRequest(http.MethodGet, "/MetricsOwner/MetricsRepo/main/f.txt?token=X", nil)
+	h.ServeHTTP(httptest.NewRecorder(), req)
+	after := rawCounterValue(t, "metricsowner", "metricsrepo", "denied_policy")
+
+	if after != before+1 {
+		t.Errorf("denied_policy counter = %v, want %v", after, before+1)
+	}
+}
+```
+
+Add `rawCounterValue` mirroring `codeloadCounterValue` (`codeload_test.go:22`) — copy that helper's implementation and change the label arity to `(owner, repo, result)`.
+
+- [ ] **Step 11: Run the full proxy suite**
+
+Run: `make check`
+Expected: PASS
+
+- [ ] **Step 12: Commit**
+
+```bash
+git add internal/backend/backend.go internal/proxy/raw.go internal/proxy/raw_test.go
+git commit -m "feat(proxy): add raw.githubusercontent.com handler
+
+Parses owner/repo from the first two path segments, which keeps both
+the classic /{owner}/{repo}/{ref}/{path} and the newer refs/heads form
+unambiguous. Handles the query-token and anonymous paths; the enforced
+GHP-token path follows."
+```
+
+---
+
+### Task 6: Raw handler — the enforced GHP-token path
+
+**Files:**
+- Modify: `internal/proxy/raw.go` (replace the `serveRawAuthenticated` stub)
+- Test: `internal/proxy/raw_test.go`
+
+**Interfaces:**
+- Consumes: `serveRawAuthenticated` signature from Task 5; `ScopeEnforcer.Resolve`, `TokenResolver.ResolveToGitHubToken`, `parseScopeInfo`, `si.isOpenScoped()`, `si.repoAllowed(repo)`, `si.Scopes.HasPermission(permission, level)` (all existing in `internal/proxy`).
+- Produces: nothing new; completes the handler.
+
+The permission enforced is `contents:read`, matching `GET /repos/{owner}/{repo}/contents/…` at `internal/proxy/scope.go:29`. Follow the flow in `NewScopedPassthroughHandler` (`passthrough.go:210-300`) — same ordering, same decision stages.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `internal/proxy/raw_test.go`. Use whatever `ScopeEnforcer` / `TokenResolver` fakes already exist in the package's test files (`passthrough_test.go` has them); if their names differ, use theirs rather than defining duplicates.
+
+```go
+func TestRawHandler_ScopeEnforcement(t *testing.T) {
+	tests := []struct {
+		name          string
+		tokenRepos    []string
+		tokenScopes   map[string]string // permission -> level; nil means unrestricted
+		target        string
+		wantStatus    int
+		wantForwarded bool
+		wantAuthHeader string
+	}{
+		{
+			name: "repo in allowlist is forwarded with real credential",
+			tokenRepos: []string{"goodtune/ghp"},
+			tokenScopes: map[string]string{"contents": "read"},
+			target: "/goodtune/ghp/main/README.md",
+			wantStatus: http.StatusOK, wantForwarded: true,
+			wantAuthHeader: "token real-github-token",
+		},
+		{
+			name: "repo outside allowlist is denied",
+			tokenRepos: []string{"goodtune/other"},
+			tokenScopes: map[string]string{"contents": "read"},
+			target: "/goodtune/ghp/main/README.md",
+			wantStatus: http.StatusForbidden, wantForwarded: false,
+		},
+		{
+			name: "missing contents permission is denied",
+			tokenRepos: []string{"goodtune/ghp"},
+			tokenScopes: map[string]string{"issues": "read"},
+			target: "/goodtune/ghp/main/README.md",
+			wantStatus: http.StatusForbidden, wantForwarded: false,
+		},
+		{
+			name: "open scoped token is forwarded",
+			tokenRepos: nil, tokenScopes: nil,
+			target: "/goodtune/ghp/main/README.md",
+			wantStatus: http.StatusOK, wantForwarded: true,
+			wantAuthHeader: "token real-github-token",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var forwarded bool
+			var gotAuth string
+			upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				forwarded = true
+				gotAuth = r.Header.Get("Authorization")
+				w.WriteHeader(http.StatusOK)
+			}))
+			defer upstream.Close()
+
+			cfg := &config.Config{}
+			cfg.Raw.AllowQueryToken = true
+
+			enforcer := newFakeScopeEnforcer(t, tt.tokenRepos, tt.tokenScopes)
+			resolver := newFakeTokenResolver("real-github-token")
+
+			h := NewRawHandler(cfg, enforcer, resolver, nil, nil, rewriteTransport(t, upstream.URL))
+
+			req := httptest.NewRequest(http.MethodGet, tt.target, nil)
+			req.Header.Set("Authorization", "token ghx_testtoken")
+			rec := httptest.NewRecorder()
+			h.ServeHTTP(rec, req)
+
+			if rec.Code != tt.wantStatus {
+				t.Errorf("status = %d, want %d", rec.Code, tt.wantStatus)
+			}
+			if forwarded != tt.wantForwarded {
+				t.Errorf("forwarded = %v, want %v", forwarded, tt.wantForwarded)
+			}
+			if tt.wantAuthHeader != "" && gotAuth != tt.wantAuthHeader {
+				t.Errorf("upstream Authorization = %q, want %q", gotAuth, tt.wantAuthHeader)
+			}
+		})
+	}
+}
+
+func TestRawHandler_StripsQueryTokenOnAuthenticatedPath(t *testing.T) {
+	var upstreamQuery string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		upstreamQuery = r.URL.RawQuery
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	cfg := &config.Config{}
+	cfg.Raw.AllowQueryToken = true
+	enforcer := newFakeScopeEnforcer(t, nil, nil)
+	resolver := newFakeTokenResolver("real-github-token")
+	h := NewRawHandler(cfg, enforcer, resolver, nil, nil, rewriteTransport(t, upstream.URL))
+
+	req := httptest.NewRequest(http.MethodGet, "/goodtune/ghp/main/README.md?token=GITHUBISSUED&ref=x", nil)
+	req.Header.Set("Authorization", "token ghx_testtoken")
+	h.ServeHTTP(httptest.NewRecorder(), req)
+
+	if strings.Contains(upstreamQuery, "GITHUBISSUED") {
+		t.Errorf("upstream query = %q, GitHub-issued token must be stripped", upstreamQuery)
+	}
+	if !strings.Contains(upstreamQuery, "ref=x") {
+		t.Errorf("upstream query = %q, unrelated params must be preserved", upstreamQuery)
+	}
+}
+```
+
+Stripping matters: forwarding both a GHP-resolved credential and a GitHub-issued capability means the enforcement decision could be bypassed by the query token if the two disagree.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/proxy/ -run TestRawHandler_Scope -v`
+Expected: FAIL — assertions fail (the stub forwards unconditionally without enforcement)
+
+- [ ] **Step 3: Implement the enforced path**
+
+Replace the `serveRawAuthenticated` stub in `internal/proxy/raw.go`:
+
+```go
+// serveRawAuthenticated handles requests bearing a GHP-issued token. The
+// token's repository allowlist and contents:read permission are enforced
+// before the request is forwarded with the resolved GitHub credential.
+//
+// Any GitHub-issued ?token= is stripped before forwarding: carrying both a
+// GHP-resolved credential and an independent GitHub capability would let the
+// latter satisfy a request the former was denied.
+func serveRawAuthenticated(w http.ResponseWriter, r *http.Request, passthrough http.Handler, cfg *config.Config, enforcer ScopeEnforcer, resolver TokenResolver, ur *UsernameResolver, logger *slog.Logger, owner, repo, clientTok string) {
+	decisionStart := time.Now()
+	repoFull := owner + "/" + repo
+
+	resolveTokenType := ""
+	if tt, ok := token.TokenTypeFromPrefix(clientTok); ok {
+		resolveTokenType = string(tt)
+	}
+
+	resolveStart := time.Now()
+	pt, err := enforcer.Resolve(r.Context(), clientTok)
+	metrics.ObserveDecision(metrics.StageTokenResolution, resolveTokenType, time.Since(resolveStart))
+	if err != nil || pt == nil {
+		if err != nil && logger != nil {
+			logger.Warn("raw scope enforcement: token resolution failed", "error", err)
+		}
+		metrics.ObserveDecision(metrics.StageTotal, resolveTokenType, time.Since(decisionStart))
+		writeError(w, http.StatusUnauthorized, "Invalid token")
+		return
+	}
+
+	tokenType := pt.TokenType
+	if pt.UserID != nil {
+		SetUserID(r, *pt.UserID)
+	}
+
+	scopeParseStart := time.Now()
+	si, err := parseScopeInfo(pt)
+	metrics.ObserveDecision(metrics.StageScopeParsing, tokenType, time.Since(scopeParseStart))
+	if err != nil {
+		if logger != nil {
+			logger.Error("raw scope enforcement: failed to parse token scope", "error", err)
+		}
+		metrics.ObserveDecision(metrics.StageTotal, tokenType, time.Since(decisionStart))
+		writeError(w, http.StatusInternalServerError, "Internal error")
+		return
+	}
+
+	if !si.isOpenScoped() {
+		scopeEnforceStart := time.Now()
+		if len(si.Repos) > 0 && !si.repoAllowed(repoFull) {
+			metrics.ObserveDecision(metrics.StageScopeEnforcement, tokenType, time.Since(scopeEnforceStart))
+			metrics.ObserveDecision(metrics.StageTotal, tokenType, time.Since(decisionStart))
+			metrics.RawRequestTotal.WithLabelValues(owner, repo, "denied_scope").Inc()
+			writeError(w, http.StatusForbidden, fmt.Sprintf("Token is not scoped to %s", repoFull))
+			return
+		}
+		if len(si.Scopes) > 0 && !si.Scopes.HasPermission("contents", "read") {
+			metrics.ObserveDecision(metrics.StageScopeEnforcement, tokenType, time.Since(scopeEnforceStart))
+			metrics.ObserveDecision(metrics.StageTotal, tokenType, time.Since(decisionStart))
+			metrics.RawRequestTotal.WithLabelValues(owner, repo, "denied_scope").Inc()
+			writeError(w, http.StatusForbidden,
+				fmt.Sprintf("Token does not have permission for contents:read on %s", repoFull))
+			return
+		}
+		metrics.ObserveDecision(metrics.StageScopeEnforcement, tokenType, time.Since(scopeEnforceStart))
+	}
+
+	ghTokenStart := time.Now()
+	realToken, err := resolver.ResolveToGitHubToken(r.Context(), clientTok)
+	metrics.ObserveDecision(metrics.StageGitHubTokenResolution, tokenType, time.Since(ghTokenStart))
+	if err != nil {
+		if logger != nil {
+			logger.Warn("raw scope enforcement: GitHub token resolution failed", "error", err)
+		}
+		metrics.ObserveDecision(metrics.StageTotal, tokenType, time.Since(decisionStart))
+		writeError(w, http.StatusUnauthorized, "Token resolution failed")
+		return
+	}
+
+	usernameStart := time.Now()
+	if ur != nil {
+		if u := ur.ResolveFromGitHubToken(r.Context(), realToken); u != "" {
+			SetUsername(r, u)
+		}
+	}
+	metrics.ObserveDecision(metrics.StageUsernameResolution, tokenType, time.Since(usernameStart))
+
+	// Strip the GitHub-issued capability before forwarding our own credential.
+	if q := r.URL.Query(); q.Get("token") != "" {
+		q.Del("token")
+		r.URL.RawQuery = q.Encode()
+	}
+
+	_, _, rewriteAuth := extractClientToken(r)
+	if rewriteAuth != nil {
+		r.Header.Set("Authorization", rewriteAuth(realToken))
+	}
+
+	metrics.RawRequestTotal.WithLabelValues(owner, repo, "authenticated").Inc()
+	SetRawAuth(r, "proxy_token")
+	metrics.ObserveDecision(metrics.StageTotal, tokenType, time.Since(decisionStart))
+
+	upstreamStart := time.Now()
+	passthrough.ServeHTTP(w, r)
+	metrics.ObserveDecision(metrics.StageUpstreamRoundtrip, tokenType, time.Since(upstreamStart))
+}
+```
+
+Add `"fmt"`, `"time"`, and `"github.com/goodtune/ghp/internal/token"` to the imports in `raw.go`.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./internal/proxy/ -run TestRawHandler -v`
+Expected: PASS
+
+- [ ] **Step 5: Run the full suite**
+
+Run: `make check`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/proxy/raw.go internal/proxy/raw_test.go
+git commit -m "feat(proxy): enforce contents:read on authenticated raw requests
+
+Resolves the GHP token, checks the repository allowlist and
+contents:read permission, and forwards with the real credential. Any
+GitHub-issued ?token= is stripped so it cannot satisfy a request the
+scope check denied."
+```
+
+---
+
+### Task 7: Wire into host dispatch, document, and record the principle
+
+**Files:**
+- Modify: `internal/server/server.go` (`hostDispatchConfig`, `newHostDispatch`, handler construction)
+- Modify: `docs/admin/configuration.md`
+- Modify: `docs/how-it-works.md`
+- Modify: `CLAUDE.md`
+- Test: `internal/server/server_test.go`
+
+**Interfaces:**
+- Consumes: `backend.Raw`, `proxy.NewRawHandler` (Tasks 5-6).
+- Produces: nothing new.
+
+- [ ] **Step 1: Write the failing dispatch test**
+
+Add to `internal/server/server_test.go`, matching the existing host-dispatch test pattern in that file:
+
+```go
+func TestHostDispatch_Raw(t *testing.T) {
+	var hit string
+	mark := func(name string) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { hit = name })
+	}
+	d := newHostDispatch(hostDispatchConfig{
+		apiHandler:      mark("api"),
+		githubHandler:   mark("github"),
+		codeloadHandler: mark("codeload"),
+		copilotHandler:  mark("copilot"),
+		rawHandler:      mark("raw"),
+		mgmtHandler:     mark("mgmt"),
+		managementHost:  "ghp.example.com",
+	})
+
+	for _, host := range []string{"raw.githubusercontent.com", "RAW.GithubUserContent.com", "raw.githubusercontent.com:443"} {
+		t.Run(host, func(t *testing.T) {
+			hit = ""
+			req := httptest.NewRequest(http.MethodGet, "/o/r/main/f.txt", nil)
+			req.Host = host
+			d.ServeHTTP(httptest.NewRecorder(), req)
+			if hit != "raw" {
+				t.Errorf("host %q routed to %q, want %q", host, hit, "raw")
+			}
+		})
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/server/ -run TestHostDispatch_Raw -v`
+Expected: FAIL — `unknown field rawHandler`
+
+- [ ] **Step 3: Add the dispatch field and case**
+
+In `internal/server/server.go`, add to `hostDispatchConfig` (line ~741):
+
+```go
+	rawHandler      http.Handler
+```
+
+Add to the switch in `newHostDispatch`, after the `backend.Codeload` case:
+
+```go
+		case host == backend.Raw:
+			cfg.rawHandler.ServeHTTP(w, r)
+```
+
+- [ ] **Step 4: Construct and wire the handler**
+
+In `internal/server/server.go`, after the `codeloadHandler` construction (line ~457):
+
+```go
+	rawHandler := proxy.NewRawHandler(s.cfg, tokenSvc, proxyTokenResolver, usernameResolver, s.logger, nil)
+```
+
+Add to the `newHostDispatch` call:
+
+```go
+		rawHandler:      accessLogHandler(backend.Raw, rawHandler, aw),
+```
+
+Note `tokenSvc` satisfies `ScopeEnforcer` and `proxyTokenResolver` satisfies `TokenResolver` — the same values passed to `NewScopedPassthroughHandler` at `server.go:453`.
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `go test ./internal/server/ -run TestHostDispatch -v`
+Expected: PASS (including pre-existing dispatch tests)
+
+- [ ] **Step 6: Run the full suite**
+
+Run: `make check`
+Expected: PASS
+
+- [ ] **Step 7: Document the config field**
+
+In `docs/admin/configuration.md`, add `GHP_RAW_ALLOW_QUERY_TOKEN` to the environment variable table (default `true`) and add to the full YAML reference:
+
+```yaml
+raw:
+  # Whether to forward raw.githubusercontent.com requests carrying a
+  # GitHub-issued ?token= query parameter when no ghx_/gha_ token is present.
+  #
+  # The GitHub contents API returns download_url values containing such a
+  # token. It is opaque to GHP: it cannot be attributed to an agent,
+  # scope-checked, or revoked, and remains valid for days.
+  #
+  # true (default) forwards and logs these requests, trading attribution for
+  # compatibility and visibility. false rejects them with 403, at the cost of
+  # breaking clients that follow download_url without sending their own token.
+  allow_query_token: true
+```
+
+- [ ] **Step 8: Document the behaviour and limitations**
+
+In `docs/how-it-works.md`, add a `raw.githubusercontent.com` section covering:
+
+- Why the handler exists: raw accepts GitHub credentials via the `Authorization` header but is **explicitly exempt** from the `sec-GitHub-allowed-enterprise` corporate proxy restriction, which GitHub scopes to `github.com`, `api.github.com` and `*.githubcopilot.com`. Cite the "Endpoints that don't require restriction" list.
+- The three-way classification table from the spec.
+- **Limitation 1 — the query-token path is unenforced.** State plainly that a token scoped to repo A can still fetch repo B's private content through this handler if the agent holds a GitHub-issued `?token=` for it, and that `allow_query_token: false` closes it. Describe the post-hoc correlation approach: match a recent REST API request against a subsequent raw request from the same user-agent and source IP, using `x-github-request-id` as a join key against GitHub's audit log.
+- **Limitation 2 — no rate-limit visibility.** Raw returns no `X-RateLimit-*` headers, so this traffic never appears in `ghp_github_ratelimit_*`. Quota consumed via raw is invisible to GHP by construction.
+
+- [ ] **Step 9: Record the guiding principle in CLAUDE.md**
+
+Add a new top-level section to `CLAUDE.md`, after "Project Overview":
+
+```markdown
+## Enforcement vs Telemetry
+
+**GHP is an enforcement point for tokens it issued and a telemetry point for
+everything else.**
+
+Handlers may forward traffic GHP cannot attribute or scope-check, provided it
+is logged and counted. This is deliberate, not a gap. Two rules follow:
+
+- **Never imply enforcement that isn't happening.** When a handler observes
+  without enforcing, say so in the docs, and give operators a config switch to
+  refuse the unenforceable traffic if they would rather break clients than
+  allow it. `raw.allow_query_token` is the reference example.
+- **A credential GHP did not issue is never forwarded alongside one it did.**
+  If a request carries both, strip the foreign credential — otherwise it can
+  satisfy a request the scope check denied.
+
+Some GitHub hosts are outside enterprise network policy entirely.
+`raw.githubusercontent.com` accepts `Authorization` headers but is exempt from
+the `sec-GitHub-allowed-enterprise` corporate proxy restriction, which GitHub
+scopes to `github.com`, `api.github.com`, and `*.githubcopilot.com` only. That
+exemption is why proxying these hosts is worth the effort: GHP is the only
+place the traffic can be seen.
+```
+
+Also add `ghp_raw_request_total` to the "Existing metrics" list in CLAUDE.md.
+
+- [ ] **Step 10: Verify docs build**
+
+Run: `make docs` (or the documented MkDocs build command — check the `Makefile` for the exact target)
+Expected: builds without warnings about the modified pages
+
+- [ ] **Step 11: Final full verification**
+
+Run: `make check && make lint`
+Expected: PASS
+
+- [ ] **Step 12: Commit**
+
+```bash
+git add internal/server/server.go internal/server/server_test.go docs/admin/configuration.md docs/how-it-works.md CLAUDE.md
+git commit -m "feat(server): route raw.githubusercontent.com
+
+Wires the raw handler into host dispatch with access logging, documents
+the configuration and both accepted limitations, and records the
+enforcement-vs-telemetry principle in CLAUDE.md."
+```
+
+---
+
+## Verification Checklist
+
+Before considering the feature complete, confirm each of these by running the command and reading the output — not by assuming:
+
+- [ ] `make check` passes.
+- [ ] `make lint` passes.
+- [ ] `go test ./internal/proxy/ -run TestRaw -v` — all subtests pass.
+- [ ] `go test ./internal/server/ -run 'TestAccessLog|TestHostDispatch' -v` — all pass.
+- [ ] `go test ./internal/config/ -run TestRawAllowQueryToken -v` — all pass.
+- [ ] `go test ./internal/metrics/ -run TestRawRequestTotal -v` — all six result values pass.
+- [ ] No access log line emits a raw `token=` value (Task 1 test asserts this).
+- [ ] `docs/admin/configuration.md` lists both the env var and the YAML field.
+- [ ] `CLAUDE.md` contains the enforcement-vs-telemetry section and the new metric.
+
+## Deferred
+
+Rewriting `download_url` in API responses, per the spec's non-goals. Adding it
+later converts the `query_token` result class into a fully attributed path
+without changing anything built above.

--- a/docs/superpowers/specs/2026-07-26-raw-githubusercontent-proxy-design.md
+++ b/docs/superpowers/specs/2026-07-26-raw-githubusercontent-proxy-design.md
@@ -1,0 +1,269 @@
+# raw.githubusercontent.com proxy handler
+
+**Date:** 2026-07-26
+**Status:** Design approved, pending implementation
+
+## Background
+
+GHP proxies `api.github.com`, `github.com`, `codeload.github.com`, and
+`*.githubcopilot.com`. It does not proxy `raw.githubusercontent.com`. Agents
+holding a `ghx_` token therefore cannot fetch raw file URLs, and any raw
+traffic that does occur is invisible to GHP — in a typical deployment it
+collapses into a single `CONNECT` line in the upstream squid log.
+
+### Research findings
+
+Empirically verified against a private repository using an OAuth (`gho_`)
+token, 2026-07-25:
+
+| Method | Result |
+| --- | --- |
+| No credential | `404` |
+| `Authorization: token gho_…` | `200` |
+| `Authorization: Bearer gho_…` | `200` |
+| Basic `user:token` | `200` |
+| Basic `x-access-token:token` | `200` |
+| Invalid token | `404` (existence masked, not `401`) |
+| `POST` / `PUT` with valid token | `403` |
+
+Additional observations:
+
+- **No rate-limit surface.** `raw.githubusercontent.com` returns no
+  `X-RateLimit-*`, no `X-OAuth-Scopes`, no `X-GitHub-SSO`. The equivalent
+  `api.github.com` request with `Accept: application/vnd.github.raw` returns
+  the full set.
+- **Fastly edge cache.** `via: 1.1 varnish`, `x-cache: HIT`,
+  `cache-control: max-age=300`, keyed by `vary: Authorization`. Private
+  content is edge-cached but isolated per Authorization value (verified: same
+  URL and cache-buster returns `200` with a token and `404` without).
+- **`github.com/{owner}/{repo}/raw/{ref}/{path}` does not honour an
+  `Authorization` header** (returns `404`). Only the
+  `raw.githubusercontent.com` host does.
+- **Not verified:** `ghs_` installation tokens. No GitHub App private key was
+  available to mint one. All evidence above is OAuth-token evidence.
+  Installation tokens behave consistently with OAuth tokens across the other
+  backends GHP proxies, so this design assumes equivalence on raw. If that
+  assumption proves wrong, only the `gha_` header path is affected — the
+  query-token and anonymous paths carry no GHP credential.
+
+### The `download_url` query token
+
+The REST contents endpoint returns `download_url` values of the form
+`https://raw.githubusercontent.com/{owner}/{repo}/{ref}/{path}?token=…`.
+Probed properties:
+
+- Freshly minted per request — two calls 2s apart returned different values.
+- Path-scoped, not repo-scoped — a token minted for one blob returns `404` on
+  a different blob in the same repository.
+- 31-character uppercase base32, opaque.
+- Lifetime is undocumented for the contents endpoint. Community reports
+  indicate roughly 7 days for private repositories, against 5 minutes for
+  archive links. Treat it as days, not minutes.
+- Not verifiably user-scoped. Assume it is not.
+
+It is therefore a bearer capability for a single blob path, valid for days,
+that GHP cannot attribute to an agent and cannot revoke.
+
+GHP does not rewrite response bodies, so these URLs pass through to agents
+unmodified.
+
+### Enterprise proxy header enforcement
+
+The corporate-proxy restriction header is
+`sec-GitHub-allowed-enterprise: ENTERPRISE-ID`. Per the GitHub Enterprise
+Cloud documentation, the supported endpoints for header injection are
+`github.com/*`, `api.github.com/*`, and `*.githubcopilot.com`.
+
+`*.githubusercontent.com` is listed under *"Endpoints that don't require
+restriction"*, with the rationale that such endpoints *"only provide data, and
+do not accept it."*
+
+`raw.githubusercontent.com` is consequently **not subject to enterprise header
+enforcement**. GitHub's threat model there addresses data ingress into
+personal accounts; read-only egress of private repository content via a
+personal token is out of scope by design. An enterprise that believes the
+proxy header has closed off personal-account use still has this path open.
+
+Source: [Restricting access to GitHub.com using a corporate proxy](https://docs.github.com/en/enterprise-cloud@latest/admin/configuring-settings/hardening-security-for-your-enterprise/restricting-access-to-githubcom-using-a-corporate-proxy)
+
+## Goals
+
+1. **Capability** — agents holding a `ghx_` token can fetch raw file URLs.
+2. **Containment** — raw requests authenticated with a GHP-issued token are
+   scope-enforced like every other backend.
+3. **Observability** — raw traffic produces access log lines and metrics
+   instead of a single opaque `CONNECT` entry.
+
+## Non-goals
+
+Rewriting `download_url` in API responses. This would make every raw fetch
+attributable without requiring client cooperation, but it means GHP would
+start buffering and rewriting response bodies, which it deliberately does not
+do today. The design below is forward-compatible with adding it later: doing
+so converts the `query_token` result class from unattributed passthrough into
+a fully attributed path.
+
+## Guiding principle
+
+> GHP is an enforcement point for tokens it issued and a telemetry point for
+> everything else.
+
+This is to be added to `CLAUDE.md`. It is what makes the asymmetry below
+deliberate rather than a half-finished enforcement point, and it should guide
+future handlers for non-API GitHub hosts.
+
+## Design
+
+### Routing and placement
+
+- New `backend.Raw = "raw.githubusercontent.com"` const in
+  `internal/backend/backend.go`.
+- New `case host == backend.Raw` in `newHostDispatch`
+  (`internal/server/server.go:764`).
+- New handler in `internal/proxy/raw.go`, wired in `server.go` alongside
+  `codeloadHandler` and wrapped in `accessLogHandler(backend.Raw, …)`.
+
+**Path grammar:** `^/+([^/]+)/([^/]+)/(.+)$` → owner, repo, remainder.
+
+Only the first two segments are used for enforcement. This sidesteps the ref
+ambiguity entirely: both `/{owner}/{repo}/{ref}/{path}` and the newer
+`/{owner}/{repo}/refs/heads/{branch}/{path}` form yield the same owner/repo.
+The remainder is never parsed into ref-versus-path; it is treated as opaque.
+
+Owner and repo are lowercased before use as Prometheus labels, matching
+`internal/proxy/codeload.go`.
+
+Paths that do not match the grammar (fewer than three segments) are passed
+through anonymously and not counted, matching how `codeload.go` treats
+non-archive paths — the counter stays scoped to well-formed requests so label
+cardinality remains predictable.
+
+**Methods:** `GET` and `HEAD` only. Any other method returns `403` without
+forwarding, mirroring upstream behaviour. The method check runs after path
+parsing so the `denied_method` counter always carries real owner/repo labels;
+a non-matching path with a disallowed method is passed through and left to
+upstream to reject.
+
+### Request classification
+
+Evaluated in this order:
+
+| Inbound | Action |
+| --- | --- |
+| `Authorization: ghx_…` / `gha_…` | Resolve token, enforce `contents:read` against the repository allowlist, strip any `?token=`, forward with the real credential |
+| `?token=` present, no GHP token | Policy check, then passthrough unmodified, unattributed |
+| Neither | Passthrough anonymously, unattributed |
+
+`contents:read` matches the existing mapping for
+`GET /repos/{owner}/{repo}/contents/…` in `internal/proxy/scope.go:29`.
+
+Anonymous passthrough is unconditional — there is no `raw.require_token`
+knob. Anonymous requests cannot reach private content by definition (GitHub
+returns `404` without a credential), so blocking them buys no confidentiality
+and breaks ordinary tooling that fetches public install scripts, action
+manifests, and templates. They are still logged.
+
+### Configuration
+
+New `RawConfig` struct in `internal/config/config.go` following
+`CodeloadConfig`'s shape, with a single field:
+
+```yaml
+raw:
+  allow_query_token: true   # GHP_RAW_ALLOW_QUERY_TOKEN
+```
+
+Default `true`. When `false`, the query-token case returns `403` with a
+message naming the policy, rather than a silent `404`.
+
+`Raw` must be included in the in-place mutation set in `ReloadFrom`
+(`config.go:466`) so `SIGUSR1` hot-reload takes effect without a restart, with
+a `RawAllowQueryToken()` accessor taking the read lock, matching
+`CodeloadRedirectTo()`.
+
+### Accepted limitations
+
+Two, both to be documented plainly rather than glossed:
+
+1. **The query-token path is unenforced.** A `ghx_` token scoped to repository
+   A can still fetch repository B's private content through this handler if
+   the agent holds a GitHub-issued `?token=` for it. `allow_query_token:
+   false` is the switch that closes this. Post-hoc attribution is possible by
+   correlating a recent REST API request with a subsequent raw request from
+   the same user-agent and source IP; the `x-github-request-id` response
+   header provides a join key against GitHub's own audit log.
+2. **No rate-limit visibility.** Raw returns no `X-RateLimit-*` headers, so
+   this traffic will never appear in `ghp_github_ratelimit_*`. Quota consumed
+   via raw is invisible to GHP by construction.
+
+## Observability
+
+### Access log
+
+Reuses `accessLogHandler(backend.Raw, …)`, so the standard attribute set is
+inherited. Two changes are required.
+
+**Query redaction (general fix, not raw-specific).**
+`internal/server/accesslog.go:125` currently emits `r.URL.RawQuery` verbatim.
+Headers are redacted via `redactRequestHeader`, but query strings are not.
+Passing through query-token raw requests would therefore write live GitHub
+blob capabilities — valid for days — into the access log.
+
+Add a `redactQueryParam(name string) bool` alongside the existing header
+redactors and emit a rewritten query where sensitive values are replaced with
+the same placeholder headers use. Redact `token`, `access_token`, and
+`client_secret`. This improves every backend, not just raw.
+
+**Attribution slot.** A new slot using the same mechanism as `CacheState` and
+`CacheRepo`, carrying how the request authenticated: `proxy_token`,
+`query_token`, or `anonymous`. Emitted as `ghp.raw.auth`, so a log query can
+partition attributable from inferred traffic directly.
+
+### Metrics
+
+One new counter, mirroring `CodeloadRedirectTotal`:
+
+```
+ghp_raw_request_total{owner, repo, result}
+```
+
+`result` ∈ `authenticated`, `query_token`, `anonymous`, `denied_scope`,
+`denied_policy`, `denied_method`.
+
+For the header-authenticated path, reuse the existing
+`ghp_proxy_decision_duration_seconds` stages rather than adding new ones —
+`token_extraction`, `token_resolution`, `scope_enforcement`,
+`github_token_resolution`, and `upstream_roundtrip` all apply unchanged,
+labelled `token_type=proxy`. The two unattributed paths observe only
+`upstream_roundtrip` with `token_type=unknown`, which reads correctly: no
+decision was made, so there is no decision time to attribute.
+
+## Testing
+
+`internal/proxy/raw_test.go`, table-driven with an `httptest` upstream,
+following `codeload_test.go`:
+
+- Path parsing: both ref forms, owner/repo casing normalisation, malformed
+  paths.
+- Each of the three classification cases.
+- `allow_query_token` true and false, including hot-reload behaviour.
+- Method rejection for non-`GET`/`HEAD`.
+- Scope denial for a repository outside the token's allowlist.
+- Query token is stripped on the header path and preserved on the passthrough
+  path.
+
+`internal/metrics/metrics_test.go`: one case per `result` label value, per the
+existing CLAUDE.md requirement that every metric has a test.
+
+`internal/server/accesslog_test.go`: assert `token=` never appears in the
+emitted `url.query` attribute.
+
+## Documentation
+
+- `docs/admin/configuration.md` — `raw.allow_query_token` in both the
+  environment variable table and the full YAML reference.
+- `docs/how-it-works.md` — classification behaviour and both stated
+  limitations.
+- `CLAUDE.md` — the guiding principle above, and a note that
+  `raw.githubusercontent.com` is exempt from enterprise header enforcement so
+  future contributors understand why the handler exists.

--- a/internal/backend/backend.go
+++ b/internal/backend/backend.go
@@ -24,6 +24,16 @@ const (
 	// configured caching mirror when codeload.redirect_to is set.
 	Codeload = "codeload.github.com"
 
+	// Raw handles requests to raw.githubusercontent.com — direct file content
+	// downloads at /{owner}/{repo}/{ref}/{path}. Requests bearing a GHP-issued
+	// token are scope-enforced and forwarded with the resolved credential.
+	// Requests bearing a GitHub-issued ?token= query parameter, and anonymous
+	// requests, are forwarded unmodified — GHP observes and logs them but
+	// cannot attribute or enforce them. This host is exempt from the
+	// sec-GitHub-allowed-enterprise corporate proxy restriction, which is why
+	// proxying it is worthwhile in the first place.
+	Raw = "raw.githubusercontent.com"
+
 	// Copilot handles requests to *.githubcopilot.com. Traffic is forwarded
 	// transparently without token interception or scope enforcement; only access
 	// logging and metrics are applied.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -62,6 +62,7 @@ type Config struct {
 	Block    BlockConfig    `koanf:"block"`
 	Releases ReleasesConfig `koanf:"releases"`
 	Codeload CodeloadConfig `koanf:"codeload"`
+	Raw      RawConfig      `koanf:"raw"`
 
 	Cache CacheConfig `koanf:"cache"`
 
@@ -150,6 +151,26 @@ type CodeloadConfig struct {
 	// (e.g. "goodtune") or org/repo pairs (e.g. "goodtune/ghp"). Matching is
 	// case-insensitive.
 	Allow []string `koanf:"allow"`
+}
+
+// RawConfig controls how raw.githubusercontent.com requests are handled.
+//
+// raw.githubusercontent.com accepts GitHub credentials via the Authorization
+// header, and is explicitly exempt from the sec-GitHub-allowed-enterprise
+// corporate proxy restriction (GitHub scopes that header to github.com,
+// api.github.com and *.githubcopilot.com only). It also returns no
+// X-RateLimit-* headers, so the traffic is invisible to both enterprise
+// network policy and GHP's rate limit telemetry unless proxied.
+type RawConfig struct {
+	// AllowQueryToken controls whether requests carrying a GitHub-issued
+	// ?token= query parameter (as returned in the contents API download_url)
+	// are forwarded when no GHP token is present.
+	//
+	// Such tokens are opaque to GHP: they cannot be attributed to an agent,
+	// scope-checked, or revoked, and remain valid for days. When true
+	// (the default) they are forwarded and logged, trading attribution for
+	// compatibility and visibility. When false they are rejected with 403.
+	AllowQueryToken bool `koanf:"allow_query_token"`
 }
 
 type TLSConfig struct {
@@ -319,6 +340,9 @@ func Defaults() *Config {
 		Cache: CacheConfig{
 			StoragePath: "cache",
 		},
+		Raw: RawConfig{
+			AllowQueryToken: true,
+		},
 	}
 }
 
@@ -441,14 +465,14 @@ func Load(path string) (*Config, error) {
 //
 // The hot-reloadable field updates are serialised with the read locks held by
 // the accessor methods (IsAdmin, IsTokenBlocked, IsReleaseAllowed,
-// IsCodeloadAllowed, CodeloadRedirectTo). The guarantee is per accessor call:
-// any single accessor invocation observes either the pre-reload or
-// post-reload value of the field it reads — never a torn read of a slice or
-// string. The guarantee does NOT extend across multiple accessor calls;
-// e.g. CodeloadRedirectTo() followed by IsCodeloadAllowed(...) may interleave
-// with a reload between them, so a handler that needs cross-field consistency
-// must add a snapshot accessor that takes the lock once and copies the
-// related fields together.
+// IsCodeloadAllowed, CodeloadRedirectTo, RawAllowQueryToken). The guarantee is
+// per accessor call: any single accessor invocation observes either the
+// pre-reload or post-reload value of the field it reads — never a torn read
+// of a slice or string. The guarantee does NOT extend across multiple
+// accessor calls; e.g. CodeloadRedirectTo() followed by
+// IsCodeloadAllowed(...) may interleave with a reload between them, so a
+// handler that needs cross-field consistency must add a snapshot accessor
+// that takes the lock once and copies the related fields together.
 func (c *Config) ReloadFrom(path string) error {
 	fresh, err := Load(path)
 	if err != nil {
@@ -464,6 +488,7 @@ func (c *Config) ReloadFrom(path string) error {
 	c.Block = fresh.Block
 	c.Releases = fresh.Releases
 	c.Codeload = fresh.Codeload
+	c.Raw = fresh.Raw
 	c.Cache = fresh.Cache
 	return nil
 }
@@ -569,6 +594,16 @@ func (c *Config) CodeloadRedirectTo() string {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 	return c.Codeload.RedirectTo
+}
+
+// RawAllowQueryToken reports whether raw.githubusercontent.com requests
+// carrying a GitHub-issued ?token= query parameter are forwarded when no GHP
+// token is present. It takes the read lock so callers on the request hot path
+// can read it without racing against ReloadFrom.
+func (c *Config) RawAllowQueryToken() bool {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.Raw.AllowQueryToken
 }
 
 // WarnInvalidBlockTargets logs a warning for any block configuration targeting

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -370,7 +370,7 @@ func Load(path string) (*Config, error) {
 			if i := strings.Index(s, "_"); i > 0 {
 				section, field := s[:i], s[i+1:]
 				switch section {
-				case "github", "database", "server", "tls", "tokens", "logging", "metrics", "otel", "auth", "block", "releases", "codeload", "cache":
+				case "github", "database", "server", "tls", "tokens", "logging", "metrics", "otel", "auth", "block", "releases", "codeload", "raw", "cache":
 					// Handle 3-level nesting for logging.file.*
 					if section == "logging" && strings.HasPrefix(field, "file_") {
 						return "logging.file." + field[len("file_"):], v

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -492,4 +492,15 @@ func TestRawAllowQueryToken(t *testing.T) {
 			t.Error("RawAllowQueryToken() = true after reload, want false")
 		}
 	})
+
+	t.Run("honours env var override", func(t *testing.T) {
+		t.Setenv("GHP_RAW_ALLOW_QUERY_TOKEN", "false")
+		cfg, err := Load("")
+		if err != nil {
+			t.Fatalf("Load: %v", err)
+		}
+		if cfg.RawAllowQueryToken() {
+			t.Error("RawAllowQueryToken() = true, want false from GHP_RAW_ALLOW_QUERY_TOKEN")
+		}
+	})
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"os"
+	"path/filepath"
 	"testing"
 )
 
@@ -442,4 +443,53 @@ func TestLoadVaultK8sFromEnv(t *testing.T) {
 	if cfg.Database.VaultK8sTokenPath != "/run/secrets/projected/token" {
 		t.Errorf("VaultK8sTokenPath = %q, want /run/secrets/projected/token", cfg.Database.VaultK8sTokenPath)
 	}
+}
+
+func TestRawAllowQueryToken(t *testing.T) {
+	t.Run("defaults to true", func(t *testing.T) {
+		cfg, err := Load("")
+		if err != nil {
+			t.Fatalf("Load: %v", err)
+		}
+		if !cfg.RawAllowQueryToken() {
+			t.Error("RawAllowQueryToken() = false, want true by default")
+		}
+	})
+
+	t.Run("honours explicit false", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "cfg.yaml")
+		if err := os.WriteFile(path, []byte("raw:\n  allow_query_token: false\n"), 0o600); err != nil {
+			t.Fatalf("WriteFile: %v", err)
+		}
+		cfg, err := Load(path)
+		if err != nil {
+			t.Fatalf("Load: %v", err)
+		}
+		if cfg.RawAllowQueryToken() {
+			t.Error("RawAllowQueryToken() = true, want false")
+		}
+	})
+
+	t.Run("hot reload picks up change", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "cfg.yaml")
+		if err := os.WriteFile(path, []byte("raw:\n  allow_query_token: true\n"), 0o600); err != nil {
+			t.Fatalf("WriteFile: %v", err)
+		}
+		cfg, err := Load(path)
+		if err != nil {
+			t.Fatalf("Load: %v", err)
+		}
+		if !cfg.RawAllowQueryToken() {
+			t.Fatal("precondition: want true before reload")
+		}
+		if err := os.WriteFile(path, []byte("raw:\n  allow_query_token: false\n"), 0o600); err != nil {
+			t.Fatalf("WriteFile: %v", err)
+		}
+		if err := cfg.ReloadFrom(path); err != nil {
+			t.Fatalf("ReloadFrom: %v", err)
+		}
+		if cfg.RawAllowQueryToken() {
+			t.Error("RawAllowQueryToken() = true after reload, want false")
+		}
+	})
 }

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -120,19 +120,35 @@ var (
 
 	// RawRequestTotal counts raw.githubusercontent.com requests handled,
 	// labeled by owner, repo, and result:
-	//   "authenticated" — GHP token present; scope enforced; forwarded with
-	//                     the resolved GitHub credential
-	//   "query_token"   — GitHub-issued ?token= present, no GHP token;
-	//                     forwarded unmodified and unattributed
-	//   "anonymous"     — no credential; forwarded unmodified
-	//   "denied_scope"  — GHP token not scoped to the requested repository,
-	//                     or lacking contents:read
-	//   "denied_policy" — query token rejected by raw.allow_query_token=false
-	//   "denied_method" — method other than GET or HEAD
+	//   "authenticated"      — GHP token present; scope enforced; forwarded
+	//                          with the resolved GitHub credential
+	//   "query_token"        — GitHub-issued ?token= present, no GHP token;
+	//                          forwarded unmodified and unattributed
+	//   "foreign_credential" — an Authorization credential GHP did not issue
+	//                          (e.g. ghp_/ghs_) and the border policy permits;
+	//                          forwarded intact and unattributed
+	//   "anonymous"          — no credential at all; forwarded unmodified
+	//   "denied_scope"       — GHP token not scoped to the requested
+	//                          repository, or lacking contents:read
+	//   "denied_token"       — GHP token could not be resolved (revoked,
+	//                          expired, unknown) or its GitHub credential
+	//                          could not be resolved
+	//   "denied_policy"      — query token rejected by
+	//                          raw.allow_query_token=false
+	//   "denied_border"      — credential rejected by the token type border
+	//                          policy (block.ghp and friends)
+	//   "denied_method"      — method other than GET or HEAD
+	//   "error"              — GHP-side fault (corrupt token scope JSON)
 	//
 	// The ref and file path are not included as labels to keep cardinality
 	// bounded; they are captured in access logs as part of the URL.
-	// Cardinality: bounded by (repos seen × results).
+	//
+	// Cardinality: client-controlled on the unauthenticated paths. owner and
+	// repo are taken from the request path, and the anonymous, foreign
+	// credential, and query-token classifications require no credential GHP
+	// issued — so any client that can reach the raw vhost can mint a new
+	// series per invented /owner/repo. Operators fronting ghp with an
+	// untrusted client population should budget metric storage accordingly.
 	RawRequestTotal = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name: "ghp_raw_request_total",
 		Help: "Total raw.githubusercontent.com requests handled, by owner, repo, and result.",

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -118,6 +118,26 @@ var (
 		Help: "Total codeload.github.com archive requests handled, by owner, repo, archive format, and result.",
 	}, []string{"owner", "repo", "archive", "result"})
 
+	// RawRequestTotal counts raw.githubusercontent.com requests handled,
+	// labeled by owner, repo, and result:
+	//   "authenticated" — GHP token present; scope enforced; forwarded with
+	//                     the resolved GitHub credential
+	//   "query_token"   — GitHub-issued ?token= present, no GHP token;
+	//                     forwarded unmodified and unattributed
+	//   "anonymous"     — no credential; forwarded unmodified
+	//   "denied_scope"  — GHP token not scoped to the requested repository,
+	//                     or lacking contents:read
+	//   "denied_policy" — query token rejected by raw.allow_query_token=false
+	//   "denied_method" — method other than GET or HEAD
+	//
+	// The ref and file path are not included as labels to keep cardinality
+	// bounded; they are captured in access logs as part of the URL.
+	// Cardinality: bounded by (repos seen × results).
+	RawRequestTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "ghp_raw_request_total",
+		Help: "Total raw.githubusercontent.com requests handled, by owner, repo, and result.",
+	}, []string{"owner", "repo", "result"})
+
 	// BlockAnonymousGitEnabled reflects whether the anonymous git blocking
 	// feature is currently active (1) or inactive (0). Set at server startup
 	// and on config reload (SIGUSR1); not updated per-request.

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -246,6 +246,29 @@ func TestReleasesRedirectHeadCheckTotal(t *testing.T) {
 	}
 }
 
+func TestRawRequestTotal(t *testing.T) {
+	results := []string{
+		"authenticated", "query_token", "anonymous",
+		"denied_scope", "denied_policy", "denied_method",
+	}
+	for _, result := range results {
+		t.Run(result, func(t *testing.T) {
+			owner, repo := "testowner", "testrepo-"+result
+			labels := prometheus.Labels{
+				"owner":  owner,
+				"repo":   repo,
+				"result": result,
+			}
+			before := getCounterValue(t, RawRequestTotal, labels)
+			RawRequestTotal.WithLabelValues(owner, repo, result).Inc()
+			after := getCounterValue(t, RawRequestTotal, labels)
+			if after-before != 1 {
+				t.Errorf("expected counter to increment by 1, got %f", after-before)
+			}
+		})
+	}
+}
+
 func TestCodeloadRedirectTotal(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -248,8 +248,9 @@ func TestReleasesRedirectHeadCheckTotal(t *testing.T) {
 
 func TestRawRequestTotal(t *testing.T) {
 	results := []string{
-		"authenticated", "query_token", "anonymous",
-		"denied_scope", "denied_policy", "denied_method",
+		"authenticated", "query_token", "foreign_credential", "anonymous",
+		"denied_scope", "denied_token", "denied_policy", "denied_border",
+		"denied_method", "error",
 	}
 	for _, result := range results {
 		t.Run(result, func(t *testing.T) {

--- a/internal/proxy/context.go
+++ b/internal/proxy/context.go
@@ -13,6 +13,7 @@ var usernameCtxKey = &contextKey{"github-username"}
 var userIDCtxKey = &contextKey{"user-id"}
 var cacheStateCtxKey = &contextKey{"cache-state"}
 var cacheRepoCtxKey = &contextKey{"cache-repo"}
+var rawAuthCtxKey = &contextKey{"raw-auth"}
 
 // AccessLogSlots holds the mutable string slots that downstream handlers
 // populate so the access-log middleware can read them after the request.
@@ -21,6 +22,7 @@ type AccessLogSlots struct {
 	UserID     *string
 	CacheState *string // "hit", "miss", "rejected", "error", or "" for non-cached
 	CacheRepo  *string // "owner/repo" if request hit a cached repository
+	RawAuth    *string // "proxy_token", "query_token", "anonymous", or "" for non-raw backends
 }
 
 // PrepareAccessLogSlots returns a new request whose context carries mutable
@@ -32,15 +34,18 @@ func PrepareAccessLogSlots(r *http.Request) (*http.Request, *AccessLogSlots) {
 	userIDSlot := new(string)
 	cacheStateSlot := new(string)
 	cacheRepoSlot := new(string)
+	rawAuthSlot := new(string)
 	ctx := context.WithValue(r.Context(), usernameCtxKey, usernameSlot)
 	ctx = context.WithValue(ctx, userIDCtxKey, userIDSlot)
 	ctx = context.WithValue(ctx, cacheStateCtxKey, cacheStateSlot)
 	ctx = context.WithValue(ctx, cacheRepoCtxKey, cacheRepoSlot)
+	ctx = context.WithValue(ctx, rawAuthCtxKey, rawAuthSlot)
 	return r.WithContext(ctx), &AccessLogSlots{
 		Username:   usernameSlot,
 		UserID:     userIDSlot,
 		CacheState: cacheStateSlot,
 		CacheRepo:  cacheRepoSlot,
+		RawAuth:    rawAuthSlot,
 	}
 }
 
@@ -113,5 +118,14 @@ func GetCacheState(r *http.Request) string {
 func SetCacheRepo(r *http.Request, repo string) {
 	if slot, ok := r.Context().Value(cacheRepoCtxKey).(*string); ok {
 		*slot = repo
+	}
+}
+
+// SetRawAuth records how a raw.githubusercontent.com request authenticated,
+// so the access-log middleware can partition attributable traffic from
+// traffic GHP only observed. It is a no-op if no slot was prepared.
+func SetRawAuth(r *http.Request, v string) {
+	if slot, ok := r.Context().Value(rawAuthCtxKey).(*string); ok && slot != nil {
+		*slot = v
 	}
 }

--- a/internal/proxy/context.go
+++ b/internal/proxy/context.go
@@ -22,7 +22,11 @@ type AccessLogSlots struct {
 	UserID     *string
 	CacheState *string // "hit", "miss", "rejected", "error", or "" for non-cached
 	CacheRepo  *string // "owner/repo" if request hit a cached repository
-	RawAuth    *string // "proxy_token", "query_token", "anonymous", or "" for non-raw backends
+	// RawAuth is how a raw.githubusercontent.com request authenticated:
+	// "proxy_token", "query_token", "foreign_credential", "anonymous", or one
+	// of the denial reasons "denied_method", "denied_border", "denied_policy",
+	// "denied_scope", "denied_token", "error". Empty for non-raw backends.
+	RawAuth *string
 }
 
 // PrepareAccessLogSlots returns a new request whose context carries mutable

--- a/internal/proxy/context_test.go
+++ b/internal/proxy/context_test.go
@@ -1,0 +1,23 @@
+package proxy
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestRawAuthSlot(t *testing.T) {
+	t.Run("round trips through the slot", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/o/r/main/f.txt", nil)
+		req, slots := PrepareAccessLogSlots(req)
+		SetRawAuth(req, "query_token")
+		if *slots.RawAuth != "query_token" {
+			t.Errorf("RawAuth = %q, want %q", *slots.RawAuth, "query_token")
+		}
+	})
+
+	t.Run("no-op without a prepared slot", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/o/r/main/f.txt", nil)
+		SetRawAuth(req, "anonymous") // must not panic
+	})
+}

--- a/internal/proxy/raw.go
+++ b/internal/proxy/raw.go
@@ -115,7 +115,7 @@ func NewRawHandler(cfg *config.Config, enforcer ScopeEnforcer, resolver TokenRes
 		}
 		metrics.ObserveDecision(metrics.StageTokenExtraction, extractTokenType, time.Since(extractStart))
 		if clientTok != "" {
-			serveRawAuthenticated(w, r, passthrough, enforcer, resolver, ur, logger, owner, repo, clientTok)
+			serveRawAuthenticated(w, r, passthrough, enforcer, resolver, ur, logger, owner, repo, clientTok, decisionStart)
 			return
 		}
 
@@ -152,8 +152,12 @@ func NewRawHandler(cfg *config.Config, enforcer ScopeEnforcer, resolver TokenRes
 // Any GitHub-issued ?token= is stripped before forwarding: carrying both a
 // GHP-resolved credential and an independent GitHub capability would let the
 // latter satisfy a request the former was denied.
-func serveRawAuthenticated(w http.ResponseWriter, r *http.Request, passthrough http.Handler, enforcer ScopeEnforcer, resolver TokenResolver, ur *UsernameResolver, logger *slog.Logger, owner, repo, clientTok string) {
-	decisionStart := time.Now()
+//
+// decisionStart is the caller's request-arrival timestamp, not a local one, so
+// that the total stage covers the full pre-forward overhead — path parsing, the
+// method check, and token extraction included — rather than only the work done
+// here.
+func serveRawAuthenticated(w http.ResponseWriter, r *http.Request, passthrough http.Handler, enforcer ScopeEnforcer, resolver TokenResolver, ur *UsernameResolver, logger *slog.Logger, owner, repo, clientTok string, decisionStart time.Time) {
 	repoFull := owner + "/" + repo
 
 	resolveTokenType := ""

--- a/internal/proxy/raw.go
+++ b/internal/proxy/raw.go
@@ -44,6 +44,69 @@ func parseRawPath(p string) (owner, repo string, ok bool) {
 	return strings.ToLower(m[1]), strings.ToLower(m[2]), true
 }
 
+// rawQuerySegments splits a raw query string into its parameter segments,
+// treating both "&" and ";" as separators.
+//
+// url.ParseQuery cannot be used for any security decision about this query:
+// it silently discards any &-segment containing a ";", so "?x=1;token=SECRET"
+// parses to an empty url.Values. Classifying or stripping on the parsed map
+// would let a token smuggled behind a semicolon slip past both the
+// raw.allow_query_token policy check and the strip on the authenticated path.
+// Splitting the raw string ourselves sees every segment a permissive upstream
+// parser might.
+func rawQuerySegments(rawQuery string) []string {
+	if rawQuery == "" {
+		return nil
+	}
+	return strings.FieldsFunc(rawQuery, func(r rune) bool {
+		return r == '&' || r == ';'
+	})
+}
+
+// isRawTokenSegment reports whether a query segment names the "token"
+// parameter. The comparison is case-insensitive because GitHub treats the
+// parameter name that way; an exact-case check would let "?TOKEN=x" through.
+func isRawTokenSegment(seg string) bool {
+	key, _, _ := strings.Cut(seg, "=")
+	// An unescape failure means the key is not a well-formed encoding of
+	// "token", but compare the raw bytes anyway rather than skipping the
+	// segment — deciding "not a token" from a parse error is how the
+	// ParseQuery bypass happened in the first place.
+	if unescaped, err := url.QueryUnescape(key); err == nil {
+		key = unescaped
+	}
+	return strings.EqualFold(key, "token")
+}
+
+// rawQueryHasToken reports whether the raw query carries a "token" parameter.
+func rawQueryHasToken(rawQuery string) bool {
+	for _, seg := range rawQuerySegments(rawQuery) {
+		if isRawTokenSegment(seg) {
+			return true
+		}
+	}
+	return false
+}
+
+// stripRawQueryToken removes every "token" parameter from a raw query,
+// returning the remaining segments joined by "&".
+//
+// Segments are preserved verbatim rather than re-encoded, so unrelated
+// parameters survive a query that url.ParseQuery cannot read. Semicolon
+// separators are normalised to "&": that keeps what we forward unambiguous to
+// upstream, which would otherwise be free to split the query differently than
+// we did.
+func stripRawQueryToken(rawQuery string) string {
+	segs := rawQuerySegments(rawQuery)
+	kept := make([]string, 0, len(segs))
+	for _, seg := range segs {
+		if !isRawTokenSegment(seg) {
+			kept = append(kept, seg)
+		}
+	}
+	return strings.Join(kept, "&")
+}
+
 // newRawPassthrough builds a transparent reverse proxy to upstream
 // raw.githubusercontent.com, preserving the client's Host header so tests and
 // access logs see the value that was sent.
@@ -119,7 +182,7 @@ func NewRawHandler(cfg *config.Config, enforcer ScopeEnforcer, resolver TokenRes
 			return
 		}
 
-		if r.URL.Query().Get("token") != "" {
+		if rawQueryHasToken(r.URL.RawQuery) {
 			if !cfg.RawAllowQueryToken() {
 				metrics.RawRequestTotal.WithLabelValues(owner, repo, "denied_policy").Inc()
 				metrics.ObserveDecision(metrics.StageTotal, "unknown", time.Since(decisionStart))
@@ -235,17 +298,10 @@ func serveRawAuthenticated(w http.ResponseWriter, r *http.Request, passthrough h
 	metrics.ObserveDecision(metrics.StageUsernameResolution, tokenType, time.Since(usernameStart))
 
 	// Strip the GitHub-issued capability before forwarding our own credential.
-	//
-	// Unconditional by design: url.Values.Get cannot be trusted to detect the
-	// parameter. ParseQuery silently discards any &-segment containing a ";",
-	// so "?x=1;token=SECRET" parses to an empty map — guarding the strip on
-	// Get("token") != "" would skip it and forward the smuggled token verbatim
-	// alongside our own credential. Re-encoding an unparseable query drops its
-	// other parameters, which is the correct fail-closed trade. Encode() also
-	// re-orders and re-normalises the parameters it does keep.
-	q := r.URL.Query()
-	q.Del("token")
-	r.URL.RawQuery = q.Encode()
+	// stripRawQueryToken works on the raw string, so it also catches a token
+	// smuggled behind a ";" and one spelled in a different case — neither of
+	// which url.Values would remove.
+	r.URL.RawQuery = stripRawQueryToken(r.URL.RawQuery)
 
 	_, _, rewriteAuth := extractClientToken(r)
 	if rewriteAuth != nil {

--- a/internal/proxy/raw.go
+++ b/internal/proxy/raw.go
@@ -87,21 +87,33 @@ func NewRawHandler(cfg *config.Config, enforcer ScopeEnforcer, resolver TokenRes
 	passthrough := newRawPassthrough(transport)
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		decisionStart := time.Now()
+
 		owner, repo, ok := parseRawPath(r.URL.Path)
 		if !ok {
 			// Not a content path. Forward and leave it to upstream; not
 			// counted, so label cardinality stays bounded by real requests.
+			metrics.ObserveDecision(metrics.StageTotal, "unknown", time.Since(decisionStart))
+			upstreamStart := time.Now()
 			passthrough.ServeHTTP(w, r)
+			metrics.ObserveDecision(metrics.StageUpstreamRoundtrip, "unknown", time.Since(upstreamStart))
 			return
 		}
 
 		if r.Method != http.MethodGet && r.Method != http.MethodHead {
 			metrics.RawRequestTotal.WithLabelValues(owner, repo, "denied_method").Inc()
+			metrics.ObserveDecision(metrics.StageTotal, "unknown", time.Since(decisionStart))
 			writeError(w, http.StatusForbidden, "Only GET and HEAD are permitted for raw content")
 			return
 		}
 
+		extractStart := time.Now()
 		clientTok, _, _ := extractClientToken(r)
+		extractTokenType := ""
+		if tt, ok := token.TokenTypeFromPrefix(clientTok); ok {
+			extractTokenType = string(tt)
+		}
+		metrics.ObserveDecision(metrics.StageTokenExtraction, extractTokenType, time.Since(extractStart))
 		if clientTok != "" {
 			serveRawAuthenticated(w, r, passthrough, enforcer, resolver, ur, logger, owner, repo, clientTok)
 			return
@@ -110,19 +122,26 @@ func NewRawHandler(cfg *config.Config, enforcer ScopeEnforcer, resolver TokenRes
 		if r.URL.Query().Get("token") != "" {
 			if !cfg.RawAllowQueryToken() {
 				metrics.RawRequestTotal.WithLabelValues(owner, repo, "denied_policy").Inc()
+				metrics.ObserveDecision(metrics.StageTotal, "unknown", time.Since(decisionStart))
 				writeError(w, http.StatusForbidden,
 					"GitHub-issued query tokens are not permitted (raw.allow_query_token is disabled)")
 				return
 			}
 			metrics.RawRequestTotal.WithLabelValues(owner, repo, "query_token").Inc()
 			SetRawAuth(r, "query_token")
+			metrics.ObserveDecision(metrics.StageTotal, "unknown", time.Since(decisionStart))
+			upstreamStart := time.Now()
 			passthrough.ServeHTTP(w, r)
+			metrics.ObserveDecision(metrics.StageUpstreamRoundtrip, "unknown", time.Since(upstreamStart))
 			return
 		}
 
 		metrics.RawRequestTotal.WithLabelValues(owner, repo, "anonymous").Inc()
 		SetRawAuth(r, "anonymous")
+		metrics.ObserveDecision(metrics.StageTotal, "unknown", time.Since(decisionStart))
+		upstreamStart := time.Now()
 		passthrough.ServeHTTP(w, r)
+		metrics.ObserveDecision(metrics.StageUpstreamRoundtrip, "unknown", time.Since(upstreamStart))
 	})
 }
 
@@ -212,10 +231,17 @@ func serveRawAuthenticated(w http.ResponseWriter, r *http.Request, passthrough h
 	metrics.ObserveDecision(metrics.StageUsernameResolution, tokenType, time.Since(usernameStart))
 
 	// Strip the GitHub-issued capability before forwarding our own credential.
-	if q := r.URL.Query(); q.Get("token") != "" {
-		q.Del("token")
-		r.URL.RawQuery = q.Encode()
-	}
+	//
+	// Unconditional by design: url.Values.Get cannot be trusted to detect the
+	// parameter. ParseQuery silently discards any &-segment containing a ";",
+	// so "?x=1;token=SECRET" parses to an empty map — guarding the strip on
+	// Get("token") != "" would skip it and forward the smuggled token verbatim
+	// alongside our own credential. Re-encoding an unparseable query drops its
+	// other parameters, which is the correct fail-closed trade. Encode() also
+	// re-orders and re-normalises the parameters it does keep.
+	q := r.URL.Query()
+	q.Del("token")
+	r.URL.RawQuery = q.Encode()
 
 	_, _, rewriteAuth := extractClientToken(r)
 	if rewriteAuth != nil {

--- a/internal/proxy/raw.go
+++ b/internal/proxy/raw.go
@@ -127,18 +127,24 @@ func newRawPassthrough(transport http.RoundTripper) http.Handler {
 
 // NewRawHandler returns an http.Handler for raw.githubusercontent.com requests.
 //
-// Requests are classified into three paths, evaluated in order:
+// Requests are classified in this order:
 //
 //   - A GHP-issued token (ghx_/gha_) in the Authorization header: the token is
 //     resolved, contents:read is enforced against the repository allowlist, any
 //     GitHub-issued ?token= is stripped, and the request is forwarded with the
 //     real credential. This is the only enforced path.
+//   - A credential GHP did not issue whose type is blocked by the token type
+//     border policy (cfg.Block): rejected with 403.
 //   - A GitHub-issued ?token= with no GHP token: forwarded unmodified when
 //     raw.allow_query_token is true (the default), rejected with 403 otherwise.
 //     GHP cannot attribute, scope-check, or revoke such tokens.
-//   - Neither: forwarded anonymously. Anonymous requests cannot reach private
-//     content — GitHub returns 404 without a credential — so blocking them buys
-//     no confidentiality and breaks ordinary public-content tooling.
+//   - A credential GHP did not issue that the border policy permits: forwarded
+//     intact, counted foreign_credential — GHP recognises only the ghx_/gha_
+//     prefixes, so it can observe but not attribute such traffic.
+//   - No credential at all: forwarded anonymously. Anonymous requests cannot
+//     reach private content — GitHub returns 404 without a credential — so
+//     blocking them buys no confidentiality and breaks ordinary public-content
+//     tooling.
 //
 // This asymmetry is deliberate: GHP is an enforcement point for tokens it
 // issued and a telemetry point for everything else.

--- a/internal/proxy/raw.go
+++ b/internal/proxy/raw.go
@@ -1,0 +1,232 @@
+package proxy
+
+import (
+	"fmt"
+	"log/slog"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/goodtune/ghp/internal/config"
+	"github.com/goodtune/ghp/internal/metrics"
+	"github.com/goodtune/ghp/internal/token"
+)
+
+// rawPathRe matches raw.githubusercontent.com content paths and captures the
+// owner and repository. The remainder is deliberately left unparsed: refs may
+// contain slashes, and both /{owner}/{repo}/{ref}/{path} and the newer
+// /{owner}/{repo}/refs/heads/{branch}/{path} form must yield the same
+// owner/repo. Only the first two segments participate in enforcement.
+var rawPathRe = regexp.MustCompile(`^/+([^/]+)/([^/]+)/(.+)$`)
+
+// upstreamRaw is the canonical upstream URL used as the passthrough target.
+var upstreamRaw = mustParseRawURL("https://raw.githubusercontent.com")
+
+func mustParseRawURL(s string) *url.URL {
+	u, err := url.Parse(s)
+	if err != nil {
+		panic(err)
+	}
+	return u
+}
+
+// parseRawPath extracts the owner and repository from a raw content path.
+// Owner and repo are lowercased: GitHub treats them case-insensitively, so
+// leaving the client's casing intact would split Prometheus time series.
+func parseRawPath(p string) (owner, repo string, ok bool) {
+	m := rawPathRe.FindStringSubmatch(p)
+	if m == nil {
+		return "", "", false
+	}
+	return strings.ToLower(m[1]), strings.ToLower(m[2]), true
+}
+
+// newRawPassthrough builds a transparent reverse proxy to upstream
+// raw.githubusercontent.com, preserving the client's Host header so tests and
+// access logs see the value that was sent.
+func newRawPassthrough(transport http.RoundTripper) http.Handler {
+	rp := &httputil.ReverseProxy{
+		Director: func(req *http.Request) {
+			originalHost := req.Host
+			req.URL.Scheme = upstreamRaw.Scheme
+			req.URL.Host = upstreamRaw.Host
+			req.Host = originalHost
+		},
+	}
+	if transport != nil {
+		rp.Transport = transport
+	}
+	return rp
+}
+
+// NewRawHandler returns an http.Handler for raw.githubusercontent.com requests.
+//
+// Requests are classified into three paths, evaluated in order:
+//
+//   - A GHP-issued token (ghx_/gha_) in the Authorization header: the token is
+//     resolved, contents:read is enforced against the repository allowlist, any
+//     GitHub-issued ?token= is stripped, and the request is forwarded with the
+//     real credential. This is the only enforced path.
+//   - A GitHub-issued ?token= with no GHP token: forwarded unmodified when
+//     raw.allow_query_token is true (the default), rejected with 403 otherwise.
+//     GHP cannot attribute, scope-check, or revoke such tokens.
+//   - Neither: forwarded anonymously. Anonymous requests cannot reach private
+//     content — GitHub returns 404 without a credential — so blocking them buys
+//     no confidentiality and breaks ordinary public-content tooling.
+//
+// This asymmetry is deliberate: GHP is an enforcement point for tokens it
+// issued and a telemetry point for everything else.
+//
+// cfg is read on every request so SIGUSR1 hot-reload of raw.allow_query_token
+// takes effect without a server restart. transport is optional; when nil the
+// default RoundTripper is used.
+func NewRawHandler(cfg *config.Config, enforcer ScopeEnforcer, resolver TokenResolver, ur *UsernameResolver, logger *slog.Logger, transport http.RoundTripper) http.Handler {
+	passthrough := newRawPassthrough(transport)
+
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		owner, repo, ok := parseRawPath(r.URL.Path)
+		if !ok {
+			// Not a content path. Forward and leave it to upstream; not
+			// counted, so label cardinality stays bounded by real requests.
+			passthrough.ServeHTTP(w, r)
+			return
+		}
+
+		if r.Method != http.MethodGet && r.Method != http.MethodHead {
+			metrics.RawRequestTotal.WithLabelValues(owner, repo, "denied_method").Inc()
+			writeError(w, http.StatusForbidden, "Only GET and HEAD are permitted for raw content")
+			return
+		}
+
+		clientTok, _, _ := extractClientToken(r)
+		if clientTok != "" {
+			serveRawAuthenticated(w, r, passthrough, enforcer, resolver, ur, logger, owner, repo, clientTok)
+			return
+		}
+
+		if r.URL.Query().Get("token") != "" {
+			if !cfg.RawAllowQueryToken() {
+				metrics.RawRequestTotal.WithLabelValues(owner, repo, "denied_policy").Inc()
+				writeError(w, http.StatusForbidden,
+					"GitHub-issued query tokens are not permitted (raw.allow_query_token is disabled)")
+				return
+			}
+			metrics.RawRequestTotal.WithLabelValues(owner, repo, "query_token").Inc()
+			SetRawAuth(r, "query_token")
+			passthrough.ServeHTTP(w, r)
+			return
+		}
+
+		metrics.RawRequestTotal.WithLabelValues(owner, repo, "anonymous").Inc()
+		SetRawAuth(r, "anonymous")
+		passthrough.ServeHTTP(w, r)
+	})
+}
+
+// serveRawAuthenticated handles requests bearing a GHP-issued token. The
+// token's repository allowlist and contents:read permission are enforced
+// before the request is forwarded with the resolved GitHub credential.
+//
+// Any GitHub-issued ?token= is stripped before forwarding: carrying both a
+// GHP-resolved credential and an independent GitHub capability would let the
+// latter satisfy a request the former was denied.
+func serveRawAuthenticated(w http.ResponseWriter, r *http.Request, passthrough http.Handler, enforcer ScopeEnforcer, resolver TokenResolver, ur *UsernameResolver, logger *slog.Logger, owner, repo, clientTok string) {
+	decisionStart := time.Now()
+	repoFull := owner + "/" + repo
+
+	resolveTokenType := ""
+	if tt, ok := token.TokenTypeFromPrefix(clientTok); ok {
+		resolveTokenType = string(tt)
+	}
+
+	resolveStart := time.Now()
+	pt, err := enforcer.Resolve(r.Context(), clientTok)
+	metrics.ObserveDecision(metrics.StageTokenResolution, resolveTokenType, time.Since(resolveStart))
+	if err != nil || pt == nil {
+		if err != nil && logger != nil {
+			logger.Warn("raw scope enforcement: token resolution failed", "error", err)
+		}
+		metrics.ObserveDecision(metrics.StageTotal, resolveTokenType, time.Since(decisionStart))
+		writeError(w, http.StatusUnauthorized, "Invalid token")
+		return
+	}
+
+	tokenType := pt.TokenType
+	if pt.UserID != nil {
+		SetUserID(r, *pt.UserID)
+	}
+
+	scopeParseStart := time.Now()
+	si, err := parseScopeInfo(pt)
+	metrics.ObserveDecision(metrics.StageScopeParsing, tokenType, time.Since(scopeParseStart))
+	if err != nil {
+		if logger != nil {
+			logger.Error("raw scope enforcement: failed to parse token scope", "error", err)
+		}
+		metrics.ObserveDecision(metrics.StageTotal, tokenType, time.Since(decisionStart))
+		writeError(w, http.StatusInternalServerError, "Internal error")
+		return
+	}
+
+	if !si.isOpenScoped() {
+		scopeEnforceStart := time.Now()
+		if len(si.Repos) > 0 && !si.repoAllowed(repoFull) {
+			metrics.ObserveDecision(metrics.StageScopeEnforcement, tokenType, time.Since(scopeEnforceStart))
+			metrics.ObserveDecision(metrics.StageTotal, tokenType, time.Since(decisionStart))
+			metrics.RawRequestTotal.WithLabelValues(owner, repo, "denied_scope").Inc()
+			writeError(w, http.StatusForbidden, fmt.Sprintf("Token is not scoped to %s", repoFull))
+			return
+		}
+		if len(si.Scopes) > 0 && !si.Scopes.HasPermission("contents", "read") {
+			metrics.ObserveDecision(metrics.StageScopeEnforcement, tokenType, time.Since(scopeEnforceStart))
+			metrics.ObserveDecision(metrics.StageTotal, tokenType, time.Since(decisionStart))
+			metrics.RawRequestTotal.WithLabelValues(owner, repo, "denied_scope").Inc()
+			writeError(w, http.StatusForbidden,
+				fmt.Sprintf("Token does not have permission for contents:read on %s", repoFull))
+			return
+		}
+		metrics.ObserveDecision(metrics.StageScopeEnforcement, tokenType, time.Since(scopeEnforceStart))
+	}
+
+	ghTokenStart := time.Now()
+	realToken, err := resolver.ResolveToGitHubToken(r.Context(), clientTok)
+	metrics.ObserveDecision(metrics.StageGitHubTokenResolution, tokenType, time.Since(ghTokenStart))
+	if err != nil {
+		if logger != nil {
+			logger.Warn("raw scope enforcement: GitHub token resolution failed", "error", err)
+		}
+		metrics.ObserveDecision(metrics.StageTotal, tokenType, time.Since(decisionStart))
+		writeError(w, http.StatusUnauthorized, "Token resolution failed")
+		return
+	}
+
+	usernameStart := time.Now()
+	if ur != nil {
+		if u := ur.ResolveFromGitHubToken(r.Context(), realToken); u != "" {
+			SetUsername(r, u)
+		}
+	}
+	metrics.ObserveDecision(metrics.StageUsernameResolution, tokenType, time.Since(usernameStart))
+
+	// Strip the GitHub-issued capability before forwarding our own credential.
+	if q := r.URL.Query(); q.Get("token") != "" {
+		q.Del("token")
+		r.URL.RawQuery = q.Encode()
+	}
+
+	_, _, rewriteAuth := extractClientToken(r)
+	if rewriteAuth != nil {
+		r.Header.Set("Authorization", rewriteAuth(realToken))
+	}
+
+	metrics.RawRequestTotal.WithLabelValues(owner, repo, "authenticated").Inc()
+	SetRawAuth(r, "proxy_token")
+	metrics.ObserveDecision(metrics.StageTotal, tokenType, time.Since(decisionStart))
+
+	upstreamStart := time.Now()
+	passthrough.ServeHTTP(w, r)
+	metrics.ObserveDecision(metrics.StageUpstreamRoundtrip, tokenType, time.Since(upstreamStart))
+}

--- a/internal/proxy/raw.go
+++ b/internal/proxy/raw.go
@@ -165,13 +165,14 @@ func NewRawHandler(cfg *config.Config, enforcer ScopeEnforcer, resolver TokenRes
 
 		if r.Method != http.MethodGet && r.Method != http.MethodHead {
 			metrics.RawRequestTotal.WithLabelValues(owner, repo, "denied_method").Inc()
+			SetRawAuth(r, "denied_method")
 			metrics.ObserveDecision(metrics.StageTotal, "unknown", time.Since(decisionStart))
 			writeError(w, http.StatusForbidden, "Only GET and HEAD are permitted for raw content")
 			return
 		}
 
 		extractStart := time.Now()
-		clientTok, _, _ := extractClientToken(r)
+		clientTok, rawCredential, _ := extractClientToken(r)
 		extractTokenType := ""
 		if tt, ok := token.TokenTypeFromPrefix(clientTok); ok {
 			extractTokenType = string(tt)
@@ -182,9 +183,25 @@ func NewRawHandler(cfg *config.Config, enforcer ScopeEnforcer, resolver TokenRes
 			return
 		}
 
+		// The credential is not one GHP issued. Apply the token type border
+		// policy before anything else forwards it: raw is exempt from GitHub's
+		// sec-GitHub-allowed-enterprise restriction, so a blocked token type
+		// reaches raw unless GHP stops it here.
+		borderStart := time.Now()
+		if cfg.IsTokenBlocked(rawCredential) {
+			metrics.ObserveDecision(metrics.StageBorderPolicyCheck, "", time.Since(borderStart))
+			metrics.RawRequestTotal.WithLabelValues(owner, repo, "denied_border").Inc()
+			SetRawAuth(r, "denied_border")
+			metrics.ObserveDecision(metrics.StageTotal, "unknown", time.Since(decisionStart))
+			writeError(w, http.StatusForbidden, "Token type is not permitted by the border policy")
+			return
+		}
+		metrics.ObserveDecision(metrics.StageBorderPolicyCheck, "", time.Since(borderStart))
+
 		if rawQueryHasToken(r.URL.RawQuery) {
 			if !cfg.RawAllowQueryToken() {
 				metrics.RawRequestTotal.WithLabelValues(owner, repo, "denied_policy").Inc()
+				SetRawAuth(r, "denied_policy")
 				metrics.ObserveDecision(metrics.StageTotal, "unknown", time.Since(decisionStart))
 				writeError(w, http.StatusForbidden,
 					"GitHub-issued query tokens are not permitted (raw.allow_query_token is disabled)")
@@ -199,8 +216,15 @@ func NewRawHandler(cfg *config.Config, enforcer ScopeEnforcer, resolver TokenRes
 			return
 		}
 
-		metrics.RawRequestTotal.WithLabelValues(owner, repo, "anonymous").Inc()
-		SetRawAuth(r, "anonymous")
+		// A credential GHP cannot resolve — a classic PAT or installation token
+		// — is forwarded intact, but it is a different event from a request
+		// that carried nothing at all, and operators need the two apart.
+		rawResult := "anonymous"
+		if rawCredential != "" {
+			rawResult = "foreign_credential"
+		}
+		metrics.RawRequestTotal.WithLabelValues(owner, repo, rawResult).Inc()
+		SetRawAuth(r, rawResult)
 		metrics.ObserveDecision(metrics.StageTotal, "unknown", time.Since(decisionStart))
 		upstreamStart := time.Now()
 		passthrough.ServeHTTP(w, r)
@@ -235,6 +259,8 @@ func serveRawAuthenticated(w http.ResponseWriter, r *http.Request, passthrough h
 		if err != nil && logger != nil {
 			logger.Warn("raw scope enforcement: token resolution failed", "error", err)
 		}
+		metrics.RawRequestTotal.WithLabelValues(owner, repo, "denied_token").Inc()
+		SetRawAuth(r, "denied_token")
 		metrics.ObserveDecision(metrics.StageTotal, resolveTokenType, time.Since(decisionStart))
 		writeError(w, http.StatusUnauthorized, "Invalid token")
 		return
@@ -252,6 +278,8 @@ func serveRawAuthenticated(w http.ResponseWriter, r *http.Request, passthrough h
 		if logger != nil {
 			logger.Error("raw scope enforcement: failed to parse token scope", "error", err)
 		}
+		metrics.RawRequestTotal.WithLabelValues(owner, repo, "error").Inc()
+		SetRawAuth(r, "error")
 		metrics.ObserveDecision(metrics.StageTotal, tokenType, time.Since(decisionStart))
 		writeError(w, http.StatusInternalServerError, "Internal error")
 		return
@@ -263,6 +291,7 @@ func serveRawAuthenticated(w http.ResponseWriter, r *http.Request, passthrough h
 			metrics.ObserveDecision(metrics.StageScopeEnforcement, tokenType, time.Since(scopeEnforceStart))
 			metrics.ObserveDecision(metrics.StageTotal, tokenType, time.Since(decisionStart))
 			metrics.RawRequestTotal.WithLabelValues(owner, repo, "denied_scope").Inc()
+			SetRawAuth(r, "denied_scope")
 			writeError(w, http.StatusForbidden, fmt.Sprintf("Token is not scoped to %s", repoFull))
 			return
 		}
@@ -270,6 +299,7 @@ func serveRawAuthenticated(w http.ResponseWriter, r *http.Request, passthrough h
 			metrics.ObserveDecision(metrics.StageScopeEnforcement, tokenType, time.Since(scopeEnforceStart))
 			metrics.ObserveDecision(metrics.StageTotal, tokenType, time.Since(decisionStart))
 			metrics.RawRequestTotal.WithLabelValues(owner, repo, "denied_scope").Inc()
+			SetRawAuth(r, "denied_scope")
 			writeError(w, http.StatusForbidden,
 				fmt.Sprintf("Token does not have permission for contents:read on %s", repoFull))
 			return
@@ -284,6 +314,8 @@ func serveRawAuthenticated(w http.ResponseWriter, r *http.Request, passthrough h
 		if logger != nil {
 			logger.Warn("raw scope enforcement: GitHub token resolution failed", "error", err)
 		}
+		metrics.RawRequestTotal.WithLabelValues(owner, repo, "denied_token").Inc()
+		SetRawAuth(r, "denied_token")
 		metrics.ObserveDecision(metrics.StageTotal, tokenType, time.Since(decisionStart))
 		writeError(w, http.StatusUnauthorized, "Token resolution failed")
 		return

--- a/internal/proxy/raw_test.go
+++ b/internal/proxy/raw_test.go
@@ -265,10 +265,21 @@ func TestRawHandler_StripsQueryTokenOnAuthenticatedPath(t *testing.T) {
 		{
 			// url.Values.Get cannot see a token smuggled behind a semicolon:
 			// ParseQuery discards any &-segment containing ";", so the parsed
-			// map is empty. Stripping must not be conditional on Get("token").
-			name:       "token smuggled behind a semicolon",
-			target:     "/goodtune/ghp/main/README.md?x=1;token=SECRET",
-			wantAbsent: "SECRET",
+			// map is empty. Stripping must not be conditional on Get("token"),
+			// and the segments that are not the token must survive.
+			name:        "token smuggled behind a semicolon",
+			target:      "/goodtune/ghp/main/README.md?x=1;token=SECRET",
+			wantAbsent:  "SECRET",
+			wantPresent: "x=1",
+		},
+		{
+			// url.Values.Del is exact-case, so an uppercased parameter name
+			// survived the strip. GitHub's query parsing is case-insensitive
+			// on this parameter; ours must be too.
+			name:        "uppercase token parameter",
+			target:      "/goodtune/ghp/main/README.md?TOKEN=SECRET&ref=x",
+			wantAbsent:  "SECRET",
+			wantPresent: "ref=x",
 		},
 	}
 
@@ -395,6 +406,40 @@ func TestRawHandler_ObservesDecisionStages(t *testing.T) {
 		}
 	})
 
+	t.Run("query_token records total and upstream_roundtrip as unknown", func(t *testing.T) {
+		beforeTotal := rawStageCount(t, metrics.StageTotal, "unknown")
+		beforeUpstream := rawStageCount(t, metrics.StageUpstreamRoundtrip, "unknown")
+
+		req := httptest.NewRequest(http.MethodGet, "/goodtune/ghp/main/README.md?token=ABC", nil)
+		newHandler().ServeHTTP(httptest.NewRecorder(), req)
+
+		if got := rawStageCount(t, metrics.StageTotal, "unknown"); got != beforeTotal+1 {
+			t.Errorf("total observations = %d, want %d", got, beforeTotal+1)
+		}
+		if got := rawStageCount(t, metrics.StageUpstreamRoundtrip, "unknown"); got != beforeUpstream+1 {
+			t.Errorf("upstream_roundtrip observations = %d, want %d", got, beforeUpstream+1)
+		}
+	})
+
+	t.Run("denied_policy records total but not upstream_roundtrip", func(t *testing.T) {
+		cfg := &config.Config{}
+		cfg.Raw.AllowQueryToken = false
+		denying := NewRawHandler(cfg, nil, nil, nil, nil, rewriteTransport(t, upstream.URL))
+
+		beforeTotal := rawStageCount(t, metrics.StageTotal, "unknown")
+		beforeUpstream := rawStageCount(t, metrics.StageUpstreamRoundtrip, "unknown")
+
+		req := httptest.NewRequest(http.MethodGet, "/goodtune/ghp/main/README.md?token=ABC", nil)
+		denying.ServeHTTP(httptest.NewRecorder(), req)
+
+		if got := rawStageCount(t, metrics.StageTotal, "unknown"); got != beforeTotal+1 {
+			t.Errorf("total observations = %d, want %d", got, beforeTotal+1)
+		}
+		if got := rawStageCount(t, metrics.StageUpstreamRoundtrip, "unknown"); got != beforeUpstream {
+			t.Errorf("upstream_roundtrip observations = %d, want %d — a denied request never reaches upstream", got, beforeUpstream)
+		}
+	})
+
 	t.Run("token extraction is timed with the real token type", func(t *testing.T) {
 		before := rawStageCount(t, metrics.StageTokenExtraction, string(token.TokenTypeProxy))
 
@@ -406,4 +451,111 @@ func TestRawHandler_ObservesDecisionStages(t *testing.T) {
 			t.Errorf("token_extraction observations = %d, want %d", got, before+1)
 		}
 	})
+}
+
+// TestRawHandler_SemicolonSmuggledQueryToken covers the classification guard.
+// ParseQuery discards any &-segment containing ";", so "?x=1;token=X" parses
+// to an empty map. Classifying on url.Values.Get would push such a request
+// past the policy branch into the anonymous branch, forwarding the
+// GitHub-issued token upstream and counting it as anonymous — an evadable
+// policy control, not the documented "forwarded but not attributed" trade.
+func TestRawHandler_SemicolonSmuggledQueryToken(t *testing.T) {
+	tests := []struct {
+		name            string
+		owner           string
+		repo            string
+		allowQueryToken bool
+		wantStatus      int
+		wantForwarded   bool
+		wantResult      string
+	}{
+		{
+			name:  "denied when policy disallows query tokens",
+			owner: "smugglea", repo: "repoa",
+			allowQueryToken: false,
+			wantStatus:      http.StatusForbidden, wantForwarded: false,
+			wantResult: "denied_policy",
+		},
+		{
+			name:  "classified as query_token when policy allows",
+			owner: "smuggleb", repo: "repob",
+			allowQueryToken: true,
+			wantStatus:      http.StatusOK, wantForwarded: true,
+			wantResult: "query_token",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var forwarded bool
+			upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				forwarded = true
+				w.WriteHeader(http.StatusOK)
+			}))
+			defer upstream.Close()
+
+			cfg := &config.Config{}
+			cfg.Raw.AllowQueryToken = tt.allowQueryToken
+			h := NewRawHandler(cfg, nil, nil, nil, nil, rewriteTransport(t, upstream.URL))
+
+			before := rawCounterValue(t, tt.owner, tt.repo, tt.wantResult)
+			anonBefore := rawCounterValue(t, tt.owner, tt.repo, "anonymous")
+
+			target := "/" + tt.owner + "/" + tt.repo + "/main/f.txt?x=1;token=GITHUBTOKEN"
+			req := httptest.NewRequest(http.MethodGet, target, nil)
+			rec := httptest.NewRecorder()
+			h.ServeHTTP(rec, req)
+
+			if rec.Code != tt.wantStatus {
+				t.Errorf("status = %d, want %d", rec.Code, tt.wantStatus)
+			}
+			if forwarded != tt.wantForwarded {
+				t.Errorf("forwarded = %v, want %v", forwarded, tt.wantForwarded)
+			}
+			if after := rawCounterValue(t, tt.owner, tt.repo, tt.wantResult); after != before+1 {
+				t.Errorf("%s counter = %v, want %v", tt.wantResult, after, before+1)
+			}
+			if after := rawCounterValue(t, tt.owner, tt.repo, "anonymous"); after != anonBefore {
+				t.Errorf("anonymous counter = %v, want %v — smuggled token must not be counted as anonymous", after, anonBefore)
+			}
+		})
+	}
+}
+
+// TestRawQueryToken exercises the token-detection and stripping helpers
+// directly. These back both the raw.allow_query_token policy check and the
+// strip on the authenticated path, so their edge cases are worth pinning down
+// independently of the handler.
+func TestRawQueryToken(t *testing.T) {
+	tests := []struct {
+		name      string
+		rawQuery  string
+		wantHas   bool
+		wantStrip string
+	}{
+		{"empty", "", false, ""},
+		{"no token", "a=1&b=2", false, "a=1&b=2"},
+		{"plain token", "token=X", true, ""},
+		{"token among others", "a=1&token=X&b=2", true, "a=1&b=2"},
+		{"semicolon separated", "x=1;token=X", true, "x=1"},
+		{"semicolon only separator", "token=X;y=2", true, "y=2"},
+		{"uppercase key", "TOKEN=X&a=1", true, "a=1"},
+		{"mixed case key", "ToKeN=X", true, ""},
+		{"percent-encoded key", "%74oken=X&a=1", true, "a=1"},
+		{"token as a value is not a key", "a=token&b=2", false, "a=token&b=2"},
+		{"key prefixed but not equal", "tokenish=X", false, "tokenish=X"},
+		{"bare token key with no value", "token", true, ""},
+		{"repeated token params", "token=X&a=1;token=Y", true, "a=1"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := rawQueryHasToken(tt.rawQuery); got != tt.wantHas {
+				t.Errorf("rawQueryHasToken(%q) = %v, want %v", tt.rawQuery, got, tt.wantHas)
+			}
+			if got := stripRawQueryToken(tt.rawQuery); got != tt.wantStrip {
+				t.Errorf("stripRawQueryToken(%q) = %q, want %q", tt.rawQuery, got, tt.wantStrip)
+			}
+		})
+	}
 }

--- a/internal/proxy/raw_test.go
+++ b/internal/proxy/raw_test.go
@@ -1,0 +1,306 @@
+package proxy
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/goodtune/ghp/internal/config"
+	"github.com/goodtune/ghp/internal/database"
+	"github.com/goodtune/ghp/internal/metrics"
+	"github.com/goodtune/ghp/internal/token"
+)
+
+// rewriteTransport returns a RoundTripper that redirects every request to the
+// given test server, so the reverse proxy under test never makes a real
+// network call.
+func rewriteTransport(t *testing.T, target string) http.RoundTripper {
+	t.Helper()
+	u, err := url.Parse(target)
+	if err != nil {
+		t.Fatalf("parse target: %v", err)
+	}
+	return roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		req = req.Clone(req.Context())
+		req.URL.Scheme = u.Scheme
+		req.URL.Host = u.Host
+		return http.DefaultTransport.RoundTrip(req)
+	})
+}
+
+func TestParseRawPath(t *testing.T) {
+	tests := []struct {
+		name      string
+		path      string
+		wantOwner string
+		wantRepo  string
+		wantOK    bool
+	}{
+		{"classic ref form", "/goodtune/ghp/main/README.md", "goodtune", "ghp", true},
+		{"explicit refs form", "/goodtune/ghp/refs/heads/main/README.md", "goodtune", "ghp", true},
+		{"ref containing slashes", "/goodtune/ghp/feature/x/y/file.txt", "goodtune", "ghp", true},
+		{"nested file path", "/goodtune/ghp/main/a/b/c/d.yaml", "goodtune", "ghp", true},
+		{"casing normalised", "/GoodTune/GHP/main/README.md", "goodtune", "ghp", true},
+		{"leading double slash", "//goodtune/ghp/main/README.md", "goodtune", "ghp", true},
+		{"owner and repo only", "/goodtune/ghp", "", "", false},
+		{"owner only", "/goodtune", "", "", false},
+		{"root", "/", "", "", false},
+		{"empty", "", "", "", false},
+		{"trailing slash no file", "/goodtune/ghp/", "", "", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			owner, repo, ok := parseRawPath(tt.path)
+			if ok != tt.wantOK || owner != tt.wantOwner || repo != tt.wantRepo {
+				t.Errorf("parseRawPath(%q) = (%q, %q, %v), want (%q, %q, %v)",
+					tt.path, owner, repo, ok, tt.wantOwner, tt.wantRepo, tt.wantOK)
+			}
+		})
+	}
+}
+
+func TestRawHandler_UnattributedPaths(t *testing.T) {
+	tests := []struct {
+		name                string
+		method              string
+		target              string
+		allowQueryToken     bool
+		wantStatus          int
+		wantForwarded       bool
+		wantQueryOnUpstream string
+	}{
+		{
+			name:   "anonymous request is forwarded",
+			method: http.MethodGet, target: "/goodtune/ghp/main/README.md",
+			allowQueryToken: true, wantStatus: http.StatusOK, wantForwarded: true,
+		},
+		{
+			name:   "query token forwarded unmodified when allowed",
+			method: http.MethodGet, target: "/goodtune/ghp/main/README.md?token=ABC123",
+			allowQueryToken: true, wantStatus: http.StatusOK, wantForwarded: true,
+			wantQueryOnUpstream: "token=ABC123",
+		},
+		{
+			name:   "query token rejected when policy disallows",
+			method: http.MethodGet, target: "/goodtune/ghp/main/README.md?token=ABC123",
+			allowQueryToken: false, wantStatus: http.StatusForbidden, wantForwarded: false,
+		},
+		{
+			name:   "HEAD is allowed",
+			method: http.MethodHead, target: "/goodtune/ghp/main/README.md",
+			allowQueryToken: true, wantStatus: http.StatusOK, wantForwarded: true,
+		},
+		{
+			name:   "POST is rejected",
+			method: http.MethodPost, target: "/goodtune/ghp/main/README.md",
+			allowQueryToken: true, wantStatus: http.StatusForbidden, wantForwarded: false,
+		},
+		{
+			name:   "non-matching path is forwarded uncounted",
+			method: http.MethodGet, target: "/goodtune/ghp",
+			allowQueryToken: true, wantStatus: http.StatusOK, wantForwarded: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var forwarded bool
+			var upstreamQuery string
+			upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				forwarded = true
+				upstreamQuery = r.URL.RawQuery
+				w.WriteHeader(http.StatusOK)
+			}))
+			defer upstream.Close()
+
+			cfg := &config.Config{}
+			cfg.Raw.AllowQueryToken = tt.allowQueryToken
+
+			h := NewRawHandler(cfg, nil, nil, nil, nil, rewriteTransport(t, upstream.URL))
+
+			req := httptest.NewRequest(tt.method, tt.target, nil)
+			rec := httptest.NewRecorder()
+			h.ServeHTTP(rec, req)
+
+			if rec.Code != tt.wantStatus {
+				t.Errorf("status = %d, want %d", rec.Code, tt.wantStatus)
+			}
+			if forwarded != tt.wantForwarded {
+				t.Errorf("forwarded = %v, want %v", forwarded, tt.wantForwarded)
+			}
+			if tt.wantQueryOnUpstream != "" && upstreamQuery != tt.wantQueryOnUpstream {
+				t.Errorf("upstream query = %q, want %q", upstreamQuery, tt.wantQueryOnUpstream)
+			}
+		})
+	}
+}
+
+// fakeScopeEnforcer resolves any client token to a ProxyToken carrying the
+// given repository allowlist and permission scopes. A nil repos slice or nil
+// scopes map encodes as JSON null, i.e. "no restriction on that dimension" —
+// the same shape the store returns for an unrestricted token.
+type fakeScopeEnforcer struct {
+	pt *database.ProxyToken
+}
+
+func newFakeScopeEnforcer(t *testing.T, repos []string, scopes map[string]string) *fakeScopeEnforcer {
+	t.Helper()
+	reposJSON, err := json.Marshal(repos)
+	if err != nil {
+		t.Fatalf("marshal repos: %v", err)
+	}
+	scopesJSON, err := json.Marshal(scopes)
+	if err != nil {
+		t.Fatalf("marshal scopes: %v", err)
+	}
+	return &fakeScopeEnforcer{pt: &database.ProxyToken{
+		TokenType:    string(token.TokenTypeProxy),
+		Repositories: reposJSON,
+		Scopes:       scopesJSON,
+	}}
+}
+
+func (f *fakeScopeEnforcer) Resolve(ctx context.Context, clientToken string) (*database.ProxyToken, error) {
+	return f.pt, nil
+}
+
+func TestRawHandler_ScopeEnforcement(t *testing.T) {
+	tests := []struct {
+		name           string
+		tokenRepos     []string
+		tokenScopes    map[string]string // permission -> level; nil means unrestricted
+		target         string
+		wantStatus     int
+		wantForwarded  bool
+		wantAuthHeader string
+	}{
+		{
+			name:        "repo in allowlist is forwarded with real credential",
+			tokenRepos:  []string{"goodtune/ghp"},
+			tokenScopes: map[string]string{"contents": "read"},
+			target:      "/goodtune/ghp/main/README.md",
+			wantStatus:  http.StatusOK, wantForwarded: true,
+			wantAuthHeader: "token real-github-token",
+		},
+		{
+			name:        "repo outside allowlist is denied",
+			tokenRepos:  []string{"goodtune/other"},
+			tokenScopes: map[string]string{"contents": "read"},
+			target:      "/goodtune/ghp/main/README.md",
+			wantStatus:  http.StatusForbidden, wantForwarded: false,
+		},
+		{
+			name:        "missing contents permission is denied",
+			tokenRepos:  []string{"goodtune/ghp"},
+			tokenScopes: map[string]string{"issues": "read"},
+			target:      "/goodtune/ghp/main/README.md",
+			wantStatus:  http.StatusForbidden, wantForwarded: false,
+		},
+		{
+			name:       "open scoped token is forwarded",
+			tokenRepos: nil, tokenScopes: nil,
+			target:     "/goodtune/ghp/main/README.md",
+			wantStatus: http.StatusOK, wantForwarded: true,
+			wantAuthHeader: "token real-github-token",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var forwarded bool
+			var gotAuth string
+			upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				forwarded = true
+				gotAuth = r.Header.Get("Authorization")
+				w.WriteHeader(http.StatusOK)
+			}))
+			defer upstream.Close()
+
+			cfg := &config.Config{}
+			cfg.Raw.AllowQueryToken = true
+
+			enforcer := newFakeScopeEnforcer(t, tt.tokenRepos, tt.tokenScopes)
+			resolver := &mockTokenResolver{token: "real-github-token"}
+
+			h := NewRawHandler(cfg, enforcer, resolver, nil, nil, rewriteTransport(t, upstream.URL))
+
+			req := httptest.NewRequest(http.MethodGet, tt.target, nil)
+			req.Header.Set("Authorization", "token "+token.PrefixProxy+"testtoken")
+			rec := httptest.NewRecorder()
+			h.ServeHTTP(rec, req)
+
+			if rec.Code != tt.wantStatus {
+				t.Errorf("status = %d, want %d", rec.Code, tt.wantStatus)
+			}
+			if forwarded != tt.wantForwarded {
+				t.Errorf("forwarded = %v, want %v", forwarded, tt.wantForwarded)
+			}
+			if tt.wantAuthHeader != "" && gotAuth != tt.wantAuthHeader {
+				t.Errorf("upstream Authorization = %q, want %q", gotAuth, tt.wantAuthHeader)
+			}
+		})
+	}
+}
+
+func TestRawHandler_StripsQueryTokenOnAuthenticatedPath(t *testing.T) {
+	var upstreamQuery string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		upstreamQuery = r.URL.RawQuery
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	cfg := &config.Config{}
+	cfg.Raw.AllowQueryToken = true
+	enforcer := newFakeScopeEnforcer(t, nil, nil)
+	resolver := &mockTokenResolver{token: "real-github-token"}
+	h := NewRawHandler(cfg, enforcer, resolver, nil, nil, rewriteTransport(t, upstream.URL))
+
+	req := httptest.NewRequest(http.MethodGet, "/goodtune/ghp/main/README.md?token=GITHUBISSUED&ref=x", nil)
+	req.Header.Set("Authorization", "token "+token.PrefixProxy+"testtoken")
+	h.ServeHTTP(httptest.NewRecorder(), req)
+
+	if strings.Contains(upstreamQuery, "GITHUBISSUED") {
+		t.Errorf("upstream query = %q, GitHub-issued token must be stripped", upstreamQuery)
+	}
+	if !strings.Contains(upstreamQuery, "ref=x") {
+		t.Errorf("upstream query = %q, unrelated params must be preserved", upstreamQuery)
+	}
+}
+
+// rawCounterValue reads the current value of the RawRequestTotal counter for
+// the given label set.
+func rawCounterValue(t *testing.T, owner, repo, result string) float64 {
+	t.Helper()
+	return getCounterValue(t, metrics.RawRequestTotal, prometheus.Labels{
+		"owner":  owner,
+		"repo":   repo,
+		"result": result,
+	})
+}
+
+func TestRawHandler_CountsResults(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	cfg := &config.Config{}
+	cfg.Raw.AllowQueryToken = false
+	h := NewRawHandler(cfg, nil, nil, nil, nil, rewriteTransport(t, upstream.URL))
+
+	before := rawCounterValue(t, "metricsowner", "metricsrepo", "denied_policy")
+	req := httptest.NewRequest(http.MethodGet, "/MetricsOwner/MetricsRepo/main/f.txt?token=X", nil)
+	h.ServeHTTP(httptest.NewRecorder(), req)
+	after := rawCounterValue(t, "metricsowner", "metricsrepo", "denied_policy")
+
+	if after != before+1 {
+		t.Errorf("denied_policy counter = %v, want %v", after, before+1)
+	}
+}

--- a/internal/proxy/raw_test.go
+++ b/internal/proxy/raw_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
 
 	"github.com/goodtune/ghp/internal/config"
 	"github.com/goodtune/ghp/internal/database"
@@ -249,28 +250,54 @@ func TestRawHandler_ScopeEnforcement(t *testing.T) {
 }
 
 func TestRawHandler_StripsQueryTokenOnAuthenticatedPath(t *testing.T) {
-	var upstreamQuery string
-	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		upstreamQuery = r.URL.RawQuery
-		w.WriteHeader(http.StatusOK)
-	}))
-	defer upstream.Close()
-
-	cfg := &config.Config{}
-	cfg.Raw.AllowQueryToken = true
-	enforcer := newFakeScopeEnforcer(t, nil, nil)
-	resolver := &mockTokenResolver{token: "real-github-token"}
-	h := NewRawHandler(cfg, enforcer, resolver, nil, nil, rewriteTransport(t, upstream.URL))
-
-	req := httptest.NewRequest(http.MethodGet, "/goodtune/ghp/main/README.md?token=GITHUBISSUED&ref=x", nil)
-	req.Header.Set("Authorization", "token "+token.PrefixProxy+"testtoken")
-	h.ServeHTTP(httptest.NewRecorder(), req)
-
-	if strings.Contains(upstreamQuery, "GITHUBISSUED") {
-		t.Errorf("upstream query = %q, GitHub-issued token must be stripped", upstreamQuery)
+	tests := []struct {
+		name        string
+		target      string
+		wantAbsent  string
+		wantPresent string
+	}{
+		{
+			name:        "plain token parameter",
+			target:      "/goodtune/ghp/main/README.md?token=GITHUBISSUED&ref=x",
+			wantAbsent:  "GITHUBISSUED",
+			wantPresent: "ref=x",
+		},
+		{
+			// url.Values.Get cannot see a token smuggled behind a semicolon:
+			// ParseQuery discards any &-segment containing ";", so the parsed
+			// map is empty. Stripping must not be conditional on Get("token").
+			name:       "token smuggled behind a semicolon",
+			target:     "/goodtune/ghp/main/README.md?x=1;token=SECRET",
+			wantAbsent: "SECRET",
+		},
 	}
-	if !strings.Contains(upstreamQuery, "ref=x") {
-		t.Errorf("upstream query = %q, unrelated params must be preserved", upstreamQuery)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var upstreamQuery string
+			upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				upstreamQuery = r.URL.RawQuery
+				w.WriteHeader(http.StatusOK)
+			}))
+			defer upstream.Close()
+
+			cfg := &config.Config{}
+			cfg.Raw.AllowQueryToken = true
+			enforcer := newFakeScopeEnforcer(t, nil, nil)
+			resolver := &mockTokenResolver{token: "real-github-token"}
+			h := NewRawHandler(cfg, enforcer, resolver, nil, nil, rewriteTransport(t, upstream.URL))
+
+			req := httptest.NewRequest(http.MethodGet, tt.target, nil)
+			req.Header.Set("Authorization", "token "+token.PrefixProxy+"testtoken")
+			h.ServeHTTP(httptest.NewRecorder(), req)
+
+			if strings.Contains(upstreamQuery, tt.wantAbsent) {
+				t.Errorf("upstream query = %q, GitHub-issued token %q must be stripped", upstreamQuery, tt.wantAbsent)
+			}
+			if tt.wantPresent != "" && !strings.Contains(upstreamQuery, tt.wantPresent) {
+				t.Errorf("upstream query = %q, unrelated params must be preserved (%q)", upstreamQuery, tt.wantPresent)
+			}
+		})
 	}
 }
 
@@ -303,4 +330,80 @@ func TestRawHandler_CountsResults(t *testing.T) {
 	if after != before+1 {
 		t.Errorf("denied_policy counter = %v, want %v", after, before+1)
 	}
+}
+
+// rawStageCount reads the observation count of the decision-pipeline histogram
+// for the given stage and token type.
+func rawStageCount(t *testing.T, stage, tokenType string) uint64 {
+	t.Helper()
+	m := &dto.Metric{}
+	h, err := metrics.ProxyDecisionDuration.GetMetricWith(prometheus.Labels{
+		"stage":      stage,
+		"token_type": tokenType,
+	})
+	if err != nil {
+		t.Fatalf("get histogram for stage %q/%q: %v", stage, tokenType, err)
+	}
+	if err := h.(prometheus.Metric).Write(m); err != nil {
+		t.Fatalf("write histogram for stage %q/%q: %v", stage, tokenType, err)
+	}
+	return m.GetHistogram().GetSampleCount()
+}
+
+// TestRawHandler_ObservesDecisionStages verifies the handler is instrumented on
+// the unattributed paths as well as the enforced one. The unattributed exits
+// record total and upstream_roundtrip under token_type="unknown"; token
+// extraction is timed on every content-path request and carries the real token
+// type when a GHP token is present.
+func TestRawHandler_ObservesDecisionStages(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	newHandler := func() http.Handler {
+		cfg := &config.Config{}
+		cfg.Raw.AllowQueryToken = true
+		return NewRawHandler(cfg, newFakeScopeEnforcer(t, nil, nil),
+			&mockTokenResolver{token: "real-github-token"}, nil, nil,
+			rewriteTransport(t, upstream.URL))
+	}
+
+	t.Run("anonymous records total and upstream_roundtrip as unknown", func(t *testing.T) {
+		beforeTotal := rawStageCount(t, metrics.StageTotal, "unknown")
+		beforeUpstream := rawStageCount(t, metrics.StageUpstreamRoundtrip, "unknown")
+
+		req := httptest.NewRequest(http.MethodGet, "/goodtune/ghp/main/README.md", nil)
+		newHandler().ServeHTTP(httptest.NewRecorder(), req)
+
+		if got := rawStageCount(t, metrics.StageTotal, "unknown"); got != beforeTotal+1 {
+			t.Errorf("total observations = %d, want %d", got, beforeTotal+1)
+		}
+		if got := rawStageCount(t, metrics.StageUpstreamRoundtrip, "unknown"); got != beforeUpstream+1 {
+			t.Errorf("upstream_roundtrip observations = %d, want %d", got, beforeUpstream+1)
+		}
+	})
+
+	t.Run("denied_method records total", func(t *testing.T) {
+		before := rawStageCount(t, metrics.StageTotal, "unknown")
+
+		req := httptest.NewRequest(http.MethodPost, "/goodtune/ghp/main/README.md", nil)
+		newHandler().ServeHTTP(httptest.NewRecorder(), req)
+
+		if got := rawStageCount(t, metrics.StageTotal, "unknown"); got != before+1 {
+			t.Errorf("total observations = %d, want %d", got, before+1)
+		}
+	})
+
+	t.Run("token extraction is timed with the real token type", func(t *testing.T) {
+		before := rawStageCount(t, metrics.StageTokenExtraction, string(token.TokenTypeProxy))
+
+		req := httptest.NewRequest(http.MethodGet, "/goodtune/ghp/main/README.md", nil)
+		req.Header.Set("Authorization", "token "+token.PrefixProxy+"testtoken")
+		newHandler().ServeHTTP(httptest.NewRecorder(), req)
+
+		if got := rawStageCount(t, metrics.StageTokenExtraction, string(token.TokenTypeProxy)); got != before+1 {
+			t.Errorf("token_extraction observations = %d, want %d", got, before+1)
+		}
+	})
 }

--- a/internal/proxy/raw_test.go
+++ b/internal/proxy/raw_test.go
@@ -2,7 +2,9 @@ package proxy
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -102,11 +104,6 @@ func TestRawHandler_UnattributedPaths(t *testing.T) {
 			method: http.MethodPost, target: "/goodtune/ghp/main/README.md",
 			allowQueryToken: true, wantStatus: http.StatusForbidden, wantForwarded: false,
 		},
-		{
-			name:   "non-matching path is forwarded uncounted",
-			method: http.MethodGet, target: "/goodtune/ghp",
-			allowQueryToken: true, wantStatus: http.StatusOK, wantForwarded: true,
-		},
 	}
 
 	for _, tt := range tests {
@@ -139,6 +136,365 @@ func TestRawHandler_UnattributedPaths(t *testing.T) {
 				t.Errorf("upstream query = %q, want %q", upstreamQuery, tt.wantQueryOnUpstream)
 			}
 		})
+	}
+}
+
+// TestRawHandler_NonMatchingPathIsUncounted pins the documented behaviour that
+// a path with fewer than three segments is forwarded without touching
+// RawRequestTotal: the owner/repo labels come from a client-controlled path, so
+// counting requests that were never classified would let a caller mint series
+// for paths that are not repositories at all.
+func TestRawHandler_NonMatchingPathIsUncounted(t *testing.T) {
+	var forwarded bool
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		forwarded = true
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	cfg := &config.Config{}
+	cfg.Raw.AllowQueryToken = true
+	h := NewRawHandler(cfg, nil, nil, nil, nil, rewriteTransport(t, upstream.URL))
+
+	results := []string{
+		"authenticated", "query_token", "anonymous", "foreign_credential",
+		"denied_scope", "denied_policy", "denied_method", "denied_border",
+		"denied_token", "error",
+	}
+	before := make(map[string]float64, len(results))
+	for _, result := range results {
+		before[result] = rawCounterValue(t, "uncounted", "path", result)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/uncounted/path", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusOK)
+	}
+	if !forwarded {
+		t.Error("forwarded = false, want true")
+	}
+	for _, result := range results {
+		if after := rawCounterValue(t, "uncounted", "path", result); after != before[result] {
+			t.Errorf("%s counter = %v, want %v — a non-matching path must not be counted", result, after, before[result])
+		}
+	}
+}
+
+// TestRawHandler_ForeignCredential covers a GitHub credential ghp did not issue
+// (a classic PAT or installation token in Authorization). It is forwarded
+// intact — ghp cannot resolve or scope-check it — but it is a distinct event
+// from a genuinely credential-free request and must be counted separately.
+func TestRawHandler_ForeignCredential(t *testing.T) {
+	tests := []struct {
+		name       string
+		owner      string
+		repo       string
+		authHeader string
+	}{
+		{"classic PAT", "foreigna", "repoa", "token ghp_classicpat"},
+		{"installation token", "foreignb", "repob", "Bearer ghs_installationtoken"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var gotAuth string
+			var forwarded bool
+			upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				forwarded = true
+				gotAuth = r.Header.Get("Authorization")
+				w.WriteHeader(http.StatusOK)
+			}))
+			defer upstream.Close()
+
+			cfg := &config.Config{}
+			cfg.Raw.AllowQueryToken = true
+			h := NewRawHandler(cfg, nil, nil, nil, nil, rewriteTransport(t, upstream.URL))
+
+			before := rawCounterValue(t, tt.owner, tt.repo, "foreign_credential")
+			anonBefore := rawCounterValue(t, tt.owner, tt.repo, "anonymous")
+
+			req := httptest.NewRequest(http.MethodGet, "/"+tt.owner+"/"+tt.repo+"/main/f.txt", nil)
+			req.Header.Set("Authorization", tt.authHeader)
+			req, slots := PrepareAccessLogSlots(req)
+			rec := httptest.NewRecorder()
+			h.ServeHTTP(rec, req)
+
+			if rec.Code != http.StatusOK {
+				t.Errorf("status = %d, want %d", rec.Code, http.StatusOK)
+			}
+			if !forwarded {
+				t.Fatal("forwarded = false, want true")
+			}
+			if gotAuth != tt.authHeader {
+				t.Errorf("upstream Authorization = %q, want %q — a foreign credential is forwarded intact", gotAuth, tt.authHeader)
+			}
+			if after := rawCounterValue(t, tt.owner, tt.repo, "foreign_credential"); after != before+1 {
+				t.Errorf("foreign_credential counter = %v, want %v", after, before+1)
+			}
+			if after := rawCounterValue(t, tt.owner, tt.repo, "anonymous"); after != anonBefore {
+				t.Errorf("anonymous counter = %v, want %v — a request carrying a credential is not anonymous", after, anonBefore)
+			}
+			if got := *slots.RawAuth; got != "foreign_credential" {
+				t.Errorf("ghp.raw.auth = %q, want %q", got, "foreign_credential")
+			}
+		})
+	}
+}
+
+// TestRawHandler_BorderPolicy verifies the token type border policy is enforced
+// on raw. Before this handler existed, raw.githubusercontent.com did not route
+// anywhere, so block.ghp closed the path by absence; forwarding a blocked
+// credential here would reopen it.
+func TestRawHandler_BorderPolicy(t *testing.T) {
+	tests := []struct {
+		name          string
+		owner         string
+		repo          string
+		authHeader    string
+		blockGHP      bool
+		blockGHS      bool
+		wantStatus    int
+		wantForwarded bool
+		wantResult    string
+	}{
+		{
+			name:  "blocked classic PAT is rejected",
+			owner: "bordera", repo: "repoa",
+			authHeader: "token ghp_classicpat", blockGHP: true,
+			wantStatus: http.StatusForbidden, wantForwarded: false,
+			wantResult: "denied_border",
+		},
+		{
+			name:  "blocked installation token in basic auth is rejected",
+			owner: "borderb", repo: "repob",
+			authHeader: "Basic " + base64.StdEncoding.EncodeToString([]byte("x-access-token:ghs_installationtoken")),
+			blockGHS:   true,
+			wantStatus: http.StatusForbidden, wantForwarded: false,
+			wantResult: "denied_border",
+		},
+		{
+			name:  "unblocked credential is forwarded",
+			owner: "borderc", repo: "repoc",
+			authHeader: "token ghp_classicpat", blockGHP: false,
+			wantStatus: http.StatusOK, wantForwarded: true,
+			wantResult: "foreign_credential",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var forwarded bool
+			upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				forwarded = true
+				w.WriteHeader(http.StatusOK)
+			}))
+			defer upstream.Close()
+
+			cfg := &config.Config{}
+			cfg.Raw.AllowQueryToken = true
+			cfg.Block.GHP = tt.blockGHP
+			cfg.Block.GHS = tt.blockGHS
+			h := NewRawHandler(cfg, nil, nil, nil, nil, rewriteTransport(t, upstream.URL))
+
+			before := rawCounterValue(t, tt.owner, tt.repo, tt.wantResult)
+			beforeBorder := rawStageCount(t, metrics.StageBorderPolicyCheck, "unknown")
+
+			req := httptest.NewRequest(http.MethodGet, "/"+tt.owner+"/"+tt.repo+"/main/f.txt", nil)
+			req.Header.Set("Authorization", tt.authHeader)
+			rec := httptest.NewRecorder()
+			h.ServeHTTP(rec, req)
+
+			if rec.Code != tt.wantStatus {
+				t.Errorf("status = %d, want %d", rec.Code, tt.wantStatus)
+			}
+			if forwarded != tt.wantForwarded {
+				t.Errorf("forwarded = %v, want %v", forwarded, tt.wantForwarded)
+			}
+			if after := rawCounterValue(t, tt.owner, tt.repo, tt.wantResult); after != before+1 {
+				t.Errorf("%s counter = %v, want %v", tt.wantResult, after, before+1)
+			}
+			if after := rawStageCount(t, metrics.StageBorderPolicyCheck, "unknown"); after != beforeBorder+1 {
+				t.Errorf("border_policy_check observations = %d, want %d", after, beforeBorder+1)
+			}
+		})
+	}
+}
+
+// TestRawHandler_BorderPolicyPrecedesQueryToken pins the ordering: a blocked
+// Authorization credential is rejected even when the request also carries a
+// GitHub-issued ?token= that the query-token branch would otherwise forward.
+func TestRawHandler_BorderPolicyPrecedesQueryToken(t *testing.T) {
+	var forwarded bool
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		forwarded = true
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	cfg := &config.Config{}
+	cfg.Raw.AllowQueryToken = true
+	cfg.Block.GHP = true
+	h := NewRawHandler(cfg, nil, nil, nil, nil, rewriteTransport(t, upstream.URL))
+
+	before := rawCounterValue(t, "borderq", "repoq", "denied_border")
+	queryBefore := rawCounterValue(t, "borderq", "repoq", "query_token")
+
+	req := httptest.NewRequest(http.MethodGet, "/borderq/repoq/main/f.txt?token=ABC", nil)
+	req.Header.Set("Authorization", "token ghp_classicpat")
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusForbidden)
+	}
+	if forwarded {
+		t.Error("forwarded = true, want false")
+	}
+	if after := rawCounterValue(t, "borderq", "repoq", "denied_border"); after != before+1 {
+		t.Errorf("denied_border counter = %v, want %v", after, before+1)
+	}
+	if after := rawCounterValue(t, "borderq", "repoq", "query_token"); after != queryBefore {
+		t.Errorf("query_token counter = %v, want %v — the border policy is evaluated first", after, queryBefore)
+	}
+}
+
+// errScopeEnforcer fails every resolution, standing in for a revoked, expired,
+// or forged GHP token.
+type errScopeEnforcer struct{ err error }
+
+func (e *errScopeEnforcer) Resolve(ctx context.Context, clientToken string) (*database.ProxyToken, error) {
+	return nil, e.err
+}
+
+// TestRawHandler_CountsDeniedTokenAndError covers the exits that reject or fail
+// a GHP-issued token. An agent presenting a revoked token must move a counter:
+// this backend's stated purpose includes observability, and a silent 401 is
+// exactly the event an operator needs to see.
+func TestRawHandler_CountsDeniedTokenAndError(t *testing.T) {
+	tests := []struct {
+		name       string
+		owner      string
+		repo       string
+		enforcer   ScopeEnforcer
+		resolver   TokenResolver
+		wantStatus int
+		wantResult string
+	}{
+		{
+			name:  "token resolution failure",
+			owner: "exita", repo: "repoa",
+			enforcer:   &errScopeEnforcer{err: errors.New("revoked")},
+			resolver:   &mockTokenResolver{token: "real-github-token"},
+			wantStatus: http.StatusUnauthorized, wantResult: "denied_token",
+		},
+		{
+			name:  "unknown token resolves to nil",
+			owner: "exitb", repo: "repob",
+			enforcer:   &errScopeEnforcer{},
+			resolver:   &mockTokenResolver{token: "real-github-token"},
+			wantStatus: http.StatusUnauthorized, wantResult: "denied_token",
+		},
+		{
+			name:  "corrupt scope JSON",
+			owner: "exitc", repo: "repoc",
+			enforcer: &fakeScopeEnforcer{pt: &database.ProxyToken{
+				TokenType:    string(token.TokenTypeProxy),
+				Repositories: []byte(`{"not":"a list"}`),
+				Scopes:       []byte(`null`),
+			}},
+			resolver:   &mockTokenResolver{token: "real-github-token"},
+			wantStatus: http.StatusInternalServerError, wantResult: "error",
+		},
+		{
+			name:  "GitHub credential resolution failure",
+			owner: "exitd", repo: "repod",
+			enforcer:   newFakeScopeEnforcer(t, nil, nil),
+			resolver:   &mockTokenResolver{err: errors.New("decrypt failed")},
+			wantStatus: http.StatusUnauthorized, wantResult: "denied_token",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var forwarded bool
+			upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				forwarded = true
+				w.WriteHeader(http.StatusOK)
+			}))
+			defer upstream.Close()
+
+			cfg := &config.Config{}
+			cfg.Raw.AllowQueryToken = true
+			h := NewRawHandler(cfg, tt.enforcer, tt.resolver, nil, nil, rewriteTransport(t, upstream.URL))
+
+			before := rawCounterValue(t, tt.owner, tt.repo, tt.wantResult)
+
+			req := httptest.NewRequest(http.MethodGet, "/"+tt.owner+"/"+tt.repo+"/main/f.txt", nil)
+			req.Header.Set("Authorization", "token "+token.PrefixProxy+"testtoken")
+			req, slots := PrepareAccessLogSlots(req)
+			rec := httptest.NewRecorder()
+			h.ServeHTTP(rec, req)
+
+			if rec.Code != tt.wantStatus {
+				t.Errorf("status = %d, want %d", rec.Code, tt.wantStatus)
+			}
+			if forwarded {
+				t.Error("forwarded = true, want false — a rejected token never reaches upstream")
+			}
+			if after := rawCounterValue(t, tt.owner, tt.repo, tt.wantResult); after != before+1 {
+				t.Errorf("%s counter = %v, want %v", tt.wantResult, after, before+1)
+			}
+			if got := *slots.RawAuth; got != tt.wantResult {
+				t.Errorf("ghp.raw.auth = %q, want %q", got, tt.wantResult)
+			}
+		})
+	}
+}
+
+// TestRawHandler_AgentToken covers the gha_ prefix on the enforced path. Every
+// other authenticated test uses ghx_; the two prefixes take the same branch but
+// carry different token types through the decision metrics.
+func TestRawHandler_AgentToken(t *testing.T) {
+	var gotAuth string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	cfg := &config.Config{}
+	cfg.Raw.AllowQueryToken = true
+	enforcer := newFakeScopeEnforcer(t, []string{"agentowner/agentrepo"}, map[string]string{"contents": "read"})
+	enforcer.pt.TokenType = string(token.TokenTypeAgent)
+	h := NewRawHandler(cfg, enforcer, &mockTokenResolver{token: "real-github-token"}, nil, nil,
+		rewriteTransport(t, upstream.URL))
+
+	before := rawCounterValue(t, "agentowner", "agentrepo", "authenticated")
+	beforeExtract := rawStageCount(t, metrics.StageTokenExtraction, string(token.TokenTypeAgent))
+
+	req := httptest.NewRequest(http.MethodGet, "/agentowner/agentrepo/main/README.md", nil)
+	req.Header.Set("Authorization", "Bearer "+token.PrefixAgent+"testtoken")
+	req, slots := PrepareAccessLogSlots(req)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusOK)
+	}
+	if gotAuth != "Bearer real-github-token" {
+		t.Errorf("upstream Authorization = %q, want %q", gotAuth, "Bearer real-github-token")
+	}
+	if after := rawCounterValue(t, "agentowner", "agentrepo", "authenticated"); after != before+1 {
+		t.Errorf("authenticated counter = %v, want %v", after, before+1)
+	}
+	if after := rawStageCount(t, metrics.StageTokenExtraction, string(token.TokenTypeAgent)); after != beforeExtract+1 {
+		t.Errorf("token_extraction observations for %s = %d, want %d", token.TokenTypeAgent, after, beforeExtract+1)
+	}
+	if got := *slots.RawAuth; got != "proxy_token" {
+		t.Errorf("ghp.raw.auth = %q, want %q", got, "proxy_token")
 	}
 }
 
@@ -180,6 +536,7 @@ func TestRawHandler_ScopeEnforcement(t *testing.T) {
 		wantStatus     int
 		wantForwarded  bool
 		wantAuthHeader string
+		wantResult     string
 	}{
 		{
 			name:        "repo in allowlist is forwarded with real credential",
@@ -188,6 +545,7 @@ func TestRawHandler_ScopeEnforcement(t *testing.T) {
 			target:      "/goodtune/ghp/main/README.md",
 			wantStatus:  http.StatusOK, wantForwarded: true,
 			wantAuthHeader: "token real-github-token",
+			wantResult:     "authenticated",
 		},
 		{
 			name:        "repo outside allowlist is denied",
@@ -195,6 +553,7 @@ func TestRawHandler_ScopeEnforcement(t *testing.T) {
 			tokenScopes: map[string]string{"contents": "read"},
 			target:      "/goodtune/ghp/main/README.md",
 			wantStatus:  http.StatusForbidden, wantForwarded: false,
+			wantResult: "denied_scope",
 		},
 		{
 			name:        "missing contents permission is denied",
@@ -202,6 +561,7 @@ func TestRawHandler_ScopeEnforcement(t *testing.T) {
 			tokenScopes: map[string]string{"issues": "read"},
 			target:      "/goodtune/ghp/main/README.md",
 			wantStatus:  http.StatusForbidden, wantForwarded: false,
+			wantResult: "denied_scope",
 		},
 		{
 			name:       "open scoped token is forwarded",
@@ -209,6 +569,7 @@ func TestRawHandler_ScopeEnforcement(t *testing.T) {
 			target:     "/goodtune/ghp/main/README.md",
 			wantStatus: http.StatusOK, wantForwarded: true,
 			wantAuthHeader: "token real-github-token",
+			wantResult:     "authenticated",
 		},
 	}
 
@@ -231,8 +592,11 @@ func TestRawHandler_ScopeEnforcement(t *testing.T) {
 
 			h := NewRawHandler(cfg, enforcer, resolver, nil, nil, rewriteTransport(t, upstream.URL))
 
+			before := rawCounterValue(t, "goodtune", "ghp", tt.wantResult)
+
 			req := httptest.NewRequest(http.MethodGet, tt.target, nil)
 			req.Header.Set("Authorization", "token "+token.PrefixProxy+"testtoken")
+			req, slots := PrepareAccessLogSlots(req)
 			rec := httptest.NewRecorder()
 			h.ServeHTTP(rec, req)
 
@@ -244,6 +608,17 @@ func TestRawHandler_ScopeEnforcement(t *testing.T) {
 			}
 			if tt.wantAuthHeader != "" && gotAuth != tt.wantAuthHeader {
 				t.Errorf("upstream Authorization = %q, want %q", gotAuth, tt.wantAuthHeader)
+			}
+			if after := rawCounterValue(t, "goodtune", "ghp", tt.wantResult); after != before+1 {
+				t.Errorf("%s counter = %v, want %v", tt.wantResult, after, before+1)
+			}
+			wantAuth := tt.wantResult
+			if wantAuth == "authenticated" {
+				// The log records the credential kind, the metric the outcome.
+				wantAuth = "proxy_token"
+			}
+			if got := *slots.RawAuth; got != wantAuth {
+				t.Errorf("ghp.raw.auth = %q, want %q", got, wantAuth)
 			}
 		})
 	}

--- a/internal/server/accesslog.go
+++ b/internal/server/accesslog.go
@@ -3,6 +3,7 @@ package server
 import (
 	"net"
 	"net/http"
+	"net/url"
 	"strconv"
 	"strings"
 	"time"
@@ -123,7 +124,7 @@ func accessLogHandler(backend string, next http.Handler, aw *accessLogWriter) ht
 			}
 		}
 		if q := r.URL.RawQuery; q != "" {
-			attrs = append(attrs, otellog.String(attrURLQuery, q))
+			attrs = append(attrs, otellog.String(attrURLQuery, redactedQuery(q)))
 		}
 		if ua := r.UserAgent(); ua != "" {
 			attrs = append(attrs, otellog.String(attrUserAgentOriginal, ua))
@@ -198,6 +199,47 @@ func redactRequestHeader(name string) bool {
 
 func redactResponseHeader(name string) bool {
 	return name == "set-cookie"
+}
+
+// redactQueryParam reports whether a URL query parameter's value must be
+// redacted from access logs. GitHub's contents API returns download_url
+// values carrying a ?token= blob capability that remains valid for days —
+// logging it verbatim would persist a usable credential in the log stream.
+func redactQueryParam(name string) bool {
+	switch strings.ToLower(name) {
+	case "token", "access_token", "client_secret":
+		return true
+	default:
+		return false
+	}
+}
+
+// redactedQuery returns rawQuery with the values of sensitive parameters
+// replaced by the same placeholder used for headers. Parameter order is
+// preserved so the logged value stays comparable to the request.
+//
+// If rawQuery cannot be parsed, the entire query is redacted rather than
+// emitted verbatim: a malformed query may still carry a credential, and
+// failing closed is cheaper than leaking one.
+func redactedQuery(rawQuery string) string {
+	if rawQuery == "" {
+		return ""
+	}
+	if _, err := url.ParseQuery(rawQuery); err != nil {
+		return "REDACTED"
+	}
+	parts := strings.Split(rawQuery, "&")
+	for i, part := range parts {
+		name, _, _ := strings.Cut(part, "=")
+		decoded, err := url.QueryUnescape(name)
+		if err != nil {
+			decoded = name
+		}
+		if redactQueryParam(decoded) {
+			parts[i] = name + "=REDACTED"
+		}
+	}
+	return strings.Join(parts, "&")
 }
 
 func requestScheme(r *http.Request) string {

--- a/internal/server/accesslog.go
+++ b/internal/server/accesslog.go
@@ -138,6 +138,9 @@ func accessLogHandler(backend string, next http.Handler, aw *accessLogWriter) ht
 		if *slots.CacheRepo != "" {
 			attrs = append(attrs, otellog.String(attrGHPCacheRepo, *slots.CacheRepo))
 		}
+		if *slots.RawAuth != "" {
+			attrs = append(attrs, otellog.String(attrGHPRawAuth, *slots.RawAuth))
+		}
 
 		// Request and response headers, redacting sensitive values, captured
 		// under the http.request.header.* / http.response.header.* conventions.

--- a/internal/server/accesslog.go
+++ b/internal/server/accesslog.go
@@ -228,6 +228,10 @@ func redactedQuery(rawQuery string) string {
 	if rawQuery == "" {
 		return ""
 	}
+	// ParseQuery is used only as a validity check; the parsed values are
+	// deliberately discarded. Redaction then works on the raw string so that
+	// parameter order is preserved in the log — reusing the parsed map would
+	// silently sort keys and rewrite encodings.
 	if _, err := url.ParseQuery(rawQuery); err != nil {
 		return "REDACTED"
 	}

--- a/internal/server/accesslog_test.go
+++ b/internal/server/accesslog_test.go
@@ -341,6 +341,11 @@ func TestRedactedQuery(t *testing.T) {
 		{"repeated param", "token=a&token=b", "token=REDACTED&token=REDACTED"},
 		{"valueless param", "token", "token=REDACTED"},
 		{"unparseable is redacted wholesale", "%zz&token=abc", "REDACTED"},
+		// Go's url.ParseQuery has rejected ";" as a separator since Go 1.17
+		// (https://go.dev/issue/25192), so a semicolon-separated query never
+		// reaches the "&"-based split below — it fails ParseQuery and is
+		// redacted wholesale by the branch above.
+		{"semicolon separator is redacted wholesale", "x=1;token=SECRET", "REDACTED"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/server/accesslog_test.go
+++ b/internal/server/accesslog_test.go
@@ -253,6 +253,53 @@ func TestAccessLog_UserIDFallsBackToUsername(t *testing.T) {
 	}
 }
 
+func TestAccessLog_RawAuthSlot(t *testing.T) {
+	t.Run("emits ghp.raw.auth when the slot is set", func(t *testing.T) {
+		logger, exp := newCaptureLogger(t)
+		aw := newAccessLogWriter(logger)
+
+		inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			proxy.SetRawAuth(r, "query_token")
+			w.WriteHeader(http.StatusOK)
+		})
+
+		handler := accessLogHandler(backend.API, inner, aw)
+
+		req := httptest.NewRequest("GET", "http://ghp.example.com/o/r/main/f.txt", nil)
+		rr := httptest.NewRecorder()
+
+		handler.ServeHTTP(rr, req)
+
+		rec := exp.only(t)
+
+		if got := rec.str(t, attrGHPRawAuth); got != "query_token" {
+			t.Errorf("%s: got %q, want query_token", attrGHPRawAuth, got)
+		}
+	})
+
+	t.Run("omits ghp.raw.auth when the slot is untouched", func(t *testing.T) {
+		logger, exp := newCaptureLogger(t)
+		aw := newAccessLogWriter(logger)
+
+		inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		})
+
+		handler := accessLogHandler(backend.Mgmt, inner, aw)
+
+		req := httptest.NewRequest("GET", "http://ghp.example.com/admin", nil)
+		rr := httptest.NewRecorder()
+
+		handler.ServeHTTP(rr, req)
+
+		rec := exp.only(t)
+
+		if rec.has(attrGHPRawAuth) {
+			t.Errorf("%s: present, want absent for non-raw backend", attrGHPRawAuth)
+		}
+	})
+}
+
 func TestAccessLog_ErrorLevel(t *testing.T) {
 	logger, exp := newCaptureLogger(t)
 	aw := newAccessLogWriter(logger)

--- a/internal/server/accesslog_test.go
+++ b/internal/server/accesslog_test.go
@@ -3,6 +3,7 @@ package server
 import (
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	otellog "go.opentelemetry.io/otel/log"
@@ -274,5 +275,53 @@ func TestAccessLog_ErrorLevel(t *testing.T) {
 	}
 	if got := rec.int(t, attrHTTPResponseStatusCode); got != 500 {
 		t.Errorf("%s: got %d, want 500", attrHTTPResponseStatusCode, got)
+	}
+}
+
+func TestRedactedQuery(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"empty", "", ""},
+		{"no sensitive params", "ref=main&path=README.md", "ref=main&path=README.md"},
+		{"github blob token", "token=AACGATXPAI3FK7WLHZDREQLKMR6GLAA", "token=REDACTED"},
+		{"access_token", "access_token=abc123", "access_token=REDACTED"},
+		{"client_secret", "client_secret=shhh", "client_secret=REDACTED"},
+		{"mixed", "ref=main&token=abc&page=2", "ref=main&token=REDACTED&page=2"},
+		{"case insensitive name", "TOKEN=abc", "TOKEN=REDACTED"},
+		{"repeated param", "token=a&token=b", "token=REDACTED&token=REDACTED"},
+		{"valueless param", "token", "token=REDACTED"},
+		{"unparseable is redacted wholesale", "%zz&token=abc", "REDACTED"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := redactedQuery(tt.in); got != tt.want {
+				t.Errorf("redactedQuery(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestAccessLogHandler_RedactsQueryToken(t *testing.T) {
+	logger, exp := newCaptureLogger(t)
+	aw := newAccessLogWriter(logger)
+
+	h := accessLogHandler(backend.Codeload, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}), aw)
+
+	req := httptest.NewRequest(http.MethodGet, "/o/r/main/README.md?token=SECRETVALUE123", nil)
+	h.ServeHTTP(httptest.NewRecorder(), req)
+
+	rec := exp.only(t)
+
+	got := rec.str(t, attrURLQuery)
+	if strings.Contains(got, "SECRETVALUE123") {
+		t.Errorf("%s = %q, must not contain the token value", attrURLQuery, got)
+	}
+	if got != "token=REDACTED" {
+		t.Errorf("%s = %q, want %q", attrURLQuery, got, "token=REDACTED")
 	}
 }

--- a/internal/server/semconv.go
+++ b/internal/server/semconv.go
@@ -33,6 +33,7 @@ const (
 	attrGHPBackend     = "ghp.backend"
 	attrGHPCacheState  = "ghp.cache.state"
 	attrGHPCacheRepo   = "ghp.cache.repo"
+	attrGHPRawAuth     = "ghp.raw.auth"
 	attrGHPAuditAction = "ghp.audit.action"
 	attrGHPUserName    = "ghp.user.name"
 	attrGHPTokenID     = "ghp.token.id"

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -456,6 +456,8 @@ func (s *Server) Run(ctx context.Context) error {
 
 	codeloadHandler := proxy.NewCodeloadHandler(s.cfg, s.logger, nil)
 
+	rawHandler := proxy.NewRawHandler(s.cfg, tokenSvc, proxyTokenResolver, usernameResolver, s.logger, nil)
+
 	copilotPassthrough := proxy.NewCopilotPassthroughHandler(
 		"https://copilot-proxy.githubusercontent.com", s.cfg.GitHub.EnterpriseSlug, s.logger, nil)
 
@@ -468,6 +470,7 @@ func (s *Server) Run(ctx context.Context) error {
 		githubHandler:   accessLogHandler(backend.GitHub, githubPassthrough, aw),
 		codeloadHandler: accessLogHandler(backend.Codeload, codeloadHandler, aw),
 		copilotHandler:  accessLogHandler(backend.Copilot, copilotPassthrough, aw),
+		rawHandler:      accessLogHandler(backend.Raw, rawHandler, aw),
 		mgmtHandler:     accessLogHandler(backend.Mgmt, web.SessionUsernameMiddleware(authHandler)(web.SecurityHeadersMiddleware(mux)), aw),
 		managementHost:  s.cfg.Server.ManagementHost,
 	})
@@ -743,6 +746,7 @@ type hostDispatchConfig struct {
 	githubHandler   http.Handler
 	codeloadHandler http.Handler
 	copilotHandler  http.Handler
+	rawHandler      http.Handler
 	mgmtHandler     http.Handler
 	managementHost  string
 }
@@ -768,6 +772,8 @@ func newHostDispatch(cfg hostDispatchConfig) http.Handler {
 			cfg.githubHandler.ServeHTTP(w, r)
 		case host == backend.Codeload:
 			cfg.codeloadHandler.ServeHTTP(w, r)
+		case host == backend.Raw:
+			cfg.rawHandler.ServeHTTP(w, r)
 		case host == "githubcopilot.com" || strings.HasSuffix(host, ".githubcopilot.com"):
 			cfg.copilotHandler.ServeHTTP(w, r)
 		case cfg.managementHost == "" || strings.EqualFold(host, cfg.managementHost):

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -141,6 +141,34 @@ func TestServerHeaderAllBackends(t *testing.T) {
 	}
 }
 
+func TestHostDispatch_Raw(t *testing.T) {
+	var hit string
+	mark := func(name string) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { hit = name })
+	}
+	d := newHostDispatch(hostDispatchConfig{
+		apiHandler:      mark("api"),
+		githubHandler:   mark("github"),
+		codeloadHandler: mark("codeload"),
+		copilotHandler:  mark("copilot"),
+		rawHandler:      mark("raw"),
+		mgmtHandler:     mark("mgmt"),
+		managementHost:  "ghp.example.com",
+	})
+
+	for _, host := range []string{"raw.githubusercontent.com", "RAW.GithubUserContent.com", "raw.githubusercontent.com:443"} {
+		t.Run(host, func(t *testing.T) {
+			hit = ""
+			req := httptest.NewRequest(http.MethodGet, "/o/r/main/f.txt", nil)
+			req.Host = host
+			d.ServeHTTP(httptest.NewRecorder(), req)
+			if hit != "raw" {
+				t.Errorf("host %q routed to %q, want %q", host, hit, "raw")
+			}
+		})
+	}
+}
+
 func TestHostDispatch_EmptyManagementHost(t *testing.T) {
 	mgmtHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Write([]byte("mgmt"))


### PR DESCRIPTION
Adds a `raw.githubusercontent.com` backend so agents holding `ghx_`/`gha_` tokens can fetch raw file URLs, and so that traffic is scope-enforced, logged, and counted instead of collapsing into a single `CONNECT` line in a squid log.

## Why

Research findings that motivated this, verified against a private repo:

- **Raw accepts header auth.** `Authorization: token`, `Bearer`, and Basic (`user:token` and `x-access-token:token`) all return 200; no credential and invalid credentials both return 404, masking existence.
- **Raw is explicitly exempt from enterprise header enforcement.** GitHub scopes `sec-GitHub-allowed-enterprise` to `github.com`, `api.github.com`, and `*.githubcopilot.com`. `*.githubusercontent.com` is listed under "Endpoints that don't require restriction" — the rationale being that such endpoints "only provide data, and do not accept it." That threat model addresses ingress into personal accounts; read-only egress of private repo content via a personal token is out of scope by design.
- **Raw returns no `X-RateLimit-*` headers**, so quota consumed there is invisible to GHP.

An enterprise that believes the corporate-proxy header has closed off personal-account use still has this path open.

## Design

The governing principle, now recorded in `CLAUDE.md`:

> GHP is an enforcement point for tokens it issued and a telemetry point for everything else.

Requests are classified in order after path parsing and a GET/HEAD check:

| Inbound | Behaviour | Result |
| --- | --- | --- |
| GHP-issued token | Repo allowlist + `contents:read` enforced; any GitHub-issued `?token=` stripped; forwarded with the resolved credential | `authenticated` |
| Blocked token type | Border policy rejects before forwarding | `denied_border` |
| GitHub-issued `?token=` | Forwarded unmodified, or 403 when `raw.allow_query_token: false` | `query_token` / `denied_policy` |
| Unresolvable credential | Forwarded unmodified, unattributable | `foreign_credential` |
| No credential | Forwarded | `anonymous` |

Only the first is enforced. The rest are observed. That asymmetry is deliberate and documented, including the limitation that a repo-A token can still reach repo B's content via a GitHub-issued `?token=` unless the policy is disabled.

Owner/repo come from the first two path segments only, so `/{owner}/{repo}/{ref}/{path}` and `/{owner}/{repo}/refs/heads/{branch}/{path}` resolve identically without parsing the ref.

## Notable during review

- **Query-token detection cannot use `url.Values`.** Go's `ParseQuery` silently drops any segment containing `;`, which made both the strip and the `allow_query_token` policy bypassable via `?x=1;token=SECRET` — the smuggled token reaching upstream alongside GHP's own credential. Detection now splits the raw query on `&` and `;` and matches keys case-insensitively, with a raw-byte comparison on unescape failure (deciding "not a token" from a parse error is how the original bug happened). An adversarial pass over ~25 constructed inputs found no evasion.
- **The border policy was not evaluated on this host.** Before this branch raw did not route at all, so `block.ghp: true` closed it by absence; adding the handler would have regressed that on the one host already exempt from enterprise enforcement. Now enforced. `codeload.github.com` has the identical gap — documented rather than fixed, as a deliberate follow-up.
- **Access-log query redaction is a global fix.** `url.query` was logged verbatim while headers were redacted, so raw's `?token=` (valid for days) would have been written to the log stream. Now redacted for every backend, closing a pre-existing leak on codeload too.

## Follow-ups deliberately not taken

- `codeload.github.com` border-policy gap.
- Result vocabulary spans five files; a test asserting docs match the constant set would stop it drifting.
- Raw's Prometheus `owner`/`repo` labels are client-controlled on credential-free paths — accurate comment and operator warning added, exposure unmitigated.
- Per-segment access-log redaction, to recover detail on queries Go cannot parse.
- Rewriting `download_url` in API responses, which would convert `query_token` into a fully attributed path.

## Testing

`make check` green (all packages, `go vet` silent). Docs build clean. No `gofmt` regressions — `config.go` is flagged on `main` too, in `TokensConfig`, untouched here.

Design and plan: `docs/superpowers/specs/2026-07-26-raw-githubusercontent-proxy-design.md`, `docs/superpowers/plans/2026-07-26-raw-githubusercontent-proxy.md`.

https://claude.ai/code/session_01AKnu9Y1qvVeihPbbLUEFtS