### PR TITLE
feat(metrics): per-client request counter ghp_client_request_total

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,4 @@ test-results/
 # Editor/IDE
 # .idea/
 # .vscode/
+.envrc

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,6 +113,7 @@ Labels: `stage`, `token_type` (`proxy` for `ghx_` tokens, `agent` for `gha_` tok
 ### Existing metrics
 
 - `ghp_http_request_duration_seconds` / `ghp_http_request_total` — all HTTP requests by backend
+- `ghp_client_request_total` — requests by originating client IP (`client`, `backend`, `token_type`, `status`); the `client` label honours only the single forwarded header named by `server.client_ip_header` (empty = peer address)
 - `ghp_proxy_request_duration_seconds` / `ghp_proxy_request_total` — proxied GitHub requests with full labels
 - `ghp_token_active` / `ghp_token_created_total` / `ghp_token_revoked_total` — token lifecycle
 - `ghp_github_ratelimit_remaining` / `ghp_github_ratelimit_limit` — GitHub rate limit gauges

--- a/docs/admin/configuration.md
+++ b/docs/admin/configuration.md
@@ -39,7 +39,8 @@ values from the config file.
 | `GHP_SERVER_HTTP_LISTEN` | HTTP listen address for HTTPS redirects | |
 | `GHP_SERVER_MANAGEMENT_HOST` | Hostname for the management UI and API | |
 | `GHP_SERVER_BASE_URL` | Public base URL for OAuth callbacks and links | |
-| `GHP_SERVER_TRUST_PROXY_HEADERS` | Honour `Forwarded` / `X-Forwarded-Proto` / `X-Forwarded-Host` when `base_url` is unset (only enable behind a trusted reverse proxy) | `false` |
+| `GHP_SERVER_TRUST_PROXY_HEADERS` | Honour `Forwarded` / `X-Forwarded-Proto` / `X-Forwarded-Host` for URL construction when `base_url` is unset (only enable behind a trusted reverse proxy) | `false` |
+| `GHP_SERVER_CLIENT_IP_HEADER` | The single forwarded header trusted for client attribution in access logs, `ghp_client_request_total`, and the per-IP auth rate limiter: `forwarded`, `x-real-ip`, or `x-forwarded-for`. Set to the one header your reverse proxy sets; all others are ignored. Empty trusts no header (peer address is used) | |
 | `GHP_SERVER_SYSTEMD_SOCKET_ACTIVATION` | Accept sockets from systemd instead of binding addresses | `false` |
 
 ### GitHub
@@ -204,9 +205,17 @@ server:
   management_host: ""          # hostname for management UI (e.g. ghp.example.com)
   base_url: ""                 # public base URL (e.g. https://ghp.example.com)
   # trust_proxy_headers: false # honour Forwarded / X-Forwarded-Proto / X-Forwarded-Host
-                                #   when base_url is unset. Set true only behind a trusted
-                                #   reverse proxy that strips and rewrites these headers.
-                                #   Prefer setting base_url instead.
+                                #   for URL construction when base_url is unset. Set true
+                                #   only behind a trusted reverse proxy that strips and
+                                #   rewrites these headers. Prefer setting base_url.
+  # client_ip_header: ""       # the single forwarded header trusted for client
+                                #   attribution in access logs, ghp_client_request_total,
+                                #   and the per-IP auth rate limiter: "forwarded" (RFC 7239
+                                #   for=), "x-real-ip", or "x-forwarded-for". Set to the
+                                #   one header your reverse proxy sets; all other forwarded
+                                #   headers are ignored so clients cannot spoof attribution
+                                #   via a header the proxy passes through untouched. Empty
+                                #   trusts no header: the peer address is always used.
   # systemd_socket_activation: false  # accept sockets from systemd
 
 tls:

--- a/docs/admin/monitoring.md
+++ b/docs/admin/monitoring.md
@@ -23,9 +23,35 @@ Scrape the metrics endpoint at `http(s)://<ghp-server>:9136/metrics` (HTTPS when
 |--------|------|-------------|
 | `ghp_http_request_duration_seconds` | Histogram | Duration of all HTTP requests (labels: `backend`, `method`, `status`) |
 | `ghp_http_request_total` | Counter | Total HTTP requests (labels: `backend`, `method`, `status`) |
+| `ghp_client_request_total` | Counter | Requests by originating client (labels: `client`, `backend`, `token_type`, `status`) |
 
 The `backend` label distinguishes traffic by virtualhost: `api.github.com`,
 `github.com`, `codeload.github.com`, `copilot`, or `management`.
+
+The `client` label on `ghp_client_request_total` is the source IP of the
+request, so operators can spot a host generating disproportionate traffic.
+By default it is the direct peer address. Behind a reverse proxy, set
+`server.client_ip_header` to the *one* forwarded header your proxy is
+documented to set — `forwarded` (RFC 7239 `for=`), `x-real-ip`, or
+`x-forwarded-for` — and only that header is consulted. All other forwarded
+headers are ignored: most proxies set exactly one family and pass the
+others through untouched, so trusting more than the configured header
+would let clients spoof attribution (and rotate per-IP rate-limit buckets)
+via a header the proxy never rewrites. The setting assumes exactly one
+trusted reverse proxy, so for the chain-style headers (`Forwarded`,
+`X-Forwarded-For`) the *rightmost* entry is used — that is the one
+appended by the trusted proxy; entries to its left arrived inside the
+client's own request and are spoofable. Header values must parse as an IP
+address (an optional port is tolerated); anything else — including RFC
+7239 `unknown` and obfuscated identifiers — falls back to the peer
+address, so clients cannot inject arbitrary strings into label values.
+The same attribution is used for the per-IP authentication rate limiter,
+so behind a reverse proxy `client_ip_header` must be set for rate limits
+to apply per client rather than per proxy. The `token_type` label is
+`proxy` (ghx_), `agent` (gha_), a native GitHub prefix (`gho`, `ghp`,
+`ghs`, ...), or `unknown` for unauthenticated traffic. Cardinality is
+bounded by the number of distinct client hosts; map IPs to hostnames in
+Grafana or with recording rules if needed.
 
 #### Proxy Metrics
 
@@ -211,7 +237,7 @@ body `handled request`. Attributes use HTTP semantic conventions:
 | `http.response.body.size` | Response body bytes |
 | `http.server.request.duration` | Request duration (seconds) |
 | `network.protocol.name` / `network.protocol.version` | e.g. `http` / `1.1` |
-| `client.address` / `client.port` | Remote peer |
+| `client.address` / `client.port` | Client address (honours the header named by `server.client_ip_header`; the port is omitted when the address came from a forwarded header) |
 | `server.address` / `server.port` | Host the request targeted |
 | `user_agent.original` | User-Agent header |
 | `enduser.id` | GitHub username when available, otherwise the internal user ID |

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -37,6 +37,7 @@ import (
 	"github.com/goodtune/ghp/internal/crypto"
 	"github.com/goodtune/ghp/internal/database"
 	"github.com/goodtune/ghp/internal/metrics"
+	"github.com/goodtune/ghp/internal/netutil"
 )
 
 const (
@@ -107,21 +108,22 @@ type Handler struct {
 
 // NewHandler creates a new auth handler.
 func NewHandler(cfg *config.Config, store database.Store, enc *crypto.Encryptor, logger *slog.Logger) *Handler {
+	clientIPHeader := netutil.IPHeader(cfg.Server.ClientIPHeader)
 	h := &Handler{
 		cfg:              cfg,
 		store:            store,
 		encryptor:        enc,
 		logger:           logger,
-		loginLimiter:     NewIPRateLimiter(100, time.Minute, "/auth/test-login", logger),
-		githubLimiter:    NewIPRateLimiter(10, time.Minute, "/auth/github", logger),
-		authorizeLimiter: NewIPRateLimiter(10, time.Minute, "/auth/authorize", logger),
+		loginLimiter:     NewIPRateLimiter(100, time.Minute, "/auth/test-login", clientIPHeader, logger),
+		githubLimiter:    NewIPRateLimiter(10, time.Minute, "/auth/github", clientIPHeader, logger),
+		authorizeLimiter: NewIPRateLimiter(10, time.Minute, "/auth/authorize", clientIPHeader, logger),
 		// /cli/auth/device kicks off a flow that creates a database row, so
 		// it gets the same conservative ceiling as /auth/github. The polling
 		// endpoint is more permissive — a single CLI run polls every few
 		// seconds for up to 10 minutes, which is up to ~300 hits, and
 		// multiple CLI processes may run from the same NAT'd IP.
-		deviceStartLimiter: NewIPRateLimiter(10, time.Minute, "/cli/auth/device", logger),
-		devicePollLimiter:  NewIPRateLimiter(600, time.Minute, "/cli/auth/device/token", logger),
+		deviceStartLimiter: NewIPRateLimiter(10, time.Minute, "/cli/auth/device", clientIPHeader, logger),
+		devicePollLimiter:  NewIPRateLimiter(600, time.Minute, "/cli/auth/device/token", clientIPHeader, logger),
 		httpClient:         &http.Client{Timeout: authHTTPTimeout},
 	}
 	if cfg.Auth.JWTPrivateKey != "" || cfg.Auth.JWTPrivateKeyFile != "" {

--- a/internal/auth/ratelimit.go
+++ b/internal/auth/ratelimit.go
@@ -2,16 +2,15 @@ package auth
 
 import (
 	"log/slog"
-	"net"
 	"net/http"
 	"strconv"
-	"strings"
 	"sync"
 	"time"
 
 	"golang.org/x/time/rate"
 
 	"github.com/goodtune/ghp/internal/metrics"
+	"github.com/goodtune/ghp/internal/netutil"
 )
 
 // visitorTTL is how long an idle visitor entry is kept before being evicted.
@@ -35,6 +34,8 @@ type IPRateLimiter struct {
 	// endpoint names the protected route; used in log and metric labels.
 	endpoint string
 	logger   *slog.Logger
+
+	clientIPHeader netutil.IPHeader
 }
 
 // NewIPRateLimiter creates a new IPRateLimiter that allows up to limit requests
@@ -44,13 +45,14 @@ type IPRateLimiter struct {
 // endpoint is included in slog and Prometheus label values so operators can
 // distinguish traffic sources in dashboards and alerts.
 // logger receives a Warn-level entry for every rejected request.
-func NewIPRateLimiter(limit int, window time.Duration, endpoint string, logger *slog.Logger) *IPRateLimiter {
+func NewIPRateLimiter(limit int, window time.Duration, endpoint string, clientIPHeader netutil.IPHeader, logger *slog.Logger) *IPRateLimiter {
 	l := &IPRateLimiter{
-		visitors: make(map[string]*visitor),
-		rate:     rate.Limit(float64(limit) / window.Seconds()),
-		burst:    limit,
-		endpoint: endpoint,
-		logger:   logger,
+		visitors:       make(map[string]*visitor),
+		rate:           rate.Limit(float64(limit) / window.Seconds()),
+		burst:          limit,
+		endpoint:       endpoint,
+		logger:         logger,
+		clientIPHeader: clientIPHeader,
 	}
 	go l.cleanupLoop()
 	return l
@@ -106,7 +108,7 @@ func (l *IPRateLimiter) cleanupLoop() {
 //   - counted in the ghp_auth_rate_limit_total{endpoint} Prometheus counter
 func (l *IPRateLimiter) Middleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		ip := ClientIP(r)
+		ip := netutil.ClientIP(r, l.clientIPHeader)
 		if !l.Allow(ip) {
 			l.logger.Warn("rate_limit_exceeded",
 				"endpoint", l.endpoint,
@@ -121,27 +123,4 @@ func (l *IPRateLimiter) Middleware(next http.Handler) http.Handler {
 		}
 		next.ServeHTTP(w, r)
 	})
-}
-
-// ClientIP extracts the client IP address from the request.
-// When the server runs behind a trusted reverse proxy it uses X-Real-IP or
-// the first entry of X-Forwarded-For; otherwise it falls back to RemoteAddr.
-// Note: X-Real-IP and X-Forwarded-For headers can be spoofed by clients when
-// the server is not behind a proxy. Deploy behind a reverse proxy that strips
-// or overwrites these headers to prevent rate-limit bypass.
-func ClientIP(r *http.Request) string {
-	if ip := r.Header.Get("X-Real-IP"); ip != "" {
-		return strings.TrimSpace(ip)
-	}
-	if forwarded := r.Header.Get("X-Forwarded-For"); forwarded != "" {
-		if idx := strings.IndexByte(forwarded, ','); idx != -1 {
-			return strings.TrimSpace(forwarded[:idx])
-		}
-		return strings.TrimSpace(forwarded)
-	}
-	host, _, err := net.SplitHostPort(r.RemoteAddr)
-	if err != nil {
-		return r.RemoteAddr
-	}
-	return host
 }

--- a/internal/auth/ratelimit_test.go
+++ b/internal/auth/ratelimit_test.go
@@ -9,12 +9,14 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/goodtune/ghp/internal/netutil"
 )
 
 // newTestLimiter creates a limiter with a no-op logger suitable for unit tests.
 func newTestLimiter(limit int, window time.Duration) *IPRateLimiter {
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
-	return NewIPRateLimiter(limit, window, "/test", logger)
+	return NewIPRateLimiter(limit, window, "/test", netutil.IPHeaderNone, logger)
 }
 
 func TestIPRateLimiter_Allow(t *testing.T) {
@@ -99,6 +101,56 @@ func TestIPRateLimiter_Middleware_ResponseHeaders(t *testing.T) {
 	}
 }
 
+func TestIPRateLimiter_Middleware_ForwardedHeaderIgnoredWhenNotConfigured(t *testing.T) {
+	limiter := newTestLimiter(1, time.Minute)
+
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	handler := limiter.Middleware(inner)
+
+	for i, want := range []int{http.StatusOK, http.StatusTooManyRequests} {
+		req := httptest.NewRequest("GET", "/", nil)
+		req.RemoteAddr = "1.2.3.4:1234"
+		req.Header.Set("X-Forwarded-For", fmt.Sprintf("10.0.0.%d", i+1))
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, req)
+		if w.Code != want {
+			t.Errorf("request %d: expected %d, got %d", i+1, want, w.Code)
+		}
+	}
+}
+
+func TestIPRateLimiter_Middleware_ConfiguredHeaderHonoured(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	limiter := NewIPRateLimiter(1, time.Minute, "/test", netutil.IPHeaderXForwardedFor, logger)
+
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	handler := limiter.Middleware(inner)
+
+	for i := 0; i < 2; i++ {
+		req := httptest.NewRequest("GET", "/", nil)
+		req.RemoteAddr = "1.2.3.4:1234"
+		req.Header.Set("X-Forwarded-For", fmt.Sprintf("10.0.0.%d", i+1))
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, req)
+		if w.Code != http.StatusOK {
+			t.Errorf("request %d: expected 200, got %d", i+1, w.Code)
+		}
+	}
+
+	req := httptest.NewRequest("GET", "/", nil)
+	req.RemoteAddr = "1.2.3.4:1234"
+	req.Header.Set("X-Forwarded-For", "10.0.0.1")
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	if w.Code != http.StatusTooManyRequests {
+		t.Errorf("expected 429 for repeated forwarded client, got %d", w.Code)
+	}
+}
+
 func TestIPRateLimiter_ConcurrentAccess(t *testing.T) {
 	limiter := newTestLimiter(1000, time.Minute)
 
@@ -122,67 +174,4 @@ func TestIPRateLimiter_ConcurrentAccess(t *testing.T) {
 		}(i)
 	}
 	wg.Wait()
-}
-
-func TestClientIP(t *testing.T) {
-	tests := []struct {
-		name       string
-		remoteAddr string
-		xRealIP    string
-		xForwarded string
-		want       string
-	}{
-		{
-			name:       "plain remote addr",
-			remoteAddr: "1.2.3.4:5678",
-			want:       "1.2.3.4",
-		},
-		{
-			name:       "X-Real-IP takes precedence",
-			remoteAddr: "1.2.3.4:5678",
-			xRealIP:    "9.9.9.9",
-			want:       "9.9.9.9",
-		},
-		{
-			name:       "X-Forwarded-For single IP",
-			remoteAddr: "1.2.3.4:5678",
-			xForwarded: "203.0.113.1",
-			want:       "203.0.113.1",
-		},
-		{
-			name:       "X-Forwarded-For first IP used",
-			remoteAddr: "1.2.3.4:5678",
-			xForwarded: "203.0.113.1, 10.0.0.1, 172.16.0.1",
-			want:       "203.0.113.1",
-		},
-		{
-			name:       "X-Real-IP beats X-Forwarded-For",
-			remoteAddr: "1.2.3.4:5678",
-			xRealIP:    "9.9.9.9",
-			xForwarded: "203.0.113.1",
-			want:       "9.9.9.9",
-		},
-		{
-			name:       "remote addr without port",
-			remoteAddr: "1.2.3.4",
-			want:       "1.2.3.4",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			req := httptest.NewRequest("GET", "/", nil)
-			req.RemoteAddr = tt.remoteAddr
-			if tt.xRealIP != "" {
-				req.Header.Set("X-Real-IP", tt.xRealIP)
-			}
-			if tt.xForwarded != "" {
-				req.Header.Set("X-Forwarded-For", tt.xForwarded)
-			}
-			got := ClientIP(req)
-			if got != tt.want {
-				t.Errorf("ClientIP() = %q, want %q", got, tt.want)
-			}
-		})
-	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -21,6 +21,8 @@ import (
 	"github.com/knadh/koanf/providers/env/v2"
 	"github.com/knadh/koanf/providers/file"
 	"github.com/knadh/koanf/v2"
+
+	"github.com/goodtune/ghp/internal/netutil"
 )
 
 // Config represents the complete server configuration.
@@ -265,7 +267,8 @@ type ServerConfig struct {
 	// headers and influence generated URLs (host-header injection). The
 	// preferred deployment pattern is to set base_url explicitly so the
 	// fallback path is never exercised.
-	TrustProxyHeaders bool `koanf:"trust_proxy_headers"`
+	TrustProxyHeaders bool   `koanf:"trust_proxy_headers"`
+	ClientIPHeader    string `koanf:"client_ip_header"`
 }
 
 type TokensConfig struct {
@@ -411,6 +414,12 @@ func Load(path string) (*Config, error) {
 	if err := k.Unmarshal("", cfg); err != nil {
 		return nil, fmt.Errorf("unmarshaling config: %w", err)
 	}
+
+	clientIPHeader, err := netutil.ParseIPHeader(cfg.Server.ClientIPHeader)
+	if err != nil {
+		return nil, fmt.Errorf("server.client_ip_header: %w", err)
+	}
+	cfg.Server.ClientIPHeader = string(clientIPHeader)
 
 	// Comma-separated list env vars for slice fields. koanf unmarshals
 	// a single env var string into a one-element slice, so we split on
@@ -628,6 +637,14 @@ func (c *Config) CodeloadRedirectTo() string {
 // and GHP_BLOCK_GHPR environment variables which a configuration mistake might
 // introduce. Note: GHP_BLOCK_GHPR targets ghp's own session token prefix (ghpr_),
 // which is distinct from GitHub's refresh token prefix (ghr_) handled by GHP_BLOCK_GHR.
+func (c *Config) WarnMissingClientIPHeader(logger interface {
+	Warn(msg string, args ...any)
+}) {
+	if c.Server.TrustProxyHeaders && c.Server.ClientIPHeader == "" {
+		logger.Warn("server.trust_proxy_headers is set but server.client_ip_header is not: client attribution and per-IP rate limits will key on the proxy address, so all clients behind the proxy share one rate-limit bucket; set server.client_ip_header to the forwarded header your proxy sets")
+	}
+}
+
 func (c *Config) WarnInvalidBlockTargets(logger interface {
 	Warn(msg string, args ...any)
 }) {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -520,3 +520,68 @@ func TestLoadVaultK8sFromEnv(t *testing.T) {
 		t.Errorf("VaultK8sTokenPath = %q, want /run/secrets/projected/token", cfg.Database.VaultK8sTokenPath)
 	}
 }
+
+func TestLoadClientIPHeaderFromEnv(t *testing.T) {
+	t.Setenv("GHP_SERVER_CLIENT_IP_HEADER", "X-Forwarded-For")
+
+	cfg, err := Load("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Server.ClientIPHeader != "x-forwarded-for" {
+		t.Errorf("ClientIPHeader = %q, want %q", cfg.Server.ClientIPHeader, "x-forwarded-for")
+	}
+}
+
+func TestLoadClientIPHeaderDefaultsEmpty(t *testing.T) {
+	cfg, err := Load("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Server.ClientIPHeader != "" {
+		t.Errorf("ClientIPHeader = %q, want empty", cfg.Server.ClientIPHeader)
+	}
+}
+
+func TestLoadClientIPHeaderInvalid(t *testing.T) {
+	t.Setenv("GHP_SERVER_CLIENT_IP_HEADER", "cf-connecting-ip")
+
+	if _, err := Load(""); err == nil {
+		t.Fatal("expected error for unsupported client_ip_header")
+	}
+}
+
+type warnRecorder struct {
+	messages []string
+}
+
+func (w *warnRecorder) Warn(msg string, args ...any) {
+	w.messages = append(w.messages, msg)
+}
+
+func TestWarnMissingClientIPHeader(t *testing.T) {
+	tests := []struct {
+		name              string
+		trustProxyHeaders bool
+		clientIPHeader    string
+		wantWarn          bool
+	}{
+		{name: "trust set without client ip header warns", trustProxyHeaders: true, wantWarn: true},
+		{name: "trust set with client ip header", trustProxyHeaders: true, clientIPHeader: "x-forwarded-for"},
+		{name: "trust unset without client ip header"},
+		{name: "trust unset with client ip header", clientIPHeader: "x-forwarded-for"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &Config{Server: ServerConfig{
+				TrustProxyHeaders: tt.trustProxyHeaders,
+				ClientIPHeader:    tt.clientIPHeader,
+			}}
+			rec := &warnRecorder{}
+			cfg.WarnMissingClientIPHeader(rec)
+			if got := len(rec.messages) > 0; got != tt.wantWarn {
+				t.Errorf("warned = %v, want %v (messages: %v)", got, tt.wantWarn, rec.messages)
+			}
+		})
+	}
+}

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -34,6 +34,11 @@ var (
 		Help: "Total number of HTTP requests by backend.",
 	}, []string{"backend", "method", "status"})
 
+	ClientRequestTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "ghp_client_request_total",
+		Help: "Total number of requests by client source IP, backend, token type, and status.",
+	}, []string{"client", "backend", "token_type", "status"})
+
 	// Proxy-level metrics for ghx_/gha_ authenticated requests.
 	ProxyRequestDuration = promauto.NewHistogramVec(prometheus.HistogramOpts{
 		Name:    "ghp_proxy_request_duration_seconds",
@@ -375,6 +380,16 @@ func ObservePassthroughRequest(backendName, method string, status int, dur time.
 	statusStr := strconv.Itoa(status)
 	ProxyRequestDuration.WithLabelValues(backendName, method, statusStr, tokenType, apiType, username, "").Observe(dur.Seconds())
 	ProxyRequestTotal.WithLabelValues(backendName, method, statusStr, tokenType, apiType, username, "").Inc()
+}
+
+func ObserveClientRequest(client, backendName, tokenType string, status int) {
+	if client == "" {
+		client = "unknown"
+	}
+	if tokenType == "" {
+		tokenType = "unknown"
+	}
+	ClientRequestTotal.WithLabelValues(client, backendName, tokenType, strconv.Itoa(status)).Inc()
 }
 
 // SetBuildInfo records build metadata as a gauge with a constant value of 1.

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -305,6 +305,36 @@ func TestObserveDecision_RedirectHeadCheck(t *testing.T) {
 	}
 }
 
+func TestObserveClientRequest(t *testing.T) {
+	labels := prometheus.Labels{
+		"client":     "10.1.2.3",
+		"backend":    "api.github.com",
+		"token_type": "proxy",
+		"status":     "200",
+	}
+	before := getCounterValue(t, ClientRequestTotal, labels)
+	ObserveClientRequest("10.1.2.3", "api.github.com", "proxy", 200)
+	after := getCounterValue(t, ClientRequestTotal, labels)
+	if after-before != 1 {
+		t.Errorf("expected counter to increment by 1, got %f", after-before)
+	}
+}
+
+func TestObserveClientRequest_UnknownDefaults(t *testing.T) {
+	labels := prometheus.Labels{
+		"client":     "unknown",
+		"backend":    "github.com",
+		"token_type": "unknown",
+		"status":     "404",
+	}
+	before := getCounterValue(t, ClientRequestTotal, labels)
+	ObserveClientRequest("", "github.com", "", 404)
+	after := getCounterValue(t, ClientRequestTotal, labels)
+	if after-before != 1 {
+		t.Errorf("expected counter to increment by 1, got %f", after-before)
+	}
+}
+
 func TestObservePassthroughRequest(t *testing.T) {
 	tests := []struct {
 		name      string

--- a/internal/netutil/netutil.go
+++ b/internal/netutil/netutil.go
@@ -1,0 +1,91 @@
+package netutil
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"strings"
+)
+
+type IPHeader string
+
+const (
+	IPHeaderNone          IPHeader = ""
+	IPHeaderForwarded     IPHeader = "forwarded"
+	IPHeaderXRealIP       IPHeader = "x-real-ip"
+	IPHeaderXForwardedFor IPHeader = "x-forwarded-for"
+)
+
+func ParseIPHeader(s string) (IPHeader, error) {
+	switch h := IPHeader(strings.ToLower(strings.TrimSpace(s))); h {
+	case IPHeaderNone, IPHeaderForwarded, IPHeaderXRealIP, IPHeaderXForwardedFor:
+		return h, nil
+	default:
+		return IPHeaderNone, fmt.Errorf("unsupported client IP header %q (expected %q, %q, or %q)", s, IPHeaderForwarded, IPHeaderXRealIP, IPHeaderXForwardedFor)
+	}
+}
+
+func ClientIP(r *http.Request, header IPHeader) string {
+	switch header {
+	case IPHeaderForwarded:
+		if ip := parseIPCandidate(rightmostForwardedFor(r.Header.Get("Forwarded"))); ip != "" {
+			return ip
+		}
+	case IPHeaderXRealIP:
+		if ip := parseIPCandidate(r.Header.Get("X-Real-IP")); ip != "" {
+			return ip
+		}
+	case IPHeaderXForwardedFor:
+		if forwarded := r.Header.Get("X-Forwarded-For"); forwarded != "" {
+			parts := strings.Split(forwarded, ",")
+			if ip := parseIPCandidate(parts[len(parts)-1]); ip != "" {
+				return ip
+			}
+		}
+	}
+	host, _, err := net.SplitHostPort(r.RemoteAddr)
+	if err != nil {
+		return r.RemoteAddr
+	}
+	return host
+}
+
+func rightmostForwardedFor(header string) string {
+	if header == "" {
+		return ""
+	}
+	last := header
+	if i := strings.LastIndexByte(last, ','); i >= 0 {
+		last = last[i+1:]
+	}
+	for _, part := range strings.Split(last, ";") {
+		part = strings.TrimSpace(part)
+		eq := strings.IndexByte(part, '=')
+		if eq < 0 || !strings.EqualFold(part[:eq], "for") {
+			continue
+		}
+		return strings.Trim(strings.TrimSpace(part[eq+1:]), `"`)
+	}
+	return ""
+}
+
+func parseIPCandidate(s string) string {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return ""
+	}
+	if ip := net.ParseIP(s); ip != nil {
+		return ip.String()
+	}
+	if host, _, err := net.SplitHostPort(s); err == nil {
+		if ip := net.ParseIP(host); ip != nil {
+			return ip.String()
+		}
+	}
+	if strings.HasPrefix(s, "[") && strings.HasSuffix(s, "]") {
+		if ip := net.ParseIP(s[1 : len(s)-1]); ip != nil {
+			return ip.String()
+		}
+	}
+	return ""
+}

--- a/internal/netutil/netutil_test.go
+++ b/internal/netutil/netutil_test.go
@@ -1,0 +1,101 @@
+package netutil
+
+import (
+	"net/http/httptest"
+	"testing"
+)
+
+func TestParseIPHeader(t *testing.T) {
+	tests := []struct {
+		in      string
+		want    IPHeader
+		wantErr bool
+	}{
+		{in: "", want: IPHeaderNone},
+		{in: "forwarded", want: IPHeaderForwarded},
+		{in: "x-real-ip", want: IPHeaderXRealIP},
+		{in: "x-forwarded-for", want: IPHeaderXForwardedFor},
+		{in: "X-Forwarded-For", want: IPHeaderXForwardedFor},
+		{in: "  Forwarded  ", want: IPHeaderForwarded},
+		{in: "x_forwarded_for", wantErr: true},
+		{in: "cf-connecting-ip", wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.in, func(t *testing.T) {
+			got, err := ParseIPHeader(tt.in)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("ParseIPHeader(%q) expected error, got %q", tt.in, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ParseIPHeader(%q) unexpected error: %v", tt.in, err)
+			}
+			if got != tt.want {
+				t.Errorf("ParseIPHeader(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestClientIP(t *testing.T) {
+	tests := []struct {
+		name       string
+		remoteAddr string
+		forwarded  string
+		xRealIP    string
+		xForwarded string
+		header     IPHeader
+		want       string
+	}{
+		{name: "remote addr only", remoteAddr: "192.168.1.10:54321", want: "192.168.1.10"},
+		{name: "remote addr without port", remoteAddr: "192.168.1.10", want: "192.168.1.10"},
+		{name: "x-real-ip ignored when no header configured", remoteAddr: "192.168.1.10:54321", xRealIP: "10.0.0.1", want: "192.168.1.10"},
+		{name: "x-forwarded-for ignored when no header configured", remoteAddr: "192.168.1.10:54321", xForwarded: "10.0.0.1", want: "192.168.1.10"},
+		{name: "forwarded ignored when no header configured", remoteAddr: "192.168.1.10:54321", forwarded: "for=10.0.0.1", want: "192.168.1.10"},
+		{name: "x-real-ip configured", remoteAddr: "192.168.1.10:54321", xRealIP: "10.0.0.1", header: IPHeaderXRealIP, want: "10.0.0.1"},
+		{name: "x-real-ip trimmed", remoteAddr: "192.168.1.10:54321", xRealIP: "  10.0.0.1  ", header: IPHeaderXRealIP, want: "10.0.0.1"},
+		{name: "x-real-ip invalid falls back", remoteAddr: "192.168.1.10:54321", xRealIP: "not-an-ip", header: IPHeaderXRealIP, want: "192.168.1.10"},
+		{name: "x-forwarded-for single", remoteAddr: "192.168.1.10:54321", xForwarded: "10.0.0.1", header: IPHeaderXForwardedFor, want: "10.0.0.1"},
+		{name: "x-forwarded-for chain uses rightmost", remoteAddr: "192.168.1.10:54321", xForwarded: "10.0.0.1, 10.0.0.2, 10.0.0.3", header: IPHeaderXForwardedFor, want: "10.0.0.3"},
+		{name: "x-forwarded-for spoofed prefix ignored", remoteAddr: "192.168.1.10:54321", xForwarded: "1.1.1.1, 172.16.0.5", header: IPHeaderXForwardedFor, want: "172.16.0.5"},
+		{name: "x-forwarded-for with port", remoteAddr: "192.168.1.10:54321", xForwarded: "10.0.0.1:8080", header: IPHeaderXForwardedFor, want: "10.0.0.1"},
+		{name: "x-forwarded-for invalid falls back", remoteAddr: "192.168.1.10:54321", xForwarded: "garbage", header: IPHeaderXForwardedFor, want: "192.168.1.10"},
+		{name: "x-forwarded-for missing falls back", remoteAddr: "192.168.1.10:54321", header: IPHeaderXForwardedFor, want: "192.168.1.10"},
+		{name: "forwarded single element", remoteAddr: "192.168.1.10:54321", forwarded: "for=10.0.0.1", header: IPHeaderForwarded, want: "10.0.0.1"},
+		{name: "forwarded chain uses rightmost element", remoteAddr: "192.168.1.10:54321", forwarded: "for=1.1.1.1, for=172.16.0.5", header: IPHeaderForwarded, want: "172.16.0.5"},
+		{name: "forwarded with other fields", remoteAddr: "192.168.1.10:54321", forwarded: "by=203.0.113.43;for=10.0.0.1;proto=https", header: IPHeaderForwarded, want: "10.0.0.1"},
+		{name: "forwarded quoted with port", remoteAddr: "192.168.1.10:54321", forwarded: `for="10.0.0.1:8080"`, header: IPHeaderForwarded, want: "10.0.0.1"},
+		{name: "forwarded bracketed ipv6", remoteAddr: "192.168.1.10:54321", forwarded: `for="[2001:db8::1]"`, header: IPHeaderForwarded, want: "2001:db8::1"},
+		{name: "forwarded bracketed ipv6 with port", remoteAddr: "192.168.1.10:54321", forwarded: `for="[2001:db8::1]:443"`, header: IPHeaderForwarded, want: "2001:db8::1"},
+		{name: "forwarded ipv6 canonicalized", remoteAddr: "192.168.1.10:54321", forwarded: `for="[2001:DB8::1]"`, header: IPHeaderForwarded, want: "2001:db8::1"},
+		{name: "forwarded unknown falls back to peer", remoteAddr: "192.168.1.10:54321", forwarded: "for=unknown", xRealIP: "10.0.0.1", header: IPHeaderForwarded, want: "192.168.1.10"},
+		{name: "forwarded obfuscated falls back to peer", remoteAddr: "192.168.1.10:54321", forwarded: "for=_hidden", xForwarded: "10.0.0.2", header: IPHeaderForwarded, want: "192.168.1.10"},
+		{name: "spoofed forwarded ignored when x-forwarded-for configured", remoteAddr: "192.168.1.10:54321", forwarded: "for=1.2.3.4", xForwarded: "10.0.0.5", header: IPHeaderXForwardedFor, want: "10.0.0.5"},
+		{name: "spoofed x-real-ip ignored when x-forwarded-for configured", remoteAddr: "192.168.1.10:54321", xRealIP: "1.2.3.4", xForwarded: "10.0.0.5", header: IPHeaderXForwardedFor, want: "10.0.0.5"},
+		{name: "spoofed forwarded ignored when x-real-ip configured", remoteAddr: "192.168.1.10:54321", forwarded: "for=1.2.3.4", xRealIP: "10.0.0.5", header: IPHeaderXRealIP, want: "10.0.0.5"},
+		{name: "spoofed x-forwarded-for ignored when forwarded configured", remoteAddr: "192.168.1.10:54321", xForwarded: "1.2.3.4", forwarded: "for=10.0.0.5", header: IPHeaderForwarded, want: "10.0.0.5"},
+		{name: "spoofed x-real-ip does not fall through when forwarded configured but absent", remoteAddr: "192.168.1.10:54321", xRealIP: "1.2.3.4", header: IPHeaderForwarded, want: "192.168.1.10"},
+		{name: "configured header missing falls back", remoteAddr: "192.168.1.10:54321", header: IPHeaderXRealIP, want: "192.168.1.10"},
+		{name: "ipv6 remote addr", remoteAddr: "[2001:db8::1]:443", want: "2001:db8::1"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := httptest.NewRequest("GET", "/", nil)
+			r.RemoteAddr = tt.remoteAddr
+			if tt.forwarded != "" {
+				r.Header.Set("Forwarded", tt.forwarded)
+			}
+			if tt.xRealIP != "" {
+				r.Header.Set("X-Real-IP", tt.xRealIP)
+			}
+			if tt.xForwarded != "" {
+				r.Header.Set("X-Forwarded-For", tt.xForwarded)
+			}
+			if got := ClientIP(r, tt.header); got != tt.want {
+				t.Errorf("ClientIP() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/proxy/context.go
+++ b/internal/proxy/context.go
@@ -13,6 +13,7 @@ var usernameCtxKey = &contextKey{"github-username"}
 var userIDCtxKey = &contextKey{"user-id"}
 var cacheStateCtxKey = &contextKey{"cache-state"}
 var cacheRepoCtxKey = &contextKey{"cache-repo"}
+var tokenTypeCtxKey = &contextKey{"token-type"}
 
 // AccessLogSlots holds the mutable string slots that downstream handlers
 // populate so the access-log middleware can read them after the request.
@@ -21,6 +22,7 @@ type AccessLogSlots struct {
 	UserID     *string
 	CacheState *string // "hit", "miss", "rejected", "error", or "" for non-cached
 	CacheRepo  *string // "owner/repo" if request hit a cached repository
+	TokenType  *string // "proxy", "agent", native prefix (e.g. "gho"), or "" if unresolved
 }
 
 // PrepareAccessLogSlots returns a new request whose context carries mutable
@@ -32,15 +34,18 @@ func PrepareAccessLogSlots(r *http.Request) (*http.Request, *AccessLogSlots) {
 	userIDSlot := new(string)
 	cacheStateSlot := new(string)
 	cacheRepoSlot := new(string)
+	tokenTypeSlot := new(string)
 	ctx := context.WithValue(r.Context(), usernameCtxKey, usernameSlot)
 	ctx = context.WithValue(ctx, userIDCtxKey, userIDSlot)
 	ctx = context.WithValue(ctx, cacheStateCtxKey, cacheStateSlot)
 	ctx = context.WithValue(ctx, cacheRepoCtxKey, cacheRepoSlot)
+	ctx = context.WithValue(ctx, tokenTypeCtxKey, tokenTypeSlot)
 	return r.WithContext(ctx), &AccessLogSlots{
 		Username:   usernameSlot,
 		UserID:     userIDSlot,
 		CacheState: cacheStateSlot,
 		CacheRepo:  cacheRepoSlot,
+		TokenType:  tokenTypeSlot,
 	}
 }
 
@@ -113,5 +118,11 @@ func GetCacheState(r *http.Request) string {
 func SetCacheRepo(r *http.Request, repo string) {
 	if slot, ok := r.Context().Value(cacheRepoCtxKey).(*string); ok {
 		*slot = repo
+	}
+}
+
+func SetTokenType(r *http.Request, tokenType string) {
+	if slot, ok := r.Context().Value(tokenTypeCtxKey).(*string); ok {
+		*slot = tokenType
 	}
 }

--- a/internal/proxy/passthrough.go
+++ b/internal/proxy/passthrough.go
@@ -106,6 +106,9 @@ func NewScopedPassthroughHandler(inner http.Handler, enforcer ScopeEnforcer, res
 			extractTokenType = string(tt)
 		}
 		metrics.ObserveDecision(metrics.StageTokenExtraction, extractTokenType, time.Since(extractStart))
+		if extractTokenType != "" {
+			SetTokenType(r, extractTokenType)
+		}
 
 		// applyEnterprise evaluates the enterprise restriction policy against
 		// the request's target, mutating r.Header (the reverse proxy copies
@@ -162,6 +165,7 @@ func NewScopedPassthroughHandler(inner http.Handler, enforcer ScopeEnforcer, res
 			// lookup before the upstream roundtrip so the background
 			// goroutine can run concurrently with the upstream request.
 			raw := extractRawGitHubToken(r)
+			SetTokenType(r, passthroughTokenType(raw))
 			if ur != nil && raw != "" {
 				ur.ResolveFromGitHubToken(r.Context(), raw)
 			}

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -181,6 +181,9 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		extractTokenType = string(tt)
 	}
 	metrics.ObserveDecision(metrics.StageTokenExtraction, extractTokenType, time.Since(extractStart))
+	if extractTokenType != "" {
+		SetTokenType(r, extractTokenType)
+	}
 	if clientToken == "" {
 		// Check the token type border policy before forwarding.
 		borderStart := time.Now()
@@ -790,6 +793,7 @@ func (h *Handler) forwardPassthrough(w http.ResponseWriter, r *http.Request, pat
 	// Grab the raw GitHub token before forwarding so we can resolve the
 	// username for metrics/access-log purposes without storing the token.
 	rawToken := extractRawGitHubToken(r)
+	SetTokenType(r, passthroughTokenType(rawToken))
 
 	// Trigger async username lookup early so it can run concurrently with
 	// the upstream roundtrip. On a cache hit this returns immediately; on a

--- a/internal/server/accesslog.go
+++ b/internal/server/accesslog.go
@@ -11,6 +11,7 @@ import (
 	"go.opentelemetry.io/otel/log/noop"
 
 	"github.com/goodtune/ghp/internal/metrics"
+	"github.com/goodtune/ghp/internal/netutil"
 	"github.com/goodtune/ghp/internal/proxy"
 )
 
@@ -73,7 +74,7 @@ func newAccessLogWriter(logger otellog.Logger) *accessLogWriter {
 
 // accessLogHandler wraps an http.Handler with OpenTelemetry access logging and
 // per-backend Prometheus metrics.
-func accessLogHandler(backend string, next http.Handler, aw *accessLogWriter) http.Handler {
+func accessLogHandler(backend string, next http.Handler, aw *accessLogWriter, clientIPHeader netutil.IPHeader) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		start := time.Now()
 		rec := &responseRecorder{ResponseWriter: w, status: http.StatusOK}
@@ -87,6 +88,7 @@ func accessLogHandler(backend string, next http.Handler, aw *accessLogWriter) ht
 		dur := time.Since(start)
 		statusStr := strconv.Itoa(rec.status)
 
+		clientIP := netutil.ClientIP(r, clientIPHeader)
 		remoteIP, remotePort := splitRemoteAddr(r.RemoteAddr)
 		serverHost, serverPort := splitHostPortPreserve(r.Host)
 
@@ -107,12 +109,12 @@ func accessLogHandler(backend string, next http.Handler, aw *accessLogWriter) ht
 			otellog.Int(attrHTTPResponseBodySize, rec.size),
 			otellog.String(attrNetworkProtocolName, "http"),
 			otellog.String(attrNetworkProtocolVersion, protocolVersion(r.Proto)),
-			otellog.String(attrClientAddress, remoteIP),
+			otellog.String(attrClientAddress, clientIP),
 			otellog.String(attrServerAddress, serverHost),
 			otellog.Float64(attrHTTPServerRequestDuration, dur.Seconds()),
 			otellog.String(attrGHPBackend, backend),
 		}
-		if remotePort != "" {
+		if remotePort != "" && clientIP == remoteIP {
 			if p, err := strconv.Atoi(remotePort); err == nil {
 				attrs = append(attrs, otellog.Int(attrClientPort, p))
 			}
@@ -158,6 +160,7 @@ func accessLogHandler(backend string, next http.Handler, aw *accessLogWriter) ht
 
 		metrics.HttpRequestDuration.WithLabelValues(backend, r.Method, statusStr).Observe(dur.Seconds())
 		metrics.HttpRequestTotal.WithLabelValues(backend, r.Method, statusStr).Inc()
+		metrics.ObserveClientRequest(clientIP, backend, *slots.TokenType, rec.status)
 	})
 }
 

--- a/internal/server/accesslog_test.go
+++ b/internal/server/accesslog_test.go
@@ -7,7 +7,12 @@ import (
 
 	otellog "go.opentelemetry.io/otel/log"
 
+	"github.com/prometheus/client_golang/prometheus"
+	io_prometheus_client "github.com/prometheus/client_model/go"
+
 	"github.com/goodtune/ghp/internal/backend"
+	"github.com/goodtune/ghp/internal/metrics"
+	"github.com/goodtune/ghp/internal/netutil"
 	"github.com/goodtune/ghp/internal/proxy"
 )
 
@@ -21,7 +26,7 @@ func TestAccessLog(t *testing.T) {
 		w.Write([]byte("hello"))
 	})
 
-	handler := accessLogHandler(backend.GitHub, inner, aw)
+	handler := accessLogHandler(backend.GitHub, inner, aw, netutil.IPHeaderNone)
 
 	req := httptest.NewRequest("GET", "http://github.com/org/repo", nil)
 	req.Header.Set("User-Agent", "git/2.40")
@@ -96,7 +101,7 @@ func TestAccessLog_SensitiveHeadersRedacted(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 	})
 
-	handler := accessLogHandler(backend.GitHub, inner, aw)
+	handler := accessLogHandler(backend.GitHub, inner, aw, netutil.IPHeaderNone)
 
 	req := httptest.NewRequest("GET", "http://github.com/org/repo", nil)
 	req.Header.Set("Authorization", "Bearer secret-token")
@@ -123,7 +128,7 @@ func TestAccessLog_ExtendedSensitiveRequestHeadersRedacted(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 	})
 
-	handler := accessLogHandler(backend.GitHub, inner, aw)
+	handler := accessLogHandler(backend.GitHub, inner, aw, netutil.IPHeaderNone)
 
 	req := httptest.NewRequest("GET", "http://github.com/org/repo", nil)
 	req.Header.Set("X-Auth-Token", "secret-auth")
@@ -157,7 +162,7 @@ func TestAccessLog_SetCookieResponseHeaderRedacted(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 	})
 
-	handler := accessLogHandler(backend.GitHub, inner, aw)
+	handler := accessLogHandler(backend.GitHub, inner, aw, netutil.IPHeaderNone)
 
 	req := httptest.NewRequest("GET", "http://github.com/org/repo", nil)
 	rr := httptest.NewRecorder()
@@ -185,7 +190,7 @@ func TestAccessLog_UserIDFromSlot(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 	})
 
-	handler := accessLogHandler(backend.Mgmt, inner, aw)
+	handler := accessLogHandler(backend.Mgmt, inner, aw, netutil.IPHeaderNone)
 
 	req := httptest.NewRequest("GET", "http://ghp.example.com/admin", nil)
 	rr := httptest.NewRecorder()
@@ -211,7 +216,7 @@ func TestAccessLog_UserIDFallsBackToUUIDWhenUsernameEmpty(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 	})
 
-	handler := accessLogHandler(backend.Mgmt, inner, aw)
+	handler := accessLogHandler(backend.Mgmt, inner, aw, netutil.IPHeaderNone)
 
 	req := httptest.NewRequest("GET", "http://ghp.example.com/admin", nil)
 	rr := httptest.NewRecorder()
@@ -237,7 +242,7 @@ func TestAccessLog_UserIDFallsBackToUsername(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 	})
 
-	handler := accessLogHandler(backend.API, inner, aw)
+	handler := accessLogHandler(backend.API, inner, aw, netutil.IPHeaderNone)
 
 	req := httptest.NewRequest("GET", "http://api.github.com/repos/org/repo", nil)
 	rr := httptest.NewRecorder()
@@ -260,7 +265,7 @@ func TestAccessLog_ErrorLevel(t *testing.T) {
 		w.WriteHeader(http.StatusInternalServerError)
 	})
 
-	handler := accessLogHandler(backend.GitHub, inner, aw)
+	handler := accessLogHandler(backend.GitHub, inner, aw, netutil.IPHeaderNone)
 
 	req := httptest.NewRequest("GET", "http://github.com/error", nil)
 	rr := httptest.NewRecorder()
@@ -274,5 +279,153 @@ func TestAccessLog_ErrorLevel(t *testing.T) {
 	}
 	if got := rec.int(t, attrHTTPResponseStatusCode); got != 500 {
 		t.Errorf("%s: got %d, want 500", attrHTTPResponseStatusCode, got)
+	}
+}
+
+func getClientRequestCount(t *testing.T, labels prometheus.Labels) float64 {
+	t.Helper()
+	c, err := metrics.ClientRequestTotal.GetMetricWith(labels)
+	if err != nil {
+		t.Fatalf("GetMetricWith: %v", err)
+	}
+	var m io_prometheus_client.Metric
+	if err := c.(prometheus.Metric).Write(&m); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	return m.GetCounter().GetValue()
+}
+
+func TestAccessLog_ClientRequestMetric(t *testing.T) {
+	logger, _ := newCaptureLogger(t)
+	aw := newAccessLogWriter(logger)
+
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		proxy.SetTokenType(r, "proxy")
+		w.WriteHeader(http.StatusOK)
+	})
+
+	handler := accessLogHandler(backend.API, inner, aw, netutil.IPHeaderNone)
+
+	req := httptest.NewRequest("GET", "http://api.github.com/repos/org/repo", nil)
+	req.RemoteAddr = "192.168.1.50:33000"
+	rr := httptest.NewRecorder()
+
+	labels := prometheus.Labels{
+		"client":     "192.168.1.50",
+		"backend":    backend.API,
+		"token_type": "proxy",
+		"status":     "200",
+	}
+	before := getClientRequestCount(t, labels)
+	handler.ServeHTTP(rr, req)
+	after := getClientRequestCount(t, labels)
+
+	if after-before != 1 {
+		t.Errorf("expected client request counter to increment by 1, got %f", after-before)
+	}
+}
+
+func TestAccessLog_ClientRequestMetric_UnknownTokenType(t *testing.T) {
+	logger, _ := newCaptureLogger(t)
+	aw := newAccessLogWriter(logger)
+
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	})
+
+	handler := accessLogHandler(backend.GitHub, inner, aw, netutil.IPHeaderNone)
+
+	req := httptest.NewRequest("GET", "http://github.com/org/repo", nil)
+	req.RemoteAddr = "192.168.1.51:33001"
+	rr := httptest.NewRecorder()
+
+	labels := prometheus.Labels{
+		"client":     "192.168.1.51",
+		"backend":    backend.GitHub,
+		"token_type": "unknown",
+		"status":     "404",
+	}
+	before := getClientRequestCount(t, labels)
+	handler.ServeHTTP(rr, req)
+	after := getClientRequestCount(t, labels)
+
+	if after-before != 1 {
+		t.Errorf("expected client request counter to increment by 1, got %f", after-before)
+	}
+}
+
+func TestAccessLog_ForwardedHeaderIgnoredWhenNotConfigured(t *testing.T) {
+	logger, exp := newCaptureLogger(t)
+	aw := newAccessLogWriter(logger)
+
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	handler := accessLogHandler(backend.GitHub, inner, aw, netutil.IPHeaderNone)
+
+	req := httptest.NewRequest("GET", "http://github.com/org/repo", nil)
+	req.RemoteAddr = "192.168.1.60:44000"
+	req.Header.Set("X-Forwarded-For", "10.9.9.9")
+	rr := httptest.NewRecorder()
+
+	labels := prometheus.Labels{
+		"client":     "192.168.1.60",
+		"backend":    backend.GitHub,
+		"token_type": "unknown",
+		"status":     "200",
+	}
+	before := getClientRequestCount(t, labels)
+	handler.ServeHTTP(rr, req)
+	after := getClientRequestCount(t, labels)
+
+	if after-before != 1 {
+		t.Errorf("expected client request counter to increment by 1, got %f", after-before)
+	}
+
+	rec := exp.only(t)
+	if got := rec.str(t, attrClientAddress); got != "192.168.1.60" {
+		t.Errorf("%s: got %q, want 192.168.1.60", attrClientAddress, got)
+	}
+	if got := rec.int(t, attrClientPort); got != 44000 {
+		t.Errorf("%s: got %d, want 44000", attrClientPort, got)
+	}
+}
+
+func TestAccessLog_ConfiguredHeaderHonoured(t *testing.T) {
+	logger, exp := newCaptureLogger(t)
+	aw := newAccessLogWriter(logger)
+
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	handler := accessLogHandler(backend.GitHub, inner, aw, netutil.IPHeaderXForwardedFor)
+
+	req := httptest.NewRequest("GET", "http://github.com/org/repo", nil)
+	req.RemoteAddr = "192.168.1.61:44001"
+	req.Header.Set("X-Forwarded-For", "6.6.6.6, 10.8.8.8")
+	rr := httptest.NewRecorder()
+
+	labels := prometheus.Labels{
+		"client":     "10.8.8.8",
+		"backend":    backend.GitHub,
+		"token_type": "unknown",
+		"status":     "200",
+	}
+	before := getClientRequestCount(t, labels)
+	handler.ServeHTTP(rr, req)
+	after := getClientRequestCount(t, labels)
+
+	if after-before != 1 {
+		t.Errorf("expected client request counter to increment by 1, got %f", after-before)
+	}
+
+	rec := exp.only(t)
+	if got := rec.str(t, attrClientAddress); got != "10.8.8.8" {
+		t.Errorf("%s: got %q, want 10.8.8.8", attrClientAddress, got)
+	}
+	if rec.has(attrClientPort) {
+		t.Errorf("%s should be omitted when client address comes from a forwarded header", attrClientPort)
 	}
 }

--- a/internal/server/api.go
+++ b/internal/server/api.go
@@ -24,6 +24,7 @@ import (
 	"github.com/goodtune/ghp/internal/gitcache"
 	ghpgithub "github.com/goodtune/ghp/internal/github"
 	"github.com/goodtune/ghp/internal/metrics"
+	"github.com/goodtune/ghp/internal/netutil"
 	"github.com/goodtune/ghp/internal/proxy"
 	"github.com/goodtune/ghp/internal/token"
 )
@@ -119,7 +120,7 @@ func NewAPI(ctx context.Context, cfg *config.Config, store database.Store, ts *t
 		logger:             logger,
 		httpClient:         &http.Client{Timeout: 10 * time.Second},
 		auditLog:           aw,
-		tokenCreateLimiter: auth.NewIPRateLimiter(20, time.Minute, "/api/tokens", logger),
+		tokenCreateLimiter: auth.NewIPRateLimiter(20, time.Minute, "/api/tokens", netutil.IPHeader(cfg.Server.ClientIPHeader), logger),
 	}
 }
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -43,6 +43,7 @@ import (
 	"github.com/goodtune/ghp/internal/gitcache"
 	"github.com/goodtune/ghp/internal/github"
 	"github.com/goodtune/ghp/internal/metrics"
+	"github.com/goodtune/ghp/internal/netutil"
 	"github.com/goodtune/ghp/internal/proxy"
 	"github.com/goodtune/ghp/internal/token"
 	"github.com/goodtune/ghp/internal/web"
@@ -259,6 +260,7 @@ func (s *Server) Run(ctx context.Context) error {
 	// Warn if the operator has set environment variables for token types
 	// that ghp manages internally and cannot be blocked via border policy.
 	s.cfg.WarnInvalidBlockTargets(s.logger)
+	s.cfg.WarnMissingClientIPHeader(s.logger)
 
 	// Initialise the anonymous git blocking gauge to reflect the startup config.
 	s.syncBlockMetrics()
@@ -470,12 +472,13 @@ func (s *Server) Run(ctx context.Context) error {
 	aw := newAccessLogWriter(s.logProvider.Logger(accessLogScope))
 
 	// Build host dispatch with access logging on all handlers.
+	clientIPHeader := netutil.IPHeader(s.cfg.Server.ClientIPHeader)
 	dispatch := newHostDispatch(hostDispatchConfig{
-		apiHandler:      accessLogHandler(backend.API, proxyHandler, aw),
-		githubHandler:   accessLogHandler(backend.GitHub, githubPassthrough, aw),
-		codeloadHandler: accessLogHandler(backend.Codeload, codeloadHandler, aw),
-		copilotHandler:  accessLogHandler(backend.Copilot, copilotPassthrough, aw),
-		mgmtHandler:     accessLogHandler(backend.Mgmt, web.SessionUsernameMiddleware(authHandler)(web.SecurityHeadersMiddleware(mux)), aw),
+		apiHandler:      accessLogHandler(backend.API, proxyHandler, aw, clientIPHeader),
+		githubHandler:   accessLogHandler(backend.GitHub, githubPassthrough, aw, clientIPHeader),
+		codeloadHandler: accessLogHandler(backend.Codeload, codeloadHandler, aw, clientIPHeader),
+		copilotHandler:  accessLogHandler(backend.Copilot, copilotPassthrough, aw, clientIPHeader),
+		mgmtHandler:     accessLogHandler(backend.Mgmt, web.SessionUsernameMiddleware(authHandler)(web.SecurityHeadersMiddleware(mux)), aw, clientIPHeader),
 		managementHost:  s.cfg.Server.ManagementHost,
 	})
 


### PR DESCRIPTION
## Summary

Adds `ghp_client_request_total` (labels: `client`, `backend`, `token_type`, `status`) so operators can attribute traffic to originating hosts and spot noisy clients.

Client attribution honours a forwarded header only when `server.client_ip_header` names it: exactly one of `forwarded` (RFC 7239 `for=`), `x-real-ip`, or `x-forwarded-for` is consulted, matching whichever header the deployed reverse proxy is documented to set. Falling back across header families would re-open spoofing — most proxies set one family and pass the others through untouched, so a client-sent header from an unset family would win. The value is validated at config load (unknown names fail startup).

For the chain-style headers the **rightmost** entry is used — with exactly one trusted reverse proxy (the setting's assumption), that is the entry the proxy appended; entries to its left arrived inside the client's own request and are spoofable. Header-derived values must parse as an IP (`net.ParseIP`, optional port tolerated); anything else falls back to the peer address so clients cannot inject arbitrary strings into metric labels or logs.

The shared `netutil.ClientIP` helper also replaces `auth.ClientIP`, which trusted forwarded headers **unconditionally** and allowed per-IP rate-limit bypass via a spoofed `X-Real-IP`. The auth rate limiter is keyed by the same setting. `server.trust_proxy_headers` now governs URL construction only; the server logs a startup warning when it is set without `client_ip_header`.

Token type is plumbed to the access-log middleware via a new context slot (`proxy`, `agent`, native GitHub prefix, or `unknown`).

## BREAKING CHANGE

Per-IP auth rate limiting no longer trusts forwarded headers by default. Deployments behind a reverse proxy (e.g. the k8s Traefik gateway) must set `server.client_ip_header` (`GHP_SERVER_CLIENT_IP_HEADER`) to the header their proxy sets — otherwise all clients behind the proxy share one rate-limit bucket keyed on the proxy address, and endpoints like the device-flow poller (600/min) will return collective 429s under fleet load. The old behaviour was a security hole (spoofed `X-Real-IP` rotated rate-limit buckets), so there is no opt-out. Setting `GHP_SERVER_BASE_URL` alongside is recommended so URL construction never consults forwarded headers.

## Testing

- `netutil.ClientIP` table covers no-header-configured vs each configured header, XFF chains (rightmost + spoofed prefix), `Forwarded` element/quoting/bracketed-IPv6/port forms, `for=unknown`/obfuscated fallback, invalid-value fallback, IPv6 canonicalisation, and cross-family spoof cases (e.g. spoofed `Forwarded` ignored when `x-forwarded-for` is configured)
- `ParseIPHeader` tests cover normalisation and rejection of unknown names; config-load tests cover env normalisation, empty default, and startup failure on invalid values
- Access-log tests assert counter increments and configured/unconfigured header behaviour, including `client.port` omission for header-derived addresses
- Rate-limiter tests assert headers are ignored when unconfigured and bucket per forwarded client when configured
- `WarnMissingClientIPHeader` table test covers all four `trust_proxy_headers` × `client_ip_header` combinations