### PR TITLE
fix(cli): isolate cmd/ghp tests from host system config

### DIFF
--- a/cmd/ghp/main_test.go
+++ b/cmd/ghp/main_test.go
@@ -14,6 +14,22 @@ import (
 	"time"
 )
 
+func TestMain(m *testing.M) {
+	code := isolateTestsFromHostSystemConfig(m)
+	os.Exit(code)
+}
+
+func isolateTestsFromHostSystemConfig(m *testing.M) int {
+	dir, err := os.MkdirTemp("", "ghp-test")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "TestMain: %v\n", err)
+		return 1
+	}
+	defer os.RemoveAll(dir)
+	systemConfigPathOverride = filepath.Join(dir, "absent-system-config.yaml")
+	return m.Run()
+}
+
 // TestHelpOutput_Root verifies that the root help text mentions all subcommands and flags.
 func TestHelpOutput_Root(t *testing.T) {
 	rootCmd := newRootCmd()


### PR DESCRIPTION
## Summary

`TestAuthLoginCmd_NoServerURL` and several sibling tests (`TestAuthStatusCmd_NoServerURL`, `TestTokenCreateCmd_NoConfig`, the `TestLoadCLIConfig_*` family) clear `GHP_SERVER_URL`/`GHP_USER_TOKEN` and sandbox `HOME`, but still merge the system-level CLI config introduced in 8383963. On a machine that has a managed `/etc/xdg/ghp/config.yaml` with a `server_url`, the "no server URL" test picks up that URL and starts a real device-login flow against the configured server, polling until the 10-minute go-test timeout. CI never catches this because runners don't have the file — the suite only hangs on hosts where ghp is actually deployed and configured, which is exactly where operators are most likely to run it.

## Fix

A `TestMain` points the existing `systemConfigPathOverride` test hook at a nonexistent file for the whole package, so tests are isolated from host state by default. Tests that exercise system-config merging already opt in via `setSystemConfig`, which layers its own per-test override on top and restores the package default afterwards. No production code is changed.

## Testing

- `go test ./cmd/ghp/` on a host with a populated `/etc/xdg/ghp/config.yaml`: previously hung for 10 minutes mid-suite, now completes in ~2s.
- Full package passes with and without the host file present.