### PR TITLE
fix(ci): skip PR comment step on fork PRs to avoid spurious job failure

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -125,7 +125,12 @@ jobs:
           retention-days: 14
 
       - name: Comment on PR
-        if: always() && github.event_name == 'pull_request'
+        # GITHUB_TOKEN is forced read-only for pull_request runs triggered from
+        # a fork, so issues.createComment/updateComment always 403 there. Skip
+        # the comment (test results still show in the job summary and the
+        # "Fail if tests failed" step below still gates the job) rather than
+        # letting an unrelated 403 mark the whole job as failed.
+        if: always() && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
         uses: actions/github-script@v9
         env:
           PLAYWRIGHT_OUTCOME: ${{ steps.playwright.outcome }}


### PR DESCRIPTION
## Summary

- The "Playwright E2E tests" job's "Comment on PR" step (`.github/workflows/test.yml`) always fails with `403 Resource not accessible by integration` on pull requests opened from a fork, because GitHub force-downgrades `GITHUB_TOKEN` to read-only for `pull_request`-triggered runs on fork PRs — regardless of the `pull-requests: write` permission declared in the workflow.
- That 403 comes from an unhandled error in the `actions/github-script` step, which fails the whole job even when every Playwright test actually passed (observed on #242 and #243, both submitted from `optiver/ghp`).
- Skip the comment step when the PR head repo isn't this repo (`github.event.pull_request.head.repo.full_name == github.repository`). Test results are still visible in the job's step summary, and the separate "Fail if tests failed" step still gates the job on the real Playwright outcome, so no coverage is lost — only the redundant/failing PR-comment attempt is skipped for fork PRs.

## Testing

- Validated the workflow YAML still parses (`python3 -c "import yaml; yaml.safe_load(...)"`).
- No Go/JS code changed; this is CI-only.

---
_Generated by [Claude Code](https://claude.ai/code/session_01C6AFoSuksdC9ShR5Hmersi)_