### PR TITLE
feat: runtime forward proxy rulesets for outbound egress routing

### DIFF
--- a/.claude/skills/precommit-review/SKILL.md
+++ b/.claude/skills/precommit-review/SKILL.md
@@ -1,0 +1,190 @@
+---
+name: precommit-review
+description: Dispatch a five-persona pre-push code review (security, architecture, cross-platform, test & correctness, docs & DX) against the current branch's unpushed changes. Use BEFORE every `git push` of new commits on a feature branch so findings drive a single clean commit series instead of a noisy round-trip with CI reviewers. Skip only when the user explicitly opts out for the current push, or when the push is purely administrative (rebase pointer update, tag, etc.) and touches no code.
+---
+
+# precommit-review
+
+Running five review personas locally before the push collapses
+the review loop: findings are addressed in-place and the
+resulting commit series tells a clear story, instead of a noisy
+comment round-trip on the PR after CI reviewers arrive one
+commit behind the author.
+
+## When to invoke
+
+Invoke before every `git push` of new commits on a feature
+branch. Skip only when:
+
+- The user has explicitly said to skip review for this push, or
+- The push is purely administrative (an existing commit being
+  re-pushed after a rebase that doesn't change the diff, a tag,
+  a branch pointer update).
+
+If you are unsure, run it. The cost is bounded (five short
+agent calls) and missing a finding has a real cost (a
+public-PR comment loop the author has to babysit).
+
+## How
+
+### 1. Determine what's about to be pushed
+
+```sh
+# Unpushed commit summaries on the current branch:
+git log --oneline @{upstream}..HEAD 2>/dev/null || git log --oneline origin/main..HEAD
+
+# Full diff to brief the personas with:
+git diff @{upstream}..HEAD 2>/dev/null || git diff origin/main...HEAD
+```
+
+If the branch has no upstream and `origin/main` doesn't exist
+either, fall back to `git status` and `git diff HEAD` so the
+personas see at least the uncommitted changes.
+
+### 2. Dispatch the five personas in parallel
+
+Issue **one** message containing five `Agent` tool calls. Each
+uses `subagent_type=general-purpose` (or `Explore` if the
+persona only needs read-only file inspection — security and
+architecture often benefit from `Explore`'s read-window-aware
+approach when the change is small).
+
+Brief each persona with:
+
+- Branch name and unpushed-commit summary
+- The diff (paste inline for small diffs; for large diffs give
+  the exact `git diff` command to run so every persona reviews
+  the identical range)
+- The persona's lens (see below)
+- The relevant `CLAUDE.md` sections to keep the bar consistent
+- An instruction: **report in under 250 words** with concrete
+  `file:line` references and a severity tag
+  (`blocker` / `major` / `minor` / `nit`). Suppress
+  "no findings" filler — return a single line saying so if
+  there is nothing to report.
+
+### 3. Triage findings
+
+| Severity | Action |
+|----------|--------|
+| `blocker` | Address before pushing. No exceptions. |
+| `major`   | Address before pushing, or push a commit message that explains the deliberate decision to defer. |
+| `minor`   | Fix if cheap. Otherwise mention in the commit message. |
+| `nit`     | Fix only if trivially co-located with other changes. |
+
+When you decline a `major` finding, the commit message that
+declines it should reference the specific persona / finding so a
+future reader knows the trade-off was deliberate.
+
+### 4. Push
+
+`git push -u origin <branch>`.
+
+## Persona briefs
+
+Each persona reviews the same diff but applies a different
+review lens.
+
+### Security
+
+> Review the diff with a security lens. Cover: credential
+> handling (ghx_/gha_ token resolution, AES-256-GCM encrypted
+> GitHub tokens, Vault tokens, OAuth client secrets, App
+> private keys — never logged, never echoed in error bodies);
+> scope enforcement staying deny-by-default (REST endpoint
+> scope tables, the GraphQL analyzer's four tables — never
+> widen analyzer defaults); token hashes vs raw tokens in the
+> database; SSRF / open-egress vectors (forward proxy targets,
+> client-supplied URLs or headers reaching outbound dials);
+> HTTP header injection (CR/LF) and hop-by-hop header
+> hygiene on the passthrough paths; Authorization header
+> leakage to redirect targets or mirrors; web UI rules from
+> CLAUDE.md (no inline JS handlers, `esc()` is not JS-safe,
+> CSRF on admin mutations); SQL injection (parameterised
+> queries only); secrets appearing in slog output even at
+> Debug level; enterprise header injection bypasses.
+
+### Architecture
+
+> Review the diff with an architectural lens. Cover: package
+> boundaries (`internal/proxy`, `auth`, `token`, `server`,
+> `database`, `github`, `gitcache`, `web`, `metrics`,
+> `crypto`, `config`); the `Store` interface contract kept
+> semantically identical across SQLite, Postgres, and Vault
+> (sentinel `ErrNotFound` conventions, (nil, nil) reads,
+> RETURNING on upserts); AppRegistry / provider lifecycle
+> rules from CLAUDE.md (reset on reload, dynamic references,
+> no stale providers); migrations parity between
+> `postgres/` and `sqlite/` including ON DELETE behaviour and
+> uniqueness enforced at the database level; decision-pipeline
+> instrumentation (every new decision point timed, bounded
+> label cardinality, ObserveDecision/ObserveProxyRequest
+> helpers); mutex coverage and atomic swap patterns for
+> hot-reloaded state; goroutine lifecycle / context
+> propagation tied to the server lifecycle context; duplicated
+> logic that should live in one package.
+
+### Cross-platform / portability
+
+> Review the diff for portability and deployment-surface
+> behaviour. Cover: `CGO_ENABLED=0` invariant (pure Go — no
+> C-backed dependencies creeping in); build tags
+> (`signal_unix.go` / `signal_windows.go` split); systemd
+> socket activation and unix-socket listener paths; SQLite
+> (modernc.org) vs Postgres (pgx) driver behaviour differences
+> (time formatting, UUID handling, error strings matched in
+> code); Vault KV semantics vs SQL semantics for any new store
+> method (withRelogin wrapping, context propagation, no
+> float64 round-trips on int64 fields); packaging drift
+> (`packaging/` systemd units, default config, goreleaser /
+> Dockerfiles) when config or binary behaviour changes; env
+> var naming consistency (`GHP_` prefix, koanf mapping).
+
+### Test & correctness
+
+> Review the diff for test coverage and behavioural
+> correctness. Cover: tests for the changed code
+> (table-driven with `t.Run()`); store contract tests running
+> against all backends with every model field asserted, valid
+> UUIDs for missing-record probes, `errors.Is(ErrNotFound)`
+> paths; handler tests using mux routes or `SetPathValue`
+> (bare `r.PathValue()` calls panic); metric tests for every
+> new metric; flake risk (sleeps, time-of-day, scheduling or
+> randomness dependencies — bound probabilistic assertions);
+> data-race hazards under `go test -race` (shared maps,
+> counters, reload paths); missing edge cases the diff implies
+> (empty slices vs nil, zero weights, malformed input);
+> whether assertions are load-bearing (would fail if the
+> production change were reverted) rather than vacuous.
+
+### Docs & DX
+
+> Review the diff for docs and developer-experience drift.
+> Cover: `CLAUDE.md` alignment (metrics tables, stage lists,
+> conventions the diff introduces or violates);
+> `docs/admin/configuration.md` env-var table and full YAML
+> reference including any new config fields;
+> `docs/how-it-works.md` and `docs/features/*` accuracy
+> (documented flags/fields/UI elements must actually exist in
+> code — verify wiring); mkdocs nav entries for new pages;
+> known-limitations sections kept honest as behaviour changes;
+> JSON API field naming rules (no ambiguous `app_id`-style
+> collisions, list endpoints returning `[]` not `null`);
+> comments describing code that no longer exists; `make test`
+> / `make build` behaviour; error message quality (actionable,
+> consistent casing).
+
+## Anti-patterns this skill exists to avoid
+
+- **Push-then-review.** Findings arriving as PR comments after
+  the push force either a rebase (rewriting history other
+  reviewers had already commented on) or layered fix commits
+  (noisy PR). Pre-push review fixes once, pushes once.
+- **Repeated dispatch in a tight loop.** If your last push
+  was less than ~5 minutes ago and you're pushing a one-line
+  fix that an earlier review explicitly flagged, the personas
+  will not have new context. Skip review and reference the
+  earlier finding in the commit message instead.
+- **Asking the personas to fix things.** Personas review and
+  report. The fix is the author's; the personas don't run
+  with write access.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,6 +98,7 @@ The proxy decision pipeline is broken into individually timed stages so that the
 | `scope_enforcement` | Repository allowlist check + permission level verification |
 | `github_token_resolution` | Loading, decrypting (or OAuth-refreshing) the real GitHub credential |
 | `enterprise_exception` | Evaluating enterprise access restriction exceptions (target match, team gate, identity minting) before header injection |
+| `forward_proxy_selection` | Selecting the upstream forward proxy for the outbound request (ruleset lookup: token → app → net → system layers) |
 | `upstream_roundtrip` | Proxying the upstream GitHub request and streaming the response (network + GitHub processing + response body transfer) |
 | `redirect_head_check` | HEAD request to the release redirect target to verify asset availability before issuing a 302 (releases handler only) |
 
@@ -121,6 +122,8 @@ Labels: `stage`, `token_type` (`proxy` for `ghx_` tokens, `agent` for `gha_` tok
 - `ghp_auth_rate_limit_total` — rate limiter rejections
 - `ghp_enterprise_exception_total` — enterprise restriction exception matches by outcome (`header_omitted`, `identity_substituted`, `team_denied`, `unauthenticated_denied`, `identity_error`)
 - `ghp_releases_redirect_head_check_total` — HEAD check outcomes (`found`, `not_found`, `error`) for release redirect targets
+- `ghp_forward_proxy_select_total` — forward proxy routing decisions by matched `ruleset` and `layer` (`token`, `app`, `net`, `system`, `ambient`)
+- `ghp_forward_proxy_rulesets_active` — gauge of enabled forward proxy rulesets compiled into the route table
 - `ghp_cache_fetch_total` / `ghp_cache_lsrefs_total` / `ghp_cache_warm_total` — cache operation counters
 - `ghp_cache_packfile_total` / `ghp_cache_packfile_bytes_total` — packfile response cache hit/miss counts and bytes served
 - `ghp_cache_repos_active` — gauge of cache-enabled repositories

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -122,7 +122,8 @@ Labels: `stage`, `token_type` (`proxy` for `ghx_` tokens, `agent` for `gha_` tok
 - `ghp_auth_rate_limit_total` — rate limiter rejections
 - `ghp_enterprise_exception_total` — enterprise restriction exception matches by outcome (`header_omitted`, `identity_substituted`, `team_denied`, `unauthenticated_denied`, `identity_error`)
 - `ghp_releases_redirect_head_check_total` — HEAD check outcomes (`found`, `not_found`, `error`) for release redirect targets
-- `ghp_forward_proxy_select_total` — forward proxy routing decisions by matched `ruleset` and `layer` (`token`, `app`, `net`, `system`, `control`, `ambient`, `direct`)
+- `ghp_forward_proxy_select_total` — forward proxy routing decisions by matched `ruleset` and `layer` (`header`, `token`, `app`, `net`, `system`, `control`, `ambient`, `direct`)
+- `ghp_forward_proxy_client_specified_total` — requests routed through a client-specified proxy via `X-GitHub-Proxy-Forward-*` headers (`scheme`, `token_type` labels; gated by `forward_proxy.allow_request_header`)
 - `ghp_forward_proxy_rulesets_active` — gauge of enabled forward proxy rulesets compiled into the route table
 - `ghp_cache_fetch_total` / `ghp_cache_lsrefs_total` / `ghp_cache_warm_total` — cache operation counters
 - `ghp_cache_packfile_total` / `ghp_cache_packfile_bytes_total` — packfile response cache hit/miss counts and bytes served

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -122,7 +122,7 @@ Labels: `stage`, `token_type` (`proxy` for `ghx_` tokens, `agent` for `gha_` tok
 - `ghp_auth_rate_limit_total` — rate limiter rejections
 - `ghp_enterprise_exception_total` — enterprise restriction exception matches by outcome (`header_omitted`, `identity_substituted`, `team_denied`, `unauthenticated_denied`, `identity_error`)
 - `ghp_releases_redirect_head_check_total` — HEAD check outcomes (`found`, `not_found`, `error`) for release redirect targets
-- `ghp_forward_proxy_select_total` — forward proxy routing decisions by matched `ruleset` and `layer` (`token`, `app`, `net`, `system`, `control`, `ambient`)
+- `ghp_forward_proxy_select_total` — forward proxy routing decisions by matched `ruleset` and `layer` (`token`, `app`, `net`, `system`, `control`, `ambient`, `direct`)
 - `ghp_forward_proxy_rulesets_active` — gauge of enabled forward proxy rulesets compiled into the route table
 - `ghp_cache_fetch_total` / `ghp_cache_lsrefs_total` / `ghp_cache_warm_total` — cache operation counters
 - `ghp_cache_packfile_total` / `ghp_cache_packfile_bytes_total` — packfile response cache hit/miss counts and bytes served

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,7 +98,7 @@ The proxy decision pipeline is broken into individually timed stages so that the
 | `scope_enforcement` | Repository allowlist check + permission level verification |
 | `github_token_resolution` | Loading, decrypting (or OAuth-refreshing) the real GitHub credential |
 | `enterprise_exception` | Evaluating enterprise access restriction exceptions (target match, team gate, identity minting) before header injection |
-| `forward_proxy_selection` | Selecting the upstream forward proxy for the outbound request (ruleset lookup: token → app → net → system layers) |
+| `forward_proxy_selection` | Selecting the upstream forward proxy for the outbound request (ruleset lookup: token → app → net → system layers for proxied traffic; control → system for control-plane calls, labeled `token_type="unknown"`) |
 | `upstream_roundtrip` | Proxying the upstream GitHub request and streaming the response (network + GitHub processing + response body transfer) |
 | `redirect_head_check` | HEAD request to the release redirect target to verify asset availability before issuing a 302 (releases handler only) |
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -122,7 +122,7 @@ Labels: `stage`, `token_type` (`proxy` for `ghx_` tokens, `agent` for `gha_` tok
 - `ghp_auth_rate_limit_total` — rate limiter rejections
 - `ghp_enterprise_exception_total` — enterprise restriction exception matches by outcome (`header_omitted`, `identity_substituted`, `team_denied`, `unauthenticated_denied`, `identity_error`)
 - `ghp_releases_redirect_head_check_total` — HEAD check outcomes (`found`, `not_found`, `error`) for release redirect targets
-- `ghp_forward_proxy_select_total` — forward proxy routing decisions by matched `ruleset` and `layer` (`token`, `app`, `net`, `system`, `ambient`)
+- `ghp_forward_proxy_select_total` — forward proxy routing decisions by matched `ruleset` and `layer` (`token`, `app`, `net`, `system`, `control`, `ambient`)
 - `ghp_forward_proxy_rulesets_active` — gauge of enabled forward proxy rulesets compiled into the route table
 - `ghp_cache_fetch_total` / `ghp_cache_lsrefs_total` / `ghp_cache_warm_total` — cache operation counters
 - `ghp_cache_packfile_total` / `ghp_cache_packfile_bytes_total` — packfile response cache hit/miss counts and bytes served

--- a/docs/admin/configuration.md
+++ b/docs/admin/configuration.md
@@ -149,6 +149,15 @@ See [Release Download Controls](../features/release-controls.md) for details.
 
 See [Codeload Redirect](../features/codeload.md) for details.
 
+### Forward Proxy
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `GHP_FORWARD_PROXY_ALLOW_REQUEST_HEADER` | Allow clients to select the upstream forward proxy per request via the `X-GitHub-Proxy-Forward-HTTP`/`-HTTPS`/`-SOCKS` headers. When disabled the headers are stripped and ignored. | `false` |
+
+Forward proxy *rulesets* are runtime configuration managed via the admin API,
+not this file. See [Forward Proxy Rulesets](../features/forward-proxy-rulesets.md).
+
 ### Git Cache
 
 | Variable | Description | Default |
@@ -274,6 +283,9 @@ codeload:
   redirect_to: ""              # absolute URL base for redirecting codeload archive requests; passthrough when empty
   allow:                       # org or org/repo entries that pass through to upstream codeload
     - "myorg"
+
+forward_proxy:
+  allow_request_header: false  # honour X-GitHub-Proxy-Forward-* client headers (rulesets are managed via the admin API)
 
 cache:
   enabled: false               # enable git clone/fetch caching

--- a/docs/features/forward-proxy-rulesets.md
+++ b/docs/features/forward-proxy-rulesets.md
@@ -34,6 +34,7 @@ A **ruleset** groups:
 | `app` | app record UUID | Requests from agent tokens minted against that GitHub App |
 | `net` | CIDR (e.g. `10.42.0.0/16`) | Requests whose client source IP falls in the network — cheap to evaluate and not tied to tokens, ideal when CI runners live in known subnets |
 | `system` | *(empty)* | All proxied traffic not matched by a more specific rule |
+| `control` | *(empty)* | ghp's own control-plane traffic: OAuth login flows and token refresh, App installation token minting, username resolution lookups, and release redirect HEAD probes |
 
 ### Layering
 
@@ -48,6 +49,28 @@ Selection is most-specific-first. The first layer with a matching rule wins:
 Token and app rules only apply on paths where ghp resolves the client token
 (the API proxy and git smart-HTTP passthrough). Traffic carrying raw GitHub
 credentials or no credentials is still covered by net and system rules.
+
+**Control traffic is layered separately.** ghp's own outbound calls are some
+of the most important traffic it emits — losing OAuth refresh or installation
+token minting to a banned egress IP takes down every client behind the proxy.
+Control traffic resolves `control` rule → `system` rule → ambient; token,
+app, and net layers never apply to it (it is not attributable to a client).
+A dedicated control ruleset lets you pin this traffic to its own tightly
+controlled egress path, isolated from the heavy proxied load:
+
+```json
+{
+  "name": "control-plane",
+  "algorithm": "round_robin",
+  "proxies": [{"url": "http://egress-quiet.internal:3128"}],
+  "rules": [{"type": "control"}]
+}
+```
+
+Note that release redirect HEAD probes target your configured redirect
+mirror, not GitHub — if that mirror is only reachable directly, keep it
+reachable from the control path (or leave control unrouted so probes use the
+ambient environment).
 
 ### Routing algorithms
 
@@ -103,7 +126,7 @@ without deleting it.
   credentials allowed, query strings and fragments rejected); weight 0–10000
   (0 normalizes to 1).
 - `rules` — up to 128; `app`/`token` values must be well-formed UUIDs, `net`
-  values valid CIDRs, `system` rules carry no value.
+  values valid CIDRs, `system` and `control` rules carry no value.
 
 ## Behaviour and failure modes
 
@@ -123,7 +146,8 @@ without deleting it.
 
 ## Observability
 
-- `ghp_forward_proxy_select_total{ruleset, layer}` — routing decisions;
+- `ghp_forward_proxy_select_total{ruleset, layer}` — routing decisions
+  (`layer` ∈ `token`, `app`, `net`, `system`, `control`, `ambient`);
   `layer="ambient"` counts requests that fell through to the environment.
 - `ghp_forward_proxy_rulesets_active` — enabled rulesets currently compiled
   into the route table.
@@ -138,6 +162,7 @@ without deleting it.
 - Token- and app-layer rules require ghp to resolve the client token, so they
   do not apply to passthrough traffic bearing raw GitHub credentials — use
   `net` rules for that traffic.
-- Internal calls that are not tied to a proxied request (OAuth token refresh,
-  GitHub App installation token minting, release redirect HEAD checks) use
-  the ambient environment.
+- Admin-UI convenience lookups that list installations/repositories through
+  the GitHub SDK use the ambient environment; the request-path control calls
+  (token minting, OAuth exchange/refresh, username resolution, HEAD probes)
+  all follow control-layer routing.

--- a/docs/features/forward-proxy-rulesets.md
+++ b/docs/features/forward-proxy-rulesets.md
@@ -134,6 +134,45 @@ without deleting it.
 - `rules` — up to 128; `app`/`token` values must be well-formed UUIDs, `net`
   values valid CIDRs, `system` and `control` rules carry no value.
 
+## Per-request client selection
+
+Sometimes a client knows something the operator's rules can't express — a
+team with its own egress path (IP allow-listing on the far side, say) that
+only needs it on particular requests. With the feature enabled, a client may
+select the forward proxy for a single request via headers:
+
+| Header | Accepted schemes |
+|---|---|
+| `X-GitHub-Proxy-Forward-HTTP` / `X-GitHub-Proxy-Forward-HTTPS` | `http`, `https` |
+| `X-GitHub-Proxy-Forward-SOCKS` | `socks5`, `socks5h` |
+
+```bash
+curl -H "Authorization: Bearer ghx_..." \
+  -H "X-GitHub-Proxy-Forward-HTTPS: http://team-egress.internal:3128" \
+  https://ghp.example.com/api/v3/user
+```
+
+Rules of engagement:
+
+- **Off by default.** Honouring the headers lets any client direct ghp to
+  open connections to an arbitrary proxy endpoint, so the feature is gated
+  behind `forward_proxy.allow_request_header: true`
+  (`GHP_FORWARD_PROXY_ALLOW_REQUEST_HEADER`). When disabled, the headers
+  are stripped and ignored.
+- A client-specified proxy **beats every ruleset layer** — the request still
+  flows through ghp, so token scoping, audit logging, and metrics all apply
+  as usual.
+- At most one proxy may be specified per request; conflicting headers or
+  invalid values are rejected with 400. Credentials in the proxy URL
+  (`http://user:pass@host:port`) are allowed; query strings and fragments
+  are not.
+- The headers are always stripped before the request is forwarded upstream —
+  they never reach GitHub.
+- Each use is counted in
+  `ghp_forward_proxy_client_specified_total{scheme, token_type}` and shows
+  as `layer="header"` in `ghp_forward_proxy_select_total`. The proxy URL is
+  deliberately never used as a metric label (client-controlled, unbounded).
+
 ## Behaviour and failure modes
 
 - **Fail-open to ambient.** A disabled ruleset, an invalid proxy URL, a
@@ -153,9 +192,11 @@ without deleting it.
 ## Observability
 
 - `ghp_forward_proxy_select_total{ruleset, layer}` — routing decisions
-  (`layer` ∈ `token`, `app`, `net`, `system`, `control`, `ambient`,
-  `direct`); `ambient` counts requests that fell through to the
+  (`layer` ∈ `header`, `token`, `app`, `net`, `system`, `control`,
+  `ambient`, `direct`); `ambient` counts requests that fell through to the
   environment, `direct` counts non-GitHub control calls sent with no proxy.
+- `ghp_forward_proxy_client_specified_total{scheme, token_type}` — requests
+  routed through a client-specified proxy header.
 - `ghp_forward_proxy_rulesets_active` — enabled rulesets currently compiled
   into the route table.
 - `ghp_proxy_decision_duration_seconds{stage="forward_proxy_selection"}` —

--- a/docs/features/forward-proxy-rulesets.md
+++ b/docs/features/forward-proxy-rulesets.md
@@ -1,0 +1,143 @@
+# Forward Proxy Rulesets
+
+By default, ghp's outbound GitHub traffic honours the process environment
+(`HTTPS_PROXY`, `HTTP_PROXY`, `NO_PROXY`) — a good default for most
+deployments. Forward proxy rulesets let you go further and deliberately steer
+GitHub-destined traffic out through specific egress paths at runtime.
+
+The motivating case is CI: continuous heavy API and clone traffic from CI
+fleets concentrated on a single egress IP has been known to trigger IP-level
+throttling or banning by GitHub. Splitting that traffic across multiple egress
+proxies — or pinning CI subnets to their own path while interactive users ride
+the default — contains the blast radius when an egress IP gets blocked.
+
+Rulesets are **runtime configuration**: they live in the database and are
+managed through the admin API, not the config file or environment. Changes
+take effect immediately on the instance that served the API call and propagate
+to other instances within a minute via a periodic route-table refresh — no
+restart required.
+
+## Concepts
+
+A **ruleset** groups:
+
+- one or more **proxy targets** — forward proxy URLs (`http`, `https`,
+  `socks5`, or `socks5h` schemes), each with an optional weight;
+- a **routing algorithm** that picks a target per request;
+- one or more **rules** that select which traffic the ruleset applies to.
+
+### Rule types
+
+| Type | Value | Matches |
+|---|---|---|
+| `token` | proxy token UUID | Requests authenticated by that specific ghx_/gha_ token |
+| `app` | app record UUID | Requests from agent tokens minted against that GitHub App |
+| `net` | CIDR (e.g. `10.42.0.0/16`) | Requests whose client source IP falls in the network — cheap to evaluate and not tied to tokens, ideal when CI runners live in known subnets |
+| `system` | *(empty)* | All proxied traffic not matched by a more specific rule |
+
+### Layering
+
+Selection is most-specific-first. The first layer with a matching rule wins:
+
+1. **Token-specific** rules
+2. **App-aligned** rules
+3. **Net (CIDR)** rules — when multiple CIDRs match, the longest prefix wins
+4. **System-wide** rules
+5. **None** — fall back to the ambient environment (`HTTPS_PROXY` et al.)
+
+Token and app rules only apply on paths where ghp resolves the client token
+(the API proxy and git smart-HTTP passthrough). Traffic carrying raw GitHub
+credentials or no credentials is still covered by net and system rules.
+
+### Routing algorithms
+
+| Algorithm | Behaviour |
+|---|---|
+| `round_robin` | Cycle through targets in order — simple even spread |
+| `weighted` | Random pick proportional to weight — e.g. run 80/20 so a blocked egress never burns both paths simultaneously |
+| `sticky` | Hash the client source IP onto the (weighted) target list, keeping each client's load on one path |
+
+Weights default to 1 and are ignored by `round_robin`.
+
+## Managing rulesets
+
+All endpoints require an admin session.
+
+```
+GET    /api/forward-proxy-rulesets        # list
+POST   /api/forward-proxy-rulesets        # create
+GET    /api/forward-proxy-rulesets/{id}   # fetch
+PATCH  /api/forward-proxy-rulesets/{id}   # partial update
+DELETE /api/forward-proxy-rulesets/{id}   # delete
+```
+
+Create a weighted CI egress split for a runner subnet:
+
+```bash
+curl -X POST https://ghp.example.com/api/forward-proxy-rulesets \
+  -H "Authorization: Bearer $ADMIN_SESSION" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "ci-egress",
+    "description": "CI runners split 80/20 across egress proxies",
+    "algorithm": "weighted",
+    "proxies": [
+      {"url": "http://egress-a.internal:3128", "weight": 80},
+      {"url": "http://egress-b.internal:3128", "weight": 20}
+    ],
+    "rules": [
+      {"type": "net", "value": "10.42.0.0/16"}
+    ]
+  }'
+```
+
+`PATCH` uses partial-update semantics: omitted fields are untouched; pass
+`"rules": []` to clear the rule list, `"enabled": false` to park a ruleset
+without deleting it.
+
+### Validation
+
+- `name` — unique; alphanumerics, dots, hyphens, underscores (max 128 chars).
+- `algorithm` — `round_robin`, `weighted`, or `sticky`.
+- `proxies` — 1–32 targets; `http`/`https`/`socks5`/`socks5h` URLs (userinfo
+  credentials allowed, query strings and fragments rejected); weight 0–10000
+  (0 normalizes to 1).
+- `rules` — up to 128; `app`/`token` values must be well-formed UUIDs, `net`
+  values valid CIDRs, `system` rules carry no value.
+
+## Behaviour and failure modes
+
+- **Fail-open to ambient.** A disabled ruleset, an invalid proxy URL, a
+  malformed CIDR, or a route-table load failure never blocks egress: affected
+  rules are skipped with a warning and unmatched traffic uses the environment
+  default.
+- **Conflicts resolve deterministically.** When two rulesets bind the same
+  token, app, or the system layer, the first by name wins and a warning is
+  logged.
+- **Connection pooling is preserved.** All outbound GitHub backends (API
+  proxy, github.com passthrough, codeload, Copilot) share one transport;
+  Go's HTTP transport pools connections per selected proxy.
+- **Client IP attribution** honours `server.client_ip_header`, the same
+  setting used for metrics and access logs. If ghp sits behind a load
+  balancer, configure it so `net` and `sticky` see real client addresses.
+
+## Observability
+
+- `ghp_forward_proxy_select_total{ruleset, layer}` — routing decisions;
+  `layer="ambient"` counts requests that fell through to the environment.
+- `ghp_forward_proxy_rulesets_active` — enabled rulesets currently compiled
+  into the route table.
+- `ghp_proxy_decision_duration_seconds{stage="forward_proxy_selection"}` —
+  selection overhead per request.
+
+## Known limitations
+
+- Round-robin counters and sticky hashing are per-instance: in HA
+  deployments each instance cycles independently, and rule changes made on
+  one instance take up to a minute to reach the others.
+- Token- and app-layer rules require ghp to resolve the client token, so they
+  do not apply to passthrough traffic bearing raw GitHub credentials — use
+  `net` rules for that traffic.
+- Internal calls that are not tied to a proxied request (OAuth token refresh,
+  GitHub App installation token minting, release redirect HEAD checks) use
+  the ambient environment.

--- a/docs/features/forward-proxy-rulesets.md
+++ b/docs/features/forward-proxy-rulesets.md
@@ -34,7 +34,7 @@ A **ruleset** groups:
 | `app` | app record UUID | Requests from agent tokens minted against that GitHub App |
 | `net` | CIDR (e.g. `10.42.0.0/16`) | Requests whose client source IP falls in the network — cheap to evaluate and not tied to tokens, ideal when CI runners live in known subnets |
 | `system` | *(empty)* | All proxied traffic not matched by a more specific rule |
-| `control` | *(empty)* | ghp's own control-plane traffic: OAuth login flows and token refresh, App installation token minting, username resolution lookups, and release redirect HEAD probes |
+| `control` | *(empty)* | ghp's own control-plane traffic: OAuth login flows and token refresh, App installation token minting, username resolution lookups. Set `include_non_github: true` on the rule to also cover control calls to non-GitHub hosts (release redirect HEAD probes), which otherwise go direct |
 
 ### Layering
 
@@ -67,10 +67,16 @@ controlled egress path, isolated from the heavy proxied load:
 }
 ```
 
-Note that release redirect HEAD probes target your configured redirect
-mirror, not GitHub — if that mirror is only reachable directly, keep it
-reachable from the control path (or leave control unrouted so probes use the
-ambient environment).
+**Non-GitHub control destinations go direct by default.** Release redirect
+HEAD probes target your configured redirect mirror, not GitHub — and mirrors
+are typically internal, so those probes are sent with no forward proxy at all
+(not even the ambient environment). To give non-GitHub control calls the same
+treatment as GitHub-destined control traffic, set `include_non_github` on the
+control rule:
+
+```json
+{"rules": [{"type": "control", "include_non_github": true}]}
+```
 
 ### Routing algorithms
 
@@ -147,8 +153,9 @@ without deleting it.
 ## Observability
 
 - `ghp_forward_proxy_select_total{ruleset, layer}` — routing decisions
-  (`layer` ∈ `token`, `app`, `net`, `system`, `control`, `ambient`);
-  `layer="ambient"` counts requests that fell through to the environment.
+  (`layer` ∈ `token`, `app`, `net`, `system`, `control`, `ambient`,
+  `direct`); `ambient` counts requests that fell through to the
+  environment, `direct` counts non-GitHub control calls sent with no proxy.
 - `ghp_forward_proxy_rulesets_active` — enabled rulesets currently compiled
   into the route table.
 - `ghp_proxy_decision_duration_seconds{stage="forward_proxy_selection"}` —
@@ -164,5 +171,6 @@ without deleting it.
   `net` rules for that traffic.
 - Admin-UI convenience lookups that list installations/repositories through
   the GitHub SDK use the ambient environment; the request-path control calls
-  (token minting, OAuth exchange/refresh, username resolution, HEAD probes)
-  all follow control-layer routing.
+  (token minting, OAuth exchange/refresh, username resolution) all follow
+  control-layer routing, and release HEAD probes follow it only with
+  `include_non_github`.

--- a/docs/features/forward-proxy-rulesets.md
+++ b/docs/features/forward-proxy-rulesets.md
@@ -223,8 +223,7 @@ Rules of engagement:
 - `token` and `app` rule values are stored as opaque references: deleting
   the referenced token or app leaves the rule in place, silently matching
   nothing. Prune stale rules when retiring tokens or apps.
-- On the Vault backend, ruleset create/rename name-uniqueness is
-  check-then-write without compare-and-set: concurrent creates of the same
-  name can race. Ruleset administration is a low-frequency operator action,
-  so this is accepted; SQL backends enforce uniqueness with a database
+- On the Vault backend, ruleset name-uniqueness is enforced by an atomic
+  KV v2 compare-and-set claim on the name index (with rollback if the
+  record write fails); SQL backends enforce uniqueness with a database
   constraint.

--- a/docs/features/forward-proxy-rulesets.md
+++ b/docs/features/forward-proxy-rulesets.md
@@ -154,11 +154,16 @@ curl -H "Authorization: Bearer ghx_..." \
 
 Rules of engagement:
 
-- **Off by default.** Honouring the headers lets any client direct ghp to
+- **Off by default.** Honouring the headers lets a client direct ghp to
   open connections to an arbitrary proxy endpoint, so the feature is gated
   behind `forward_proxy.allow_request_header: true`
   (`GHP_FORWARD_PROXY_ALLOW_REQUEST_HEADER`). When disabled, the headers
   are stripped and ignored.
+- **Authenticated requests only.** The header is honoured only after a
+  ghx_/gha_ token has been resolved for the request; anonymous traffic and
+  raw GitHub credentials on the passthrough path fall through to normal
+  ruleset selection. This keeps every client-directed egress attributable
+  to a token identity and closes the unauthenticated SSRF vector.
 - A client-specified proxy **beats every ruleset layer** — the request still
   flows through ghp, so token scoping, audit logging, and metrics all apply
   as usual.
@@ -215,3 +220,11 @@ Rules of engagement:
   (token minting, OAuth exchange/refresh, username resolution) all follow
   control-layer routing, and release HEAD probes follow it only with
   `include_non_github`.
+- `token` and `app` rule values are stored as opaque references: deleting
+  the referenced token or app leaves the rule in place, silently matching
+  nothing. Prune stale rules when retiring tokens or apps.
+- On the Vault backend, ruleset create/rename name-uniqueness is
+  check-then-write without compare-and-set: concurrent creates of the same
+  name can race. Ruleset administration is a low-frequency operator action,
+  so this is accepted; SQL backends enforce uniqueness with a database
+  constraint.

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -140,9 +140,11 @@ so an IP ban never takes down interactive users.
 Rulesets bind proxy targets and a routing algorithm (round robin, weighted,
 sticky-by-source-IP) to traffic selected by token, app, source network (CIDR),
 system-wide, or control rules; more specific layers win. Control rules cover
-ghp's own outbound calls (OAuth flows and token refresh, installation token
-minting, username resolution, release HEAD probes) so the proxy's
-control-plane traffic can be pinned to a dedicated egress path. They are managed via the admin
+ghp's own GitHub-destined calls (OAuth flows and token refresh, installation
+token minting, username resolution) so the proxy's control-plane traffic can
+be pinned to a dedicated egress path; release HEAD probes target the
+operator's mirror and go direct unless the control rule opts them in via
+`include_non_github`. They are managed via the admin
 API (`/api/forward-proxy-rulesets`) and take effect without a restart.
 Anything not matched by a ruleset continues to use the ambient environment.
 

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -139,7 +139,10 @@ so an IP ban never takes down interactive users.
 
 Rulesets bind proxy targets and a routing algorithm (round robin, weighted,
 sticky-by-source-IP) to traffic selected by token, app, source network (CIDR),
-or system-wide rules; more specific layers win. They are managed via the admin
+system-wide, or control rules; more specific layers win. Control rules cover
+ghp's own outbound calls (OAuth flows and token refresh, installation token
+minting, username resolution, release HEAD probes) so the proxy's
+control-plane traffic can be pinned to a dedicated egress path. They are managed via the admin
 API (`/api/forward-proxy-rulesets`) and take effect without a restart.
 Anything not matched by a ruleset continues to use the ambient environment.
 

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -129,6 +129,22 @@ verifies GitHub access before serving cached data.
 
 See [Git Cache](features/git-cache.md) for configuration and details.
 
+### Forward Proxy Rulesets
+
+Outbound GitHub traffic honours the process environment (`HTTPS_PROXY` et al.)
+by default. Forward proxy rulesets let operators steer traffic out through
+specific egress proxies at runtime — for example splitting heavy CI traffic
+80/20 across two egress IPs, or pinning CI runner subnets to a dedicated path
+so an IP ban never takes down interactive users.
+
+Rulesets bind proxy targets and a routing algorithm (round robin, weighted,
+sticky-by-source-IP) to traffic selected by token, app, source network (CIDR),
+or system-wide rules; more specific layers win. They are managed via the admin
+API (`/api/forward-proxy-rulesets`) and take effect without a restart.
+Anything not matched by a ruleset continues to use the ambient environment.
+
+See [Forward Proxy Rulesets](features/forward-proxy-rulesets.md) for details.
+
 ### Multi-App Support
 
 ghp supports multiple GitHub Apps simultaneously. Each app can have its own

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -150,6 +150,14 @@ func NewHandler(cfg *config.Config, store database.Store, enc *crypto.Encryptor,
 	return h
 }
 
+// SetTransport sets the transport used for outbound OAuth and GitHub API
+// requests (code exchange, user lookups). The server installs the forward
+// proxy control transport here so auth traffic — ghp control traffic —
+// follows the control-layer egress routing.
+func (h *Handler) SetTransport(rt http.RoundTripper) {
+	h.httpClient.Transport = rt
+}
+
 // secureCookies returns true when cookies should be sent with the Secure flag.
 // This is the case when TLS certificates are configured or when the BaseURL
 // uses an https:// scheme.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -418,6 +418,15 @@ func Load(path string) (*Config, error) {
 						return "logging.file." + field[len("file_"):], v
 					}
 					return section + "." + field, v
+				case "forward":
+					// The forward_proxy section contains an underscore, so the
+					// first-underscore split yields section "forward" with the
+					// real field after the "proxy_" prefix
+					// (GHP_FORWARD_PROXY_ALLOW_REQUEST_HEADER ->
+					// forward_proxy.allow_request_header).
+					if strings.HasPrefix(field, "proxy_") {
+						return "forward_proxy." + field[len("proxy_"):], v
+					}
 				}
 			}
 			return s, v

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -67,11 +67,26 @@ type Config struct {
 
 	Cache CacheConfig `koanf:"cache"`
 
+	ForwardProxy ForwardProxyConfig `koanf:"forward_proxy"`
+
 	EncryptionKey string `koanf:"encryption_key"`
 
 	// DevMode enables test-only endpoints (e.g. /auth/test-login).
 	// Must never be enabled in production.
 	DevMode bool `koanf:"dev_mode"`
+}
+
+// ForwardProxyConfig gates forward proxy behaviours that are configured
+// statically rather than through the runtime ruleset API.
+type ForwardProxyConfig struct {
+	// AllowRequestHeader enables per-request client selection of the
+	// upstream forward proxy via the X-GitHub-Proxy-Forward-HTTP,
+	// X-GitHub-Proxy-Forward-HTTPS, and X-GitHub-Proxy-Forward-SOCKS
+	// request headers. Off by default: honouring the headers lets any
+	// client direct ghp to open connections to an arbitrary proxy
+	// endpoint, so operators must opt in deliberately. When disabled the
+	// headers are stripped and ignored.
+	AllowRequestHeader bool `koanf:"allow_request_header"`
 }
 
 // BlockConfig defines which GitHub token prefixes are blocked from

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -585,3 +585,25 @@ func TestWarnMissingClientIPHeader(t *testing.T) {
 		})
 	}
 }
+
+func TestLoadForwardProxyAllowRequestHeaderFromEnv(t *testing.T) {
+	t.Setenv("GHP_FORWARD_PROXY_ALLOW_REQUEST_HEADER", "true")
+
+	cfg, err := Load("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !cfg.ForwardProxy.AllowRequestHeader {
+		t.Error("expected ForwardProxy.AllowRequestHeader to be true")
+	}
+}
+
+func TestForwardProxyAllowRequestHeaderDefaultsFalse(t *testing.T) {
+	cfg, err := Load("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.ForwardProxy.AllowRequestHeader {
+		t.Error("expected ForwardProxy.AllowRequestHeader to default to false")
+	}
+}

--- a/internal/database/migrations/postgres/011_add_forward_proxy_rulesets.down.sql
+++ b/internal/database/migrations/postgres/011_add_forward_proxy_rulesets.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS forward_proxy_rulesets;

--- a/internal/database/migrations/postgres/011_add_forward_proxy_rulesets.up.sql
+++ b/internal/database/migrations/postgres/011_add_forward_proxy_rulesets.up.sql
@@ -1,0 +1,13 @@
+CREATE TABLE forward_proxy_rulesets (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    name TEXT NOT NULL,
+    description TEXT NOT NULL DEFAULT '',
+    algorithm TEXT NOT NULL CHECK (algorithm IN ('round_robin', 'weighted', 'sticky')),
+    proxies TEXT NOT NULL DEFAULT '[]',
+    rules TEXT NOT NULL DEFAULT '[]',
+    enabled BOOLEAN NOT NULL DEFAULT TRUE,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE UNIQUE INDEX idx_forward_proxy_rulesets_name ON forward_proxy_rulesets (name);

--- a/internal/database/migrations/sqlite/011_add_forward_proxy_rulesets.down.sql
+++ b/internal/database/migrations/sqlite/011_add_forward_proxy_rulesets.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS forward_proxy_rulesets;

--- a/internal/database/migrations/sqlite/011_add_forward_proxy_rulesets.up.sql
+++ b/internal/database/migrations/sqlite/011_add_forward_proxy_rulesets.up.sql
@@ -1,0 +1,13 @@
+CREATE TABLE forward_proxy_rulesets (
+    id TEXT PRIMARY KEY,
+    name TEXT NOT NULL,
+    description TEXT NOT NULL DEFAULT '',
+    algorithm TEXT NOT NULL CHECK (algorithm IN ('round_robin', 'weighted', 'sticky')),
+    proxies TEXT NOT NULL DEFAULT '[]',
+    rules TEXT NOT NULL DEFAULT '[]',
+    enabled INTEGER NOT NULL DEFAULT 1,
+    created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+    updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+);
+
+CREATE UNIQUE INDEX idx_forward_proxy_rulesets_name ON forward_proxy_rulesets (name);

--- a/internal/database/models.go
+++ b/internal/database/models.go
@@ -120,6 +120,97 @@ type CachedRepository struct {
 	UpdatedAt       time.Time `json:"updated_at"`
 }
 
+// Forward proxy ruleset routing algorithms. The DB CHECK constraint enforces
+// these values; keep them in sync.
+const (
+	ForwardProxyAlgoRoundRobin = "round_robin"
+	ForwardProxyAlgoWeighted   = "weighted"
+	ForwardProxyAlgoSticky     = "sticky"
+)
+
+// Forward proxy rule types. A rule binds a ruleset to the traffic it should
+// route: the whole system, a GitHub App record, a specific proxy token, or a
+// client source network.
+const (
+	ForwardProxyRuleSystem = "system"
+	ForwardProxyRuleApp    = "app"
+	ForwardProxyRuleToken  = "token"
+	ForwardProxyRuleNet    = "net"
+)
+
+// ForwardProxyEntry is a single upstream forward proxy target within a
+// ruleset. Weight is only meaningful for the weighted and sticky algorithms;
+// a zero weight is normalized to 1 at validation time.
+type ForwardProxyEntry struct {
+	URL    string `json:"url"`
+	Weight int    `json:"weight"`
+}
+
+// ForwardProxyRule binds a ruleset to matching traffic. Value is empty for
+// "system" rules, an App record UUID for "app" rules, a ProxyToken UUID for
+// "token" rules, and a CIDR (e.g. "10.1.0.0/16") for "net" rules.
+type ForwardProxyRule struct {
+	Type  string `json:"type"`
+	Value string `json:"value,omitempty"`
+}
+
+// ForwardProxyRuleset groups a set of upstream forward proxies with a routing
+// algorithm and the rules that select which traffic egresses through them.
+// Rulesets are runtime configuration: they live in the database and are
+// managed through the admin API, not the config file.
+type ForwardProxyRuleset struct {
+	ID          string              `json:"id"`
+	Name        string              `json:"name"`
+	Description string              `json:"description"`
+	Algorithm   string              `json:"algorithm"`
+	Proxies     []ForwardProxyEntry `json:"proxies"`
+	Rules       []ForwardProxyRule  `json:"rules"`
+	Enabled     bool                `json:"enabled"`
+	CreatedAt   time.Time           `json:"created_at"`
+	UpdatedAt   time.Time           `json:"updated_at"`
+}
+
+// encodeForwardProxyFields serializes the Proxies and Rules slices to JSON for
+// SQL storage. Nil slices encode as "[]" so the columns never hold SQL NULL or
+// the JSON literal null.
+func encodeForwardProxyFields(rs *ForwardProxyRuleset) (proxies string, rules string, err error) {
+	p := rs.Proxies
+	if p == nil {
+		p = []ForwardProxyEntry{}
+	}
+	r := rs.Rules
+	if r == nil {
+		r = []ForwardProxyRule{}
+	}
+	pb, err := json.Marshal(p)
+	if err != nil {
+		return "", "", err
+	}
+	rb, err := json.Marshal(r)
+	if err != nil {
+		return "", "", err
+	}
+	return string(pb), string(rb), nil
+}
+
+// decodeForwardProxyFields populates the Proxies and Rules slices from their
+// JSON column values. Missing/empty values decode to empty (non-nil) slices.
+func decodeForwardProxyFields(rs *ForwardProxyRuleset, proxies, rules string) error {
+	rs.Proxies = make([]ForwardProxyEntry, 0)
+	rs.Rules = make([]ForwardProxyRule, 0)
+	if proxies != "" {
+		if err := json.Unmarshal([]byte(proxies), &rs.Proxies); err != nil {
+			return err
+		}
+	}
+	if rules != "" {
+		if err := json.Unmarshal([]byte(rules), &rs.Rules); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // Session represents a persisted browser/CLI session. The bearer token
 // presented in the Authorization header (or the ghp_session cookie) is
 // hashed with SHA-256 before being looked up here, so the database never
@@ -237,6 +328,27 @@ type Store interface {
 	ListCachedRepositories(ctx context.Context) ([]*CachedRepository, error)
 	UpdateCachedRepository(ctx context.Context, repo *CachedRepository) error
 	DeleteCachedRepository(ctx context.Context, id string) error
+
+	// Forward proxy rulesets (runtime egress routing configuration).
+	//
+	// CreateForwardProxyRuleset inserts a new ruleset. The Name must be
+	// unique; violations surface as a backend-specific unique-constraint or
+	// "already exists" error.
+	CreateForwardProxyRuleset(ctx context.Context, rs *ForwardProxyRuleset) error
+	// GetForwardProxyRulesetByID returns the ruleset with the given ID, or
+	// (nil, nil) if it does not exist.
+	GetForwardProxyRulesetByID(ctx context.Context, id string) (*ForwardProxyRuleset, error)
+	// GetForwardProxyRulesetByName returns the ruleset with the given name,
+	// or (nil, nil) if it does not exist.
+	GetForwardProxyRulesetByName(ctx context.Context, name string) (*ForwardProxyRuleset, error)
+	// ListForwardProxyRulesets returns all rulesets ordered by name.
+	ListForwardProxyRulesets(ctx context.Context) ([]*ForwardProxyRuleset, error)
+	// UpdateForwardProxyRuleset persists all mutable fields of rs. Returns
+	// ErrNotFound if the ruleset does not exist.
+	UpdateForwardProxyRuleset(ctx context.Context, rs *ForwardProxyRuleset) error
+	// DeleteForwardProxyRuleset removes a ruleset by ID. Returns ErrNotFound
+	// if the ruleset does not exist.
+	DeleteForwardProxyRuleset(ctx context.Context, id string) error
 
 	// Sessions (browser cookie / CLI bearer).
 	//

--- a/internal/database/models.go
+++ b/internal/database/models.go
@@ -347,8 +347,8 @@ type Store interface {
 	// unique; violations surface as a backend-specific unique-constraint or
 	// "already exists" error.
 	CreateForwardProxyRuleset(ctx context.Context, rs *ForwardProxyRuleset) error
-	// GetForwardProxyRulesetByID returns the ruleset with the given ID, or
-	// (nil, nil) if it does not exist.
+	// GetForwardProxyRulesetByID returns the ruleset with the given ID.
+	// Returns wrapped ErrNotFound if it does not exist.
 	GetForwardProxyRulesetByID(ctx context.Context, id string) (*ForwardProxyRuleset, error)
 	// GetForwardProxyRulesetByName returns the ruleset with the given name,
 	// or (nil, nil) if it does not exist.

--- a/internal/database/models.go
+++ b/internal/database/models.go
@@ -129,13 +129,16 @@ const (
 )
 
 // Forward proxy rule types. A rule binds a ruleset to the traffic it should
-// route: the whole system, a GitHub App record, a specific proxy token, or a
-// client source network.
+// route: the whole system, a GitHub App record, a specific proxy token, a
+// client source network, or ghp's own control-plane traffic (OAuth flows and
+// token refresh, App installation token minting, username resolution, release
+// redirect HEAD probes).
 const (
-	ForwardProxyRuleSystem = "system"
-	ForwardProxyRuleApp    = "app"
-	ForwardProxyRuleToken  = "token"
-	ForwardProxyRuleNet    = "net"
+	ForwardProxyRuleSystem  = "system"
+	ForwardProxyRuleApp     = "app"
+	ForwardProxyRuleToken   = "token"
+	ForwardProxyRuleNet     = "net"
+	ForwardProxyRuleControl = "control"
 )
 
 // ForwardProxyEntry is a single upstream forward proxy target within a

--- a/internal/database/models.go
+++ b/internal/database/models.go
@@ -150,11 +150,20 @@ type ForwardProxyEntry struct {
 }
 
 // ForwardProxyRule binds a ruleset to matching traffic. Value is empty for
-// "system" rules, an App record UUID for "app" rules, a ProxyToken UUID for
-// "token" rules, and a CIDR (e.g. "10.1.0.0/16") for "net" rules.
+// "system" and "control" rules, an App record UUID for "app" rules, a
+// ProxyToken UUID for "token" rules, and a CIDR (e.g. "10.1.0.0/16") for
+// "net" rules.
+//
+// IncludeNonGitHub is only meaningful on "control" rules: when true, ghp's
+// control calls that target non-GitHub hosts (currently release redirect
+// HEAD probes against the operator's mirror) are routed through the control
+// ruleset like GitHub-destined control traffic. When false (the default),
+// those calls are sent direct — mirrors are typically internal, so no
+// forward proxy (not even the ambient environment) is applied.
 type ForwardProxyRule struct {
-	Type  string `json:"type"`
-	Value string `json:"value,omitempty"`
+	Type             string `json:"type"`
+	Value            string `json:"value,omitempty"`
+	IncludeNonGitHub bool   `json:"include_non_github,omitempty"`
 }
 
 // ForwardProxyRuleset groups a set of upstream forward proxies with a routing

--- a/internal/database/postgres.go
+++ b/internal/database/postgres.go
@@ -672,6 +672,117 @@ func (s *PostgresStore) DeleteCachedRepository(ctx context.Context, id string) e
 	return nil
 }
 
+// --- Forward proxy rulesets ---
+
+func (s *PostgresStore) CreateForwardProxyRuleset(ctx context.Context, rs *ForwardProxyRuleset) error {
+	if rs.ID == "" {
+		rs.ID = uuid.New().String()
+	}
+	proxies, rules, err := encodeForwardProxyFields(rs)
+	if err != nil {
+		return fmt.Errorf("encoding forward proxy ruleset: %w", err)
+	}
+	now := time.Now().UTC()
+	return s.db.QueryRowContext(ctx, `
+		INSERT INTO forward_proxy_rulesets (id, name, description, algorithm, proxies, rules, enabled, created_at, updated_at)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+		RETURNING created_at, updated_at
+	`, rs.ID, rs.Name, rs.Description, rs.Algorithm, proxies, rules, rs.Enabled, now, now,
+	).Scan(&rs.CreatedAt, &rs.UpdatedAt)
+}
+
+func scanPostgresForwardProxyRuleset(scan func(dest ...interface{}) error) (*ForwardProxyRuleset, error) {
+	rs := &ForwardProxyRuleset{}
+	var proxies, rules string
+	if err := scan(&rs.ID, &rs.Name, &rs.Description, &rs.Algorithm, &proxies, &rules, &rs.Enabled, &rs.CreatedAt, &rs.UpdatedAt); err != nil {
+		return nil, err
+	}
+	if err := decodeForwardProxyFields(rs, proxies, rules); err != nil {
+		return nil, err
+	}
+	return rs, nil
+}
+
+const postgresForwardProxyRulesetColumns = `id, name, description, algorithm, proxies, rules, enabled, created_at, updated_at`
+
+func (s *PostgresStore) GetForwardProxyRulesetByID(ctx context.Context, id string) (*ForwardProxyRuleset, error) {
+	row := s.db.QueryRowContext(ctx,
+		`SELECT `+postgresForwardProxyRulesetColumns+` FROM forward_proxy_rulesets WHERE id = $1`, id)
+	rs, err := scanPostgresForwardProxyRuleset(row.Scan)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	return rs, err
+}
+
+func (s *PostgresStore) GetForwardProxyRulesetByName(ctx context.Context, name string) (*ForwardProxyRuleset, error) {
+	row := s.db.QueryRowContext(ctx,
+		`SELECT `+postgresForwardProxyRulesetColumns+` FROM forward_proxy_rulesets WHERE name = $1`, name)
+	rs, err := scanPostgresForwardProxyRuleset(row.Scan)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	return rs, err
+}
+
+func (s *PostgresStore) ListForwardProxyRulesets(ctx context.Context) ([]*ForwardProxyRuleset, error) {
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT `+postgresForwardProxyRulesetColumns+` FROM forward_proxy_rulesets ORDER BY name`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var rulesets []*ForwardProxyRuleset
+	for rows.Next() {
+		rs, err := scanPostgresForwardProxyRuleset(rows.Scan)
+		if err != nil {
+			return nil, err
+		}
+		rulesets = append(rulesets, rs)
+	}
+	return rulesets, rows.Err()
+}
+
+func (s *PostgresStore) UpdateForwardProxyRuleset(ctx context.Context, rs *ForwardProxyRuleset) error {
+	proxies, rules, err := encodeForwardProxyFields(rs)
+	if err != nil {
+		return fmt.Errorf("encoding forward proxy ruleset: %w", err)
+	}
+	now := time.Now().UTC()
+	result, err := s.db.ExecContext(ctx, `
+		UPDATE forward_proxy_rulesets SET name = $1, description = $2, algorithm = $3, proxies = $4, rules = $5, enabled = $6, updated_at = $7
+		WHERE id = $8
+	`, rs.Name, rs.Description, rs.Algorithm, proxies, rules, rs.Enabled, now, rs.ID)
+	if err != nil {
+		return err
+	}
+	n, err := result.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if n == 0 {
+		return fmt.Errorf("forward proxy ruleset %s: %w", rs.ID, ErrNotFound)
+	}
+	rs.UpdatedAt = now
+	return nil
+}
+
+func (s *PostgresStore) DeleteForwardProxyRuleset(ctx context.Context, id string) error {
+	result, err := s.db.ExecContext(ctx, `DELETE FROM forward_proxy_rulesets WHERE id = $1`, id)
+	if err != nil {
+		return err
+	}
+	n, err := result.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if n == 0 {
+		return fmt.Errorf("forward proxy ruleset %s: %w", id, ErrNotFound)
+	}
+	return nil
+}
+
 // --- Sessions ---
 
 func (s *PostgresStore) CreateSession(ctx context.Context, sess *Session) error {

--- a/internal/database/postgres.go
+++ b/internal/database/postgres.go
@@ -710,7 +710,7 @@ func (s *PostgresStore) GetForwardProxyRulesetByID(ctx context.Context, id strin
 		`SELECT `+postgresForwardProxyRulesetColumns+` FROM forward_proxy_rulesets WHERE id = $1`, id)
 	rs, err := scanPostgresForwardProxyRuleset(row.Scan)
 	if err == sql.ErrNoRows {
-		return nil, nil
+		return nil, fmt.Errorf("forward proxy ruleset %s: %w", id, ErrNotFound)
 	}
 	return rs, err
 }

--- a/internal/database/sqlite.go
+++ b/internal/database/sqlite.go
@@ -859,7 +859,7 @@ func (s *SQLiteStore) GetForwardProxyRulesetByID(ctx context.Context, id string)
 		`SELECT `+sqliteForwardProxyRulesetColumns+` FROM forward_proxy_rulesets WHERE id = ?`, id)
 	rs, err := scanForwardProxyRuleset(row.Scan)
 	if err == sql.ErrNoRows {
-		return nil, nil
+		return nil, fmt.Errorf("forward proxy ruleset %s: %w", id, ErrNotFound)
 	}
 	return rs, err
 }

--- a/internal/database/sqlite.go
+++ b/internal/database/sqlite.go
@@ -815,6 +815,123 @@ func (s *SQLiteStore) DeleteCachedRepository(ctx context.Context, id string) err
 	return nil
 }
 
+// --- Forward proxy rulesets ---
+
+func (s *SQLiteStore) CreateForwardProxyRuleset(ctx context.Context, rs *ForwardProxyRuleset) error {
+	if rs.ID == "" {
+		rs.ID = uuid.New().String()
+	}
+	proxies, rules, err := encodeForwardProxyFields(rs)
+	if err != nil {
+		return fmt.Errorf("encoding forward proxy ruleset: %w", err)
+	}
+	now := time.Now().UTC().Format(time.RFC3339Nano)
+	_, err = s.db.ExecContext(ctx, `
+		INSERT INTO forward_proxy_rulesets (id, name, description, algorithm, proxies, rules, enabled, created_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+	`, rs.ID, rs.Name, rs.Description, rs.Algorithm, proxies, rules, rs.Enabled, now, now)
+	if err != nil {
+		return err
+	}
+	rs.CreatedAt = parseTime(now)
+	rs.UpdatedAt = parseTime(now)
+	return nil
+}
+
+func scanForwardProxyRuleset(scan func(dest ...interface{}) error) (*ForwardProxyRuleset, error) {
+	rs := &ForwardProxyRuleset{}
+	var proxies, rules, createdStr, updatedStr string
+	if err := scan(&rs.ID, &rs.Name, &rs.Description, &rs.Algorithm, &proxies, &rules, &rs.Enabled, &createdStr, &updatedStr); err != nil {
+		return nil, err
+	}
+	if err := decodeForwardProxyFields(rs, proxies, rules); err != nil {
+		return nil, err
+	}
+	rs.CreatedAt = parseTime(createdStr)
+	rs.UpdatedAt = parseTime(updatedStr)
+	return rs, nil
+}
+
+const sqliteForwardProxyRulesetColumns = `id, name, description, algorithm, proxies, rules, enabled, created_at, updated_at`
+
+func (s *SQLiteStore) GetForwardProxyRulesetByID(ctx context.Context, id string) (*ForwardProxyRuleset, error) {
+	row := s.db.QueryRowContext(ctx,
+		`SELECT `+sqliteForwardProxyRulesetColumns+` FROM forward_proxy_rulesets WHERE id = ?`, id)
+	rs, err := scanForwardProxyRuleset(row.Scan)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	return rs, err
+}
+
+func (s *SQLiteStore) GetForwardProxyRulesetByName(ctx context.Context, name string) (*ForwardProxyRuleset, error) {
+	row := s.db.QueryRowContext(ctx,
+		`SELECT `+sqliteForwardProxyRulesetColumns+` FROM forward_proxy_rulesets WHERE name = ?`, name)
+	rs, err := scanForwardProxyRuleset(row.Scan)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	return rs, err
+}
+
+func (s *SQLiteStore) ListForwardProxyRulesets(ctx context.Context) ([]*ForwardProxyRuleset, error) {
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT `+sqliteForwardProxyRulesetColumns+` FROM forward_proxy_rulesets ORDER BY name`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var rulesets []*ForwardProxyRuleset
+	for rows.Next() {
+		rs, err := scanForwardProxyRuleset(rows.Scan)
+		if err != nil {
+			return nil, err
+		}
+		rulesets = append(rulesets, rs)
+	}
+	return rulesets, rows.Err()
+}
+
+func (s *SQLiteStore) UpdateForwardProxyRuleset(ctx context.Context, rs *ForwardProxyRuleset) error {
+	proxies, rules, err := encodeForwardProxyFields(rs)
+	if err != nil {
+		return fmt.Errorf("encoding forward proxy ruleset: %w", err)
+	}
+	now := time.Now().UTC().Format(time.RFC3339Nano)
+	result, err := s.db.ExecContext(ctx, `
+		UPDATE forward_proxy_rulesets SET name = ?, description = ?, algorithm = ?, proxies = ?, rules = ?, enabled = ?, updated_at = ?
+		WHERE id = ?
+	`, rs.Name, rs.Description, rs.Algorithm, proxies, rules, rs.Enabled, now, rs.ID)
+	if err != nil {
+		return err
+	}
+	n, err := result.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if n == 0 {
+		return fmt.Errorf("forward proxy ruleset %s: %w", rs.ID, ErrNotFound)
+	}
+	rs.UpdatedAt = parseTime(now)
+	return nil
+}
+
+func (s *SQLiteStore) DeleteForwardProxyRuleset(ctx context.Context, id string) error {
+	result, err := s.db.ExecContext(ctx, `DELETE FROM forward_proxy_rulesets WHERE id = ?`, id)
+	if err != nil {
+		return err
+	}
+	n, err := result.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if n == 0 {
+		return fmt.Errorf("forward proxy ruleset %s: %w", id, ErrNotFound)
+	}
+	return nil
+}
+
 // --- Sessions ---
 
 func (s *SQLiteStore) CreateSession(ctx context.Context, sess *Session) error {

--- a/internal/database/store_test.go
+++ b/internal/database/store_test.go
@@ -1699,9 +1699,10 @@ func testForwardProxyRulesetCRUD(t *testing.T, store Store) {
 		t.Fatalf("GetForwardProxyRulesetByName = %+v, want ID %s", byName, rs.ID)
 	}
 
-	// Missing lookups return (nil, nil).
-	if missing, err := store.GetForwardProxyRulesetByID(ctx, newUUIDString()); err != nil || missing != nil {
-		t.Errorf("GetForwardProxyRulesetByID(missing) = (%+v, %v), want (nil, nil)", missing, err)
+	// Missing ID lookups return wrapped ErrNotFound; name lookups are
+	// existence probes and return (nil, nil).
+	if _, err := store.GetForwardProxyRulesetByID(ctx, newUUIDString()); !errors.Is(err, ErrNotFound) {
+		t.Errorf("GetForwardProxyRulesetByID(missing) err = %v, want ErrNotFound", err)
 	}
 	if missing, err := store.GetForwardProxyRulesetByName(ctx, "no-such-ruleset"); err != nil || missing != nil {
 		t.Errorf("GetForwardProxyRulesetByName(missing) = (%+v, %v), want (nil, nil)", missing, err)
@@ -1758,8 +1759,8 @@ func testForwardProxyRulesetCRUD(t *testing.T, store Store) {
 	if err := store.DeleteForwardProxyRuleset(ctx, rs.ID); err != nil {
 		t.Fatalf("DeleteForwardProxyRuleset: %v", err)
 	}
-	if gone, err := store.GetForwardProxyRulesetByID(ctx, rs.ID); err != nil || gone != nil {
-		t.Errorf("GetForwardProxyRulesetByID after delete = (%+v, %v), want (nil, nil)", gone, err)
+	if _, err := store.GetForwardProxyRulesetByID(ctx, rs.ID); !errors.Is(err, ErrNotFound) {
+		t.Errorf("GetForwardProxyRulesetByID after delete err = %v, want ErrNotFound", err)
 	}
 	if err := store.DeleteForwardProxyRuleset(ctx, newUUIDString()); !errors.Is(err, ErrNotFound) {
 		t.Errorf("DeleteForwardProxyRuleset(missing) = %v, want ErrNotFound", err)

--- a/internal/database/store_test.go
+++ b/internal/database/store_test.go
@@ -1625,7 +1625,7 @@ func testForwardProxyRulesetCRUD(t *testing.T, store Store) {
 		},
 		Rules: []ForwardProxyRule{
 			{Type: ForwardProxyRuleNet, Value: "10.42.0.0/16"},
-			{Type: ForwardProxyRuleSystem},
+			{Type: ForwardProxyRuleControl, IncludeNonGitHub: true},
 		},
 		Enabled: true,
 	}
@@ -1677,8 +1677,11 @@ func testForwardProxyRulesetCRUD(t *testing.T, store Store) {
 	if got.Rules[0].Type != ForwardProxyRuleNet || got.Rules[0].Value != "10.42.0.0/16" {
 		t.Errorf("rules[0] = %+v, want {net 10.42.0.0/16}", got.Rules[0])
 	}
-	if got.Rules[1].Type != ForwardProxyRuleSystem || got.Rules[1].Value != "" {
-		t.Errorf("rules[1] = %+v, want {system }", got.Rules[1])
+	if got.Rules[1].Type != ForwardProxyRuleControl || got.Rules[1].Value != "" || !got.Rules[1].IncludeNonGitHub {
+		t.Errorf("rules[1] = %+v, want {control include_non_github=true}", got.Rules[1])
+	}
+	if got.Rules[0].IncludeNonGitHub {
+		t.Errorf("rules[0].IncludeNonGitHub = true, want false")
 	}
 	if !got.Enabled {
 		t.Error("expected enabled = true")

--- a/internal/database/store_test.go
+++ b/internal/database/store_test.go
@@ -7,9 +7,16 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/google/uuid"
 )
 
 func timePtr(t time.Time) *time.Time { return &t }
+
+// newUUIDString returns a fresh random UUID for non-existent record lookups.
+// Postgres UUID columns reject arbitrary strings, so tests must always use
+// well-formed UUIDs for missing-record probes.
+func newUUIDString() string { return uuid.New().String() }
 
 // testStoreContract runs the full CRUD test suite against any Store implementation.
 // Each backend test file calls this with its own Store instance.
@@ -25,6 +32,7 @@ func testStoreContract(t *testing.T, store Store) {
 	t.Run("GitHubTokenAppID", func(t *testing.T) { testGitHubTokenAppID(t, store) })
 	t.Run("SyncAdminRoles", func(t *testing.T) { testSyncAdminRoles(t, store) })
 	t.Run("CachedRepositoryCRUD", func(t *testing.T) { testCachedRepositoryCRUD(t, store) })
+	t.Run("ForwardProxyRulesetCRUD", func(t *testing.T) { testForwardProxyRulesetCRUD(t, store) })
 	t.Run("DeleteExpiredProxyTokens", func(t *testing.T) { testDeleteExpiredProxyTokens(t, store) })
 	t.Run("SessionCRUD", func(t *testing.T) { testSessionCRUD(t, store) })
 	t.Run("OAuthStateConsume", func(t *testing.T) { testOAuthStateConsume(t, store) })
@@ -1600,5 +1608,157 @@ func testDeviceAuthCRUD(t *testing.T, store Store) {
 	}
 	if n < 1 {
 		t.Errorf("DeleteExpiredDeviceAuths removed %d, want >= 1", n)
+	}
+}
+
+func testForwardProxyRulesetCRUD(t *testing.T, store Store) {
+	ctx := context.Background()
+
+	// Create.
+	rs := &ForwardProxyRuleset{
+		Name:        "ci-egress",
+		Description: "CI traffic egress split",
+		Algorithm:   ForwardProxyAlgoWeighted,
+		Proxies: []ForwardProxyEntry{
+			{URL: "http://proxy-a.internal:3128", Weight: 80},
+			{URL: "http://proxy-b.internal:3128", Weight: 20},
+		},
+		Rules: []ForwardProxyRule{
+			{Type: ForwardProxyRuleNet, Value: "10.42.0.0/16"},
+			{Type: ForwardProxyRuleSystem},
+		},
+		Enabled: true,
+	}
+	if err := store.CreateForwardProxyRuleset(ctx, rs); err != nil {
+		t.Fatalf("CreateForwardProxyRuleset: %v", err)
+	}
+	if rs.ID == "" {
+		t.Fatal("expected ID to be set")
+	}
+	if rs.CreatedAt.IsZero() || rs.UpdatedAt.IsZero() {
+		t.Fatal("expected CreatedAt/UpdatedAt to be set")
+	}
+
+	// Duplicate name must be rejected.
+	dup := &ForwardProxyRuleset{Name: "ci-egress", Algorithm: ForwardProxyAlgoRoundRobin}
+	if err := store.CreateForwardProxyRuleset(ctx, dup); err == nil {
+		t.Error("expected duplicate name create to fail")
+	}
+
+	// Get by ID — every field round-trips.
+	got, err := store.GetForwardProxyRulesetByID(ctx, rs.ID)
+	if err != nil {
+		t.Fatalf("GetForwardProxyRulesetByID: %v", err)
+	}
+	if got == nil {
+		t.Fatal("expected ruleset, got nil")
+	}
+	if got.Name != "ci-egress" {
+		t.Errorf("name = %q, want ci-egress", got.Name)
+	}
+	if got.Description != "CI traffic egress split" {
+		t.Errorf("description = %q, want CI traffic egress split", got.Description)
+	}
+	if got.Algorithm != ForwardProxyAlgoWeighted {
+		t.Errorf("algorithm = %q, want %q", got.Algorithm, ForwardProxyAlgoWeighted)
+	}
+	if len(got.Proxies) != 2 {
+		t.Fatalf("proxies len = %d, want 2", len(got.Proxies))
+	}
+	if got.Proxies[0].URL != "http://proxy-a.internal:3128" || got.Proxies[0].Weight != 80 {
+		t.Errorf("proxies[0] = %+v, want {http://proxy-a.internal:3128 80}", got.Proxies[0])
+	}
+	if got.Proxies[1].URL != "http://proxy-b.internal:3128" || got.Proxies[1].Weight != 20 {
+		t.Errorf("proxies[1] = %+v, want {http://proxy-b.internal:3128 20}", got.Proxies[1])
+	}
+	if len(got.Rules) != 2 {
+		t.Fatalf("rules len = %d, want 2", len(got.Rules))
+	}
+	if got.Rules[0].Type != ForwardProxyRuleNet || got.Rules[0].Value != "10.42.0.0/16" {
+		t.Errorf("rules[0] = %+v, want {net 10.42.0.0/16}", got.Rules[0])
+	}
+	if got.Rules[1].Type != ForwardProxyRuleSystem || got.Rules[1].Value != "" {
+		t.Errorf("rules[1] = %+v, want {system }", got.Rules[1])
+	}
+	if !got.Enabled {
+		t.Error("expected enabled = true")
+	}
+	if got.CreatedAt.IsZero() || got.UpdatedAt.IsZero() {
+		t.Error("expected CreatedAt/UpdatedAt to be set on retrieved ruleset")
+	}
+
+	// Get by name.
+	byName, err := store.GetForwardProxyRulesetByName(ctx, "ci-egress")
+	if err != nil {
+		t.Fatalf("GetForwardProxyRulesetByName: %v", err)
+	}
+	if byName == nil || byName.ID != rs.ID {
+		t.Fatalf("GetForwardProxyRulesetByName = %+v, want ID %s", byName, rs.ID)
+	}
+
+	// Missing lookups return (nil, nil).
+	if missing, err := store.GetForwardProxyRulesetByID(ctx, newUUIDString()); err != nil || missing != nil {
+		t.Errorf("GetForwardProxyRulesetByID(missing) = (%+v, %v), want (nil, nil)", missing, err)
+	}
+	if missing, err := store.GetForwardProxyRulesetByName(ctx, "no-such-ruleset"); err != nil || missing != nil {
+		t.Errorf("GetForwardProxyRulesetByName(missing) = (%+v, %v), want (nil, nil)", missing, err)
+	}
+
+	// List.
+	rulesets, err := store.ListForwardProxyRulesets(ctx)
+	if err != nil {
+		t.Fatalf("ListForwardProxyRulesets: %v", err)
+	}
+	if len(rulesets) != 1 {
+		t.Errorf("ListForwardProxyRulesets returned %d, want 1", len(rulesets))
+	}
+
+	// Update (including rename and clearing to empty slices).
+	rs.Name = "ci-egress-v2"
+	rs.Description = "renamed"
+	rs.Algorithm = ForwardProxyAlgoSticky
+	rs.Proxies = []ForwardProxyEntry{{URL: "socks5://egress.internal:1080", Weight: 1}}
+	rs.Rules = []ForwardProxyRule{}
+	rs.Enabled = false
+	if err := store.UpdateForwardProxyRuleset(ctx, rs); err != nil {
+		t.Fatalf("UpdateForwardProxyRuleset: %v", err)
+	}
+	got2, err := store.GetForwardProxyRulesetByID(ctx, rs.ID)
+	if err != nil {
+		t.Fatalf("GetForwardProxyRulesetByID after update: %v", err)
+	}
+	if got2.Name != "ci-egress-v2" || got2.Description != "renamed" || got2.Algorithm != ForwardProxyAlgoSticky || got2.Enabled {
+		t.Errorf("updated ruleset = %+v, want renamed sticky disabled", got2)
+	}
+	if len(got2.Proxies) != 1 || got2.Proxies[0].URL != "socks5://egress.internal:1080" {
+		t.Errorf("updated proxies = %+v, want single socks5 entry", got2.Proxies)
+	}
+	if got2.Rules == nil || len(got2.Rules) != 0 {
+		t.Errorf("updated rules = %+v, want empty non-nil slice", got2.Rules)
+	}
+
+	// Old name is released, new name resolves.
+	if old, err := store.GetForwardProxyRulesetByName(ctx, "ci-egress"); err != nil || old != nil {
+		t.Errorf("GetForwardProxyRulesetByName(old) = (%+v, %v), want (nil, nil)", old, err)
+	}
+	if renamed, err := store.GetForwardProxyRulesetByName(ctx, "ci-egress-v2"); err != nil || renamed == nil {
+		t.Errorf("GetForwardProxyRulesetByName(new) = (%+v, %v), want ruleset", renamed, err)
+	}
+
+	// Update of a non-existent ruleset returns ErrNotFound.
+	ghost := &ForwardProxyRuleset{ID: newUUIDString(), Name: "ghost", Algorithm: ForwardProxyAlgoRoundRobin}
+	if err := store.UpdateForwardProxyRuleset(ctx, ghost); !errors.Is(err, ErrNotFound) {
+		t.Errorf("UpdateForwardProxyRuleset(missing) = %v, want ErrNotFound", err)
+	}
+
+	// Delete.
+	if err := store.DeleteForwardProxyRuleset(ctx, rs.ID); err != nil {
+		t.Fatalf("DeleteForwardProxyRuleset: %v", err)
+	}
+	if gone, err := store.GetForwardProxyRulesetByID(ctx, rs.ID); err != nil || gone != nil {
+		t.Errorf("GetForwardProxyRulesetByID after delete = (%+v, %v), want (nil, nil)", gone, err)
+	}
+	if err := store.DeleteForwardProxyRuleset(ctx, newUUIDString()); !errors.Is(err, ErrNotFound) {
+		t.Errorf("DeleteForwardProxyRuleset(missing) = %v, want ErrNotFound", err)
 	}
 }

--- a/internal/database/vault.go
+++ b/internal/database/vault.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"sort"
 	"strings"
 	"time"
 
@@ -1105,6 +1106,163 @@ func (s *VaultStore) DeleteCachedRepository(ctx context.Context, id string) erro
 	// Delete the owner/name index entry.
 	_ = s.kvDelete(ctx, fmt.Sprintf("cached-repos/by-owner-name/%s/%s", existing.Owner, existing.Name))
 	return s.kvDelete(ctx, "cached-repos/"+id)
+}
+
+// --- Forward proxy rulesets ---
+
+func (s *VaultStore) CreateForwardProxyRuleset(ctx context.Context, rs *ForwardProxyRuleset) error {
+	if rs.ID == "" {
+		rs.ID = uuid.New().String()
+	}
+	now := time.Now().UTC()
+	rs.CreatedAt = now
+	rs.UpdatedAt = now
+	if rs.Proxies == nil {
+		rs.Proxies = []ForwardProxyEntry{}
+	}
+	if rs.Rules == nil {
+		rs.Rules = []ForwardProxyRule{}
+	}
+
+	// Check name uniqueness before writing the record to avoid orphaned entries.
+	indexPath := "forward-proxy-rulesets/by-name/" + rs.Name
+	existing, err := s.kvRead(ctx, indexPath)
+	if err != nil {
+		return err
+	}
+	if existing != nil {
+		return fmt.Errorf("forward proxy ruleset %q already exists", rs.Name)
+	}
+
+	data, err := marshalToMap(rs)
+	if err != nil {
+		return fmt.Errorf("marshaling forward proxy ruleset: %w", err)
+	}
+	if err := s.kvWrite(ctx, "forward-proxy-rulesets/"+rs.ID, data); err != nil {
+		return err
+	}
+	return s.kvWrite(ctx, indexPath, map[string]interface{}{
+		"id": rs.ID,
+	})
+}
+
+func (s *VaultStore) GetForwardProxyRulesetByID(ctx context.Context, id string) (*ForwardProxyRuleset, error) {
+	data, err := s.kvRead(ctx, "forward-proxy-rulesets/"+id)
+	if err != nil {
+		return nil, err
+	}
+	if data == nil {
+		return nil, nil
+	}
+	var rs ForwardProxyRuleset
+	if err := unmarshalFromMap(data, &rs); err != nil {
+		return nil, err
+	}
+	if rs.Proxies == nil {
+		rs.Proxies = []ForwardProxyEntry{}
+	}
+	if rs.Rules == nil {
+		rs.Rules = []ForwardProxyRule{}
+	}
+	return &rs, nil
+}
+
+func (s *VaultStore) GetForwardProxyRulesetByName(ctx context.Context, name string) (*ForwardProxyRuleset, error) {
+	indexData, err := s.kvRead(ctx, "forward-proxy-rulesets/by-name/"+name)
+	if err != nil {
+		return nil, err
+	}
+	if indexData == nil {
+		return nil, nil
+	}
+	id, ok := indexData["id"].(string)
+	if !ok {
+		return nil, nil
+	}
+	return s.GetForwardProxyRulesetByID(ctx, id)
+}
+
+func (s *VaultStore) ListForwardProxyRulesets(ctx context.Context) ([]*ForwardProxyRuleset, error) {
+	keys, err := s.kvList(ctx, "forward-proxy-rulesets")
+	if err != nil {
+		return nil, err
+	}
+	var rulesets []*ForwardProxyRuleset
+	for _, key := range keys {
+		// Skip index paths.
+		if key == "by-name" {
+			continue
+		}
+		rs, err := s.GetForwardProxyRulesetByID(ctx, key)
+		if err != nil {
+			return nil, err
+		}
+		if rs != nil {
+			rulesets = append(rulesets, rs)
+		}
+	}
+	sort.Slice(rulesets, func(i, j int) bool { return rulesets[i].Name < rulesets[j].Name })
+	return rulesets, nil
+}
+
+func (s *VaultStore) UpdateForwardProxyRuleset(ctx context.Context, rs *ForwardProxyRuleset) error {
+	existing, err := s.GetForwardProxyRulesetByID(ctx, rs.ID)
+	if err != nil {
+		return err
+	}
+	if existing == nil {
+		return fmt.Errorf("forward proxy ruleset %s: %w", rs.ID, ErrNotFound)
+	}
+
+	// If the name changed, check for conflicts before writing anything.
+	nameChanged := existing.Name != rs.Name
+	if nameChanged {
+		conflicting, err := s.kvRead(ctx, "forward-proxy-rulesets/by-name/"+rs.Name)
+		if err != nil {
+			return err
+		}
+		if conflicting != nil {
+			return fmt.Errorf("forward proxy ruleset %q already exists", rs.Name)
+		}
+	}
+
+	rs.CreatedAt = existing.CreatedAt // preserve immutable field
+	rs.UpdatedAt = time.Now().UTC()
+	if rs.Proxies == nil {
+		rs.Proxies = []ForwardProxyEntry{}
+	}
+	if rs.Rules == nil {
+		rs.Rules = []ForwardProxyRule{}
+	}
+	data, err := marshalToMap(rs)
+	if err != nil {
+		return fmt.Errorf("marshaling forward proxy ruleset: %w", err)
+	}
+	if err := s.kvWrite(ctx, "forward-proxy-rulesets/"+rs.ID, data); err != nil {
+		return err
+	}
+	if nameChanged {
+		if err := s.kvWrite(ctx, "forward-proxy-rulesets/by-name/"+rs.Name, map[string]interface{}{
+			"id": rs.ID,
+		}); err != nil {
+			return err
+		}
+		_ = s.kvDelete(ctx, "forward-proxy-rulesets/by-name/"+existing.Name)
+	}
+	return nil
+}
+
+func (s *VaultStore) DeleteForwardProxyRuleset(ctx context.Context, id string) error {
+	existing, err := s.GetForwardProxyRulesetByID(ctx, id)
+	if err != nil {
+		return err
+	}
+	if existing == nil {
+		return fmt.Errorf("forward proxy ruleset %s: %w", id, ErrNotFound)
+	}
+	// Delete the name index entry.
+	_ = s.kvDelete(ctx, "forward-proxy-rulesets/by-name/"+existing.Name)
+	return s.kvDelete(ctx, "forward-proxy-rulesets/"+id)
 }
 
 // --- Sessions ---

--- a/internal/database/vault.go
+++ b/internal/database/vault.go
@@ -1124,30 +1124,30 @@ func (s *VaultStore) CreateForwardProxyRuleset(ctx context.Context, rs *ForwardP
 		rs.Rules = []ForwardProxyRule{}
 	}
 
-	// Check name uniqueness before writing the record to avoid orphaned
-	// entries. This is check-then-write without CAS, so concurrent creates
-	// of the same name can race — accepted for this admin-driven,
-	// low-frequency surface (documented in
-	// docs/features/forward-proxy-rulesets.md known limitations).
+	// Claim the name first with an atomic KV v2 CAS create, then write the
+	// record. Claiming first means a concurrent create of the same name
+	// loses the CAS race cleanly, and a failed record write can roll the
+	// claim back — no sequence leaves a listed record without an index.
 	indexPath := "forward-proxy-rulesets/by-name/" + rs.Name
-	existing, err := s.kvRead(ctx, indexPath)
-	if err != nil {
+	if err := s.kvCreate(ctx, indexPath, map[string]interface{}{"id": rs.ID}); err != nil {
+		if errors.Is(err, errKVAlreadyExists) {
+			return fmt.Errorf("forward proxy ruleset %q already exists", rs.Name)
+		}
 		return err
-	}
-	if existing != nil {
-		return fmt.Errorf("forward proxy ruleset %q already exists", rs.Name)
 	}
 
 	data, err := marshalToMap(rs)
 	if err != nil {
+		_ = s.kvDelete(ctx, indexPath)
 		return fmt.Errorf("marshaling forward proxy ruleset: %w", err)
 	}
 	if err := s.kvWrite(ctx, "forward-proxy-rulesets/"+rs.ID, data); err != nil {
+		// Roll back the name claim so a retry does not hit a phantom
+		// duplicate.
+		_ = s.kvDelete(ctx, indexPath)
 		return err
 	}
-	return s.kvWrite(ctx, indexPath, map[string]interface{}{
-		"id": rs.ID,
-	})
+	return nil
 }
 
 func (s *VaultStore) GetForwardProxyRulesetByID(ctx context.Context, id string) (*ForwardProxyRuleset, error) {
@@ -1156,7 +1156,7 @@ func (s *VaultStore) GetForwardProxyRulesetByID(ctx context.Context, id string) 
 		return nil, err
 	}
 	if data == nil {
-		return nil, nil
+		return nil, fmt.Errorf("forward proxy ruleset %s: %w", id, ErrNotFound)
 	}
 	var rs ForwardProxyRuleset
 	if err := unmarshalFromMap(data, &rs); err != nil {
@@ -1183,7 +1183,12 @@ func (s *VaultStore) GetForwardProxyRulesetByName(ctx context.Context, name stri
 	if !ok {
 		return nil, nil
 	}
-	return s.GetForwardProxyRulesetByID(ctx, id)
+	rs, err := s.GetForwardProxyRulesetByID(ctx, id)
+	if errors.Is(err, ErrNotFound) {
+		// Stale index entry: treat as missing for this read-style lookup.
+		return nil, nil
+	}
+	return rs, err
 }
 
 func (s *VaultStore) ListForwardProxyRulesets(ctx context.Context) ([]*ForwardProxyRuleset, error) {
@@ -1198,6 +1203,9 @@ func (s *VaultStore) ListForwardProxyRulesets(ctx context.Context) ([]*ForwardPr
 			continue
 		}
 		rs, err := s.GetForwardProxyRulesetByID(ctx, key)
+		if errors.Is(err, ErrNotFound) {
+			continue // deleted concurrently with the list
+		}
 		if err != nil {
 			return nil, err
 		}
@@ -1212,21 +1220,21 @@ func (s *VaultStore) ListForwardProxyRulesets(ctx context.Context) ([]*ForwardPr
 func (s *VaultStore) UpdateForwardProxyRuleset(ctx context.Context, rs *ForwardProxyRuleset) error {
 	existing, err := s.GetForwardProxyRulesetByID(ctx, rs.ID)
 	if err != nil {
-		return err
-	}
-	if existing == nil {
-		return fmt.Errorf("forward proxy ruleset %s: %w", rs.ID, ErrNotFound)
+		return err // wraps ErrNotFound when the ruleset does not exist
 	}
 
-	// If the name changed, check for conflicts before writing anything.
+	// On rename, claim the new name atomically (KV v2 CAS create) before
+	// touching the record, and roll the claim back if the record write
+	// fails; the old index is removed only after the record is persisted.
 	nameChanged := existing.Name != rs.Name
 	if nameChanged {
-		conflicting, err := s.kvRead(ctx, "forward-proxy-rulesets/by-name/"+rs.Name)
-		if err != nil {
+		if err := s.kvCreate(ctx, "forward-proxy-rulesets/by-name/"+rs.Name, map[string]interface{}{
+			"id": rs.ID,
+		}); err != nil {
+			if errors.Is(err, errKVAlreadyExists) {
+				return fmt.Errorf("forward proxy ruleset %q already exists", rs.Name)
+			}
 			return err
-		}
-		if conflicting != nil {
-			return fmt.Errorf("forward proxy ruleset %q already exists", rs.Name)
 		}
 	}
 
@@ -1239,18 +1247,16 @@ func (s *VaultStore) UpdateForwardProxyRuleset(ctx context.Context, rs *ForwardP
 		rs.Rules = []ForwardProxyRule{}
 	}
 	data, err := marshalToMap(rs)
-	if err != nil {
-		return fmt.Errorf("marshaling forward proxy ruleset: %w", err)
+	if err == nil {
+		err = s.kvWrite(ctx, "forward-proxy-rulesets/"+rs.ID, data)
 	}
-	if err := s.kvWrite(ctx, "forward-proxy-rulesets/"+rs.ID, data); err != nil {
-		return err
+	if err != nil {
+		if nameChanged {
+			_ = s.kvDelete(ctx, "forward-proxy-rulesets/by-name/"+rs.Name)
+		}
+		return fmt.Errorf("persisting forward proxy ruleset: %w", err)
 	}
 	if nameChanged {
-		if err := s.kvWrite(ctx, "forward-proxy-rulesets/by-name/"+rs.Name, map[string]interface{}{
-			"id": rs.ID,
-		}); err != nil {
-			return err
-		}
 		_ = s.kvDelete(ctx, "forward-proxy-rulesets/by-name/"+existing.Name)
 	}
 	return nil
@@ -1259,10 +1265,7 @@ func (s *VaultStore) UpdateForwardProxyRuleset(ctx context.Context, rs *ForwardP
 func (s *VaultStore) DeleteForwardProxyRuleset(ctx context.Context, id string) error {
 	existing, err := s.GetForwardProxyRulesetByID(ctx, id)
 	if err != nil {
-		return err
-	}
-	if existing == nil {
-		return fmt.Errorf("forward proxy ruleset %s: %w", id, ErrNotFound)
+		return err // wraps ErrNotFound when the ruleset does not exist
 	}
 	// Delete the name index entry.
 	_ = s.kvDelete(ctx, "forward-proxy-rulesets/by-name/"+existing.Name)

--- a/internal/database/vault.go
+++ b/internal/database/vault.go
@@ -1124,7 +1124,11 @@ func (s *VaultStore) CreateForwardProxyRuleset(ctx context.Context, rs *ForwardP
 		rs.Rules = []ForwardProxyRule{}
 	}
 
-	// Check name uniqueness before writing the record to avoid orphaned entries.
+	// Check name uniqueness before writing the record to avoid orphaned
+	// entries. This is check-then-write without CAS, so concurrent creates
+	// of the same name can race — accepted for this admin-driven,
+	// low-frequency surface (documented in
+	// docs/features/forward-proxy-rulesets.md known limitations).
 	indexPath := "forward-proxy-rulesets/by-name/" + rs.Name
 	existing, err := s.kvRead(ctx, indexPath)
 	if err != nil {

--- a/internal/gitcache/handler.go
+++ b/internal/gitcache/handler.go
@@ -82,7 +82,6 @@ type ServiceTokenFunc func(ctx context.Context) (string, error)
 // (enforced by the lsRefsSucceeded gate in ServeUploadPack). For standalone
 // fetch requests, the ScopedPassthroughHandler has already validated the
 // token and enforced scope before the request reaches this handler.
-//
 type Handler struct {
 	registry         *Registry
 	serviceTokenFn   ServiceTokenFunc
@@ -110,6 +109,15 @@ func NewHandler(registry *Registry, serviceTokenFn ServiceTokenFunc, upstreamBas
 		httpClient:       &http.Client{}, // no client-level timeout; per-request context controls it
 		responseCacheDir: responseCacheDir,
 	}
+}
+
+// SetTransport sets the transport used for upstream ls-refs/fetch requests.
+// The server installs the forward proxy ruleset transport here so cached-repo
+// git traffic follows the same egress selection as the raw passthrough
+// (upstream requests are built with the inbound request context, so route
+// info seeded by the server middleware flows through).
+func (h *Handler) SetTransport(rt http.RoundTripper) {
+	h.httpClient.Transport = rt
 }
 
 // ServeInfoRefs handles GET /owner/repo.git/info/refs?service=git-upload-pack

--- a/internal/github/app.go
+++ b/internal/github/app.go
@@ -140,6 +140,14 @@ func NewAppTokenProvider(cfg AppConfig) (*AppTokenProvider, error) {
 	}, nil
 }
 
+// SetTransport sets the transport used for GitHub App API calls (JWT-signed
+// installation listing and installation token minting). The server installs
+// the forward proxy control transport here so App credential traffic — ghp
+// control traffic — follows the control-layer egress routing.
+func (p *AppTokenProvider) SetTransport(rt http.RoundTripper) {
+	p.client.Transport = rt
+}
+
 // installationCacheKey returns a stable cache key that uniquely identifies a
 // (installationID, repos, permissions) tuple. The repos and permissions are
 // sorted before hashing so that call-site ordering does not affect the key.

--- a/internal/github/registry.go
+++ b/internal/github/registry.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"net/http"
 	"sort"
 	"sync"
 
@@ -20,6 +21,7 @@ type AppRegistry struct {
 	store     database.Store
 	encryptor *crypto.Encryptor
 	logger    *slog.Logger
+	transport http.RoundTripper // applied to every provider; nil = default transport
 }
 
 // NewAppRegistry creates a new registry. Call LoadAll to populate it.
@@ -29,6 +31,20 @@ func NewAppRegistry(store database.Store, enc *crypto.Encryptor, logger *slog.Lo
 		store:     store,
 		encryptor: enc,
 		logger:    logger,
+	}
+}
+
+// SetTransport sets the transport applied to every loaded provider's GitHub
+// App API client (current and future loads). The server installs the forward
+// proxy control transport here so installation token minting — ghp control
+// traffic — follows the control-layer egress routing. Call before LoadAll for
+// full coverage; providers already loaded are updated in place.
+func (r *AppRegistry) SetTransport(rt http.RoundTripper) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.transport = rt
+	for _, p := range r.providers {
+		p.SetTransport(rt)
 	}
 }
 
@@ -106,6 +122,9 @@ func (r *AppRegistry) loadAppLocked(app *database.App) error {
 	})
 	if err != nil {
 		return fmt.Errorf("creating provider: %w", err)
+	}
+	if r.transport != nil {
+		provider.SetTransport(r.transport)
 	}
 
 	r.providers[app.ID] = provider

--- a/internal/github/registry_test.go
+++ b/internal/github/registry_test.go
@@ -128,6 +128,24 @@ func (m *mockStore) DeleteDeviceAuth(_ context.Context, _ string) error { panic(
 func (m *mockStore) DeleteExpiredDeviceAuths(_ context.Context) (int64, error) {
 	panic("unexpected")
 }
+func (m *mockStore) CreateForwardProxyRuleset(_ context.Context, _ *database.ForwardProxyRuleset) error {
+	panic("unexpected")
+}
+func (m *mockStore) GetForwardProxyRulesetByID(_ context.Context, _ string) (*database.ForwardProxyRuleset, error) {
+	panic("unexpected")
+}
+func (m *mockStore) GetForwardProxyRulesetByName(_ context.Context, _ string) (*database.ForwardProxyRuleset, error) {
+	panic("unexpected")
+}
+func (m *mockStore) ListForwardProxyRulesets(_ context.Context) ([]*database.ForwardProxyRuleset, error) {
+	panic("unexpected")
+}
+func (m *mockStore) UpdateForwardProxyRuleset(_ context.Context, _ *database.ForwardProxyRuleset) error {
+	panic("unexpected")
+}
+func (m *mockStore) DeleteForwardProxyRuleset(_ context.Context, _ string) error {
+	panic("unexpected")
+}
 func (m *mockStore) Close() error { return nil }
 
 // makeApp creates a minimal App record with a valid private key for testing.

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -310,9 +310,10 @@ var (
 
 	// ForwardProxySelectTotal counts forward proxy routing decisions on
 	// outbound GitHub requests, labeled by the matched ruleset name and the
-	// layer that matched ("token", "app", "net", "system", "control", or
+	// layer that matched ("token", "app", "net", "system", "control";
 	// "ambient" when no ruleset applied and the environment default was
-	// used; ruleset is empty for ambient decisions).
+	// used; "direct" for non-GitHub control calls sent with no proxy;
+	// ruleset is empty for ambient and direct decisions).
 	ForwardProxySelectTotal = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name: "ghp_forward_proxy_select_total",
 		Help: "Total forward proxy routing decisions by matched ruleset and layer.",

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -310,9 +310,9 @@ var (
 
 	// ForwardProxySelectTotal counts forward proxy routing decisions on
 	// outbound GitHub requests, labeled by the matched ruleset name and the
-	// layer that matched ("token", "app", "net", "system", or "ambient" when
-	// no ruleset applied and the environment default was used; ruleset is
-	// empty for ambient decisions).
+	// layer that matched ("token", "app", "net", "system", "control", or
+	// "ambient" when no ruleset applied and the environment default was
+	// used; ruleset is empty for ambient decisions).
 	ForwardProxySelectTotal = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name: "ghp_forward_proxy_select_total",
 		Help: "Total forward proxy routing decisions by matched ruleset and layer.",

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -308,6 +308,23 @@ var (
 		Help: "Total number of CLI device-authorization requests that reached a terminal state.",
 	}, []string{"result"})
 
+	// ForwardProxySelectTotal counts forward proxy routing decisions on
+	// outbound GitHub requests, labeled by the matched ruleset name and the
+	// layer that matched ("token", "app", "net", "system", or "ambient" when
+	// no ruleset applied and the environment default was used; ruleset is
+	// empty for ambient decisions).
+	ForwardProxySelectTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "ghp_forward_proxy_select_total",
+		Help: "Total forward proxy routing decisions by matched ruleset and layer.",
+	}, []string{"ruleset", "layer"})
+
+	// ForwardProxyRulesetsActive is a gauge reflecting how many enabled
+	// forward proxy rulesets are currently compiled into the route table.
+	ForwardProxyRulesetsActive = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "ghp_forward_proxy_rulesets_active",
+		Help: "Number of enabled forward proxy rulesets currently active in the route table.",
+	})
+
 	// BuildInfo is a gauge with a constant value of 1 labeled by build
 	// metadata. It follows the node_exporter_build_info convention.
 	BuildInfo = promauto.NewGaugeVec(prometheus.GaugeOpts{
@@ -331,6 +348,7 @@ const (
 	StageCacheLookup           = "cache_lookup"
 	StageGraphQLAnalysis       = "graphql_analysis"
 	StageEnterpriseException   = "enterprise_exception"
+	StageForwardProxySelection = "forward_proxy_selection"
 )
 
 // ObserveDecision records the duration of a single stage in the proxy

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -311,13 +311,25 @@ var (
 	// ForwardProxySelectTotal counts forward proxy routing decisions on
 	// outbound GitHub requests, labeled by the matched ruleset name and the
 	// layer that matched ("token", "app", "net", "system", "control";
+	// "header" when the client selected the proxy via request headers;
 	// "ambient" when no ruleset applied and the environment default was
 	// used; "direct" for non-GitHub control calls sent with no proxy;
-	// ruleset is empty for ambient and direct decisions).
+	// ruleset is empty for header, ambient, and direct decisions).
 	ForwardProxySelectTotal = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name: "ghp_forward_proxy_select_total",
 		Help: "Total forward proxy routing decisions by matched ruleset and layer.",
 	}, []string{"ruleset", "layer"})
+
+	// ForwardProxyClientSpecifiedTotal counts requests whose forward proxy
+	// was selected by the client via the X-GitHub-Proxy-Forward-* request
+	// headers (feature-gated by forward_proxy.allow_request_header),
+	// labeled by the proxy URL scheme and the client token type. The proxy
+	// URL itself is never used as a label — it is client-controlled and
+	// unbounded.
+	ForwardProxyClientSpecifiedTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "ghp_forward_proxy_client_specified_total",
+		Help: "Total requests routed through a client-specified forward proxy via request headers.",
+	}, []string{"scheme", "token_type"})
 
 	// ForwardProxyRulesetsActive is a gauge reflecting how many enabled
 	// forward proxy rulesets are currently compiled into the route table.

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -613,6 +613,7 @@ func TestForwardProxySelectTotal(t *testing.T) {
 		{"default", "system"},
 		{"control-plane", "control"},
 		{"", "ambient"},
+		{"", "direct"},
 	}
 	for _, c := range cases {
 		t.Run(c.layer, func(t *testing.T) {

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -162,6 +162,7 @@ func TestObserveDecision_AllStages(t *testing.T) {
 		StageRedirectHeadCheck,
 		StageCacheLookup,
 		StageGraphQLAnalysis,
+		StageForwardProxySelection,
 	}
 
 	for _, stage := range stages {
@@ -601,5 +602,37 @@ func TestTokenCleanupDeletedTotal(t *testing.T) {
 	after := getCounterValueSimple(t, TokenCleanupDeletedTotal)
 	if after-before != 5 {
 		t.Errorf("expected counter to increment by 5, got %f", after-before)
+	}
+}
+
+func TestForwardProxySelectTotal(t *testing.T) {
+	cases := []struct{ ruleset, layer string }{
+		{"ci-egress", "token"},
+		{"ci-egress", "app"},
+		{"ci-egress", "net"},
+		{"default", "system"},
+		{"", "ambient"},
+	}
+	for _, c := range cases {
+		t.Run(c.layer, func(t *testing.T) {
+			labels := prometheus.Labels{"ruleset": c.ruleset, "layer": c.layer}
+			before := getCounterValue(t, ForwardProxySelectTotal, labels)
+			ForwardProxySelectTotal.WithLabelValues(c.ruleset, c.layer).Inc()
+			after := getCounterValue(t, ForwardProxySelectTotal, labels)
+			if after-before != 1 {
+				t.Errorf("expected counter to increment by 1, got %f", after-before)
+			}
+		})
+	}
+}
+
+func TestForwardProxyRulesetsActive_Gauge(t *testing.T) {
+	ForwardProxyRulesetsActive.Set(3)
+	if got := getGaugeValue(t, ForwardProxyRulesetsActive); got != 3 {
+		t.Errorf("expected gauge value 3, got %f", got)
+	}
+	ForwardProxyRulesetsActive.Set(0)
+	if got := getGaugeValue(t, ForwardProxyRulesetsActive); got != 0 {
+		t.Errorf("expected gauge value 0, got %f", got)
 	}
 }

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -614,6 +614,7 @@ func TestForwardProxySelectTotal(t *testing.T) {
 		{"control-plane", "control"},
 		{"", "ambient"},
 		{"", "direct"},
+		{"", "header"},
 	}
 	for _, c := range cases {
 		t.Run(c.layer, func(t *testing.T) {
@@ -636,5 +637,24 @@ func TestForwardProxyRulesetsActive_Gauge(t *testing.T) {
 	ForwardProxyRulesetsActive.Set(0)
 	if got := getGaugeValue(t, ForwardProxyRulesetsActive); got != 0 {
 		t.Errorf("expected gauge value 0, got %f", got)
+	}
+}
+
+func TestForwardProxyClientSpecifiedTotal(t *testing.T) {
+	cases := []struct{ scheme, tokenType string }{
+		{"http", "proxy"},
+		{"socks5", "agent"},
+		{"https", "unknown"},
+	}
+	for _, c := range cases {
+		t.Run(c.scheme+"_"+c.tokenType, func(t *testing.T) {
+			labels := prometheus.Labels{"scheme": c.scheme, "token_type": c.tokenType}
+			before := getCounterValue(t, ForwardProxyClientSpecifiedTotal, labels)
+			ForwardProxyClientSpecifiedTotal.WithLabelValues(c.scheme, c.tokenType).Inc()
+			after := getCounterValue(t, ForwardProxyClientSpecifiedTotal, labels)
+			if after-before != 1 {
+				t.Errorf("expected counter to increment by 1, got %f", after-before)
+			}
+		})
 	}
 }

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -611,6 +611,7 @@ func TestForwardProxySelectTotal(t *testing.T) {
 		{"ci-egress", "app"},
 		{"ci-egress", "net"},
 		{"default", "system"},
+		{"control-plane", "control"},
 		{"", "ambient"},
 	}
 	for _, c := range cases {

--- a/internal/proxy/context.go
+++ b/internal/proxy/context.go
@@ -126,3 +126,42 @@ func SetTokenType(r *http.Request, tokenType string) {
 		*slot = tokenType
 	}
 }
+
+var forwardProxyCtxKey = &contextKey{"forward-proxy-route"}
+
+// ForwardProxyRouteInfo carries the request identity the forward proxy
+// router selects on. The struct is mutable: the server middleware seeds the
+// client IP before dispatch, and the token-resolving handlers fill in the
+// token/app identity once known. Outbound requests built from the inbound
+// request context inherit the same pointer, so http.Transport.Proxy sees the
+// final values at roundtrip time.
+type ForwardProxyRouteInfo struct {
+	ClientIP  string
+	TokenID   string // proxy token record UUID, "" when no ghx_/gha_ token resolved
+	AppID     string // GitHub App record UUID (agent tokens only), "" otherwise
+	TokenType string // "proxy", "agent", or "" — used for metrics labeling only
+}
+
+// PrepareForwardProxyInfo returns a request whose context carries a mutable
+// forward proxy route-info slot seeded with the client IP.
+func PrepareForwardProxyInfo(r *http.Request, clientIP string) *http.Request {
+	info := &ForwardProxyRouteInfo{ClientIP: clientIP}
+	return r.WithContext(context.WithValue(r.Context(), forwardProxyCtxKey, info))
+}
+
+// SetForwardProxyIdentity records the resolved token/app identity in the
+// request's route-info slot. It is a no-op if no slot was prepared.
+func SetForwardProxyIdentity(r *http.Request, tokenID, appID, tokenType string) {
+	if info, ok := r.Context().Value(forwardProxyCtxKey).(*ForwardProxyRouteInfo); ok {
+		info.TokenID = tokenID
+		info.AppID = appID
+		info.TokenType = tokenType
+	}
+}
+
+// ForwardProxyInfoFromContext returns the route-info slot from ctx, or nil
+// when none was prepared.
+func ForwardProxyInfoFromContext(ctx context.Context) *ForwardProxyRouteInfo {
+	info, _ := ctx.Value(forwardProxyCtxKey).(*ForwardProxyRouteInfo)
+	return info
+}

--- a/internal/proxy/context.go
+++ b/internal/proxy/context.go
@@ -140,6 +140,7 @@ type ForwardProxyRouteInfo struct {
 	TokenID   string // proxy token record UUID, "" when no ghx_/gha_ token resolved
 	AppID     string // GitHub App record UUID (agent tokens only), "" otherwise
 	TokenType string // "proxy", "agent", or "" — used for metrics labeling only
+	Control   bool   // ghp-originated control traffic: route via the control layer only
 }
 
 // PrepareForwardProxyInfo returns a request whose context carries a mutable
@@ -157,6 +158,16 @@ func SetForwardProxyIdentity(r *http.Request, tokenID, appID, tokenType string) 
 		info.AppID = appID
 		info.TokenType = tokenType
 	}
+}
+
+// WithForwardProxyControl returns a context whose route-info slot marks the
+// traffic as ghp-originated control traffic (control rule → system rule →
+// ambient). It shadows any request-derived route info already on the context,
+// so internal calls made with a proxied request's context (e.g. OAuth token
+// refresh) are classified as control rather than inheriting the client's
+// token/app/net routing.
+func WithForwardProxyControl(ctx context.Context) context.Context {
+	return context.WithValue(ctx, forwardProxyCtxKey, &ForwardProxyRouteInfo{Control: true})
 }
 
 // ForwardProxyInfoFromContext returns the route-info slot from ctx, or nil

--- a/internal/proxy/context.go
+++ b/internal/proxy/context.go
@@ -3,6 +3,7 @@ package proxy
 import (
 	"context"
 	"net/http"
+	"net/url"
 )
 
 // contextKey is an unexported type used for context keys in this package
@@ -141,6 +142,10 @@ type ForwardProxyRouteInfo struct {
 	AppID     string // GitHub App record UUID (agent tokens only), "" otherwise
 	TokenType string // "proxy", "agent", or "" — used for metrics labeling only
 	Control   bool   // ghp-originated control traffic: route via the control layer only
+	// ClientProxy is a per-request forward proxy the client selected via
+	// the X-GitHub-Proxy-Forward-* headers (validated and feature-gated at
+	// the edge). Non-nil beats every ruleset layer.
+	ClientProxy *url.URL
 }
 
 // PrepareForwardProxyInfo returns a request whose context carries a mutable
@@ -157,6 +162,14 @@ func SetForwardProxyIdentity(r *http.Request, tokenID, appID, tokenType string) 
 		info.TokenID = tokenID
 		info.AppID = appID
 		info.TokenType = tokenType
+	}
+}
+
+// SetForwardProxyClientChoice records a client-selected forward proxy in the
+// request's route-info slot. It is a no-op if no slot was prepared.
+func SetForwardProxyClientChoice(r *http.Request, u *url.URL) {
+	if info, ok := r.Context().Value(forwardProxyCtxKey).(*ForwardProxyRouteInfo); ok {
+		info.ClientProxy = u
 	}
 }
 

--- a/internal/proxy/enterprise.go
+++ b/internal/proxy/enterprise.go
@@ -319,6 +319,17 @@ type membershipFlight struct {
 	member bool
 }
 
+// SetTransport sets the transport used for team membership lookups. The
+// server installs the forward proxy control transport here so membership
+// checks — ghp control traffic — follow the control-layer egress routing
+// instead of dialing GitHub directly. No-op when team checking is disabled
+// (no identity source).
+func (p *EnterprisePolicy) SetTransport(rt http.RoundTripper) {
+	if p.teams != nil {
+		p.teams.client.Transport = rt
+	}
+}
+
 func newTeamChecker(identity ExceptionIdentitySource, logger *slog.Logger) *teamChecker {
 	return &teamChecker{
 		identity: identity,

--- a/internal/proxy/enterprise.go
+++ b/internal/proxy/enterprise.go
@@ -322,12 +322,14 @@ type membershipFlight struct {
 // SetTransport sets the transport used for team membership lookups. The
 // server installs the forward proxy control transport here so membership
 // checks — ghp control traffic — follow the control-layer egress routing
-// instead of dialing GitHub directly. No-op when team checking is disabled
-// (no identity source).
+// instead of dialing GitHub directly. Safe on a nil policy
+// (NewEnterprisePolicy returns nil when the feature is disabled) and a
+// no-op when team checking is disabled (no identity source).
 func (p *EnterprisePolicy) SetTransport(rt http.RoundTripper) {
-	if p.teams != nil {
-		p.teams.client.Transport = rt
+	if p == nil || p.teams == nil {
+		return
 	}
+	p.teams.client.Transport = rt
 }
 
 func newTeamChecker(identity ExceptionIdentitySource, logger *slog.Logger) *teamChecker {

--- a/internal/proxy/enterprise_test.go
+++ b/internal/proxy/enterprise_test.go
@@ -848,3 +848,23 @@ func newScopedPassthroughWithPolicy(t *testing.T, inner http.Handler, policy *En
 	handler := NewScopedPassthroughHandler(inner, tokenSvc, resolver, nil, policy, slog.Default())
 	return handler, result.Token
 }
+
+func TestEnterprisePolicy_SetTransportNilSafe(t *testing.T) {
+	// NewEnterprisePolicy returns nil when the feature is disabled; the
+	// server calls SetTransport unconditionally, so it must be nil-safe.
+	var p *EnterprisePolicy
+	p.SetTransport(http.DefaultTransport)
+
+	disabled := NewEnterprisePolicy(config.GitHubConfig{}, nil, nil)
+	if disabled != nil {
+		t.Fatalf("expected nil policy when enterprise_slug is empty, got %+v", disabled)
+	}
+	disabled.SetTransport(http.DefaultTransport)
+
+	// Enabled policy without identity source: teams is nil, still a no-op.
+	enabled := NewEnterprisePolicy(config.GitHubConfig{EnterpriseSlug: "corp"}, nil, nil)
+	if enabled == nil {
+		t.Fatal("expected non-nil policy when enterprise_slug is set")
+	}
+	enabled.SetTransport(http.DefaultTransport)
+}

--- a/internal/proxy/forwardproxy.go
+++ b/internal/proxy/forwardproxy.go
@@ -2,6 +2,7 @@ package proxy
 
 import (
 	"context"
+	"fmt"
 	"hash/fnv"
 	"log/slog"
 	"math/rand/v2"
@@ -9,6 +10,7 @@ import (
 	"net/http"
 	"net/url"
 	"sort"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -34,7 +36,91 @@ const (
 	// default for those calls unless a control rule opts them in via
 	// include_non_github.
 	ForwardProxyLayerDirect = "direct"
+	// ForwardProxyLayerHeader marks requests whose forward proxy was chosen
+	// by the client via the X-GitHub-Proxy-Forward-* request headers
+	// (requires forward_proxy.allow_request_header). Client choice beats
+	// every ruleset layer.
+	ForwardProxyLayerHeader = "header"
 )
+
+// Request headers a client may use to select the upstream forward proxy for
+// a single request, when forward_proxy.allow_request_header is enabled.
+// The HTTP and HTTPS headers are aliases accepting http:// or https:// proxy
+// URLs; the SOCKS header accepts socks5:// or socks5h:// URLs. The headers
+// are always stripped before the request is forwarded upstream.
+const (
+	ForwardProxyHeaderHTTP  = "X-GitHub-Proxy-Forward-HTTP"
+	ForwardProxyHeaderHTTPS = "X-GitHub-Proxy-Forward-HTTPS"
+	ForwardProxyHeaderSOCKS = "X-GitHub-Proxy-Forward-SOCKS"
+)
+
+// ExtractClientForwardProxy reads and strips the X-GitHub-Proxy-Forward-*
+// headers from r. When enabled is false the headers are stripped and ignored
+// (nil, nil). When enabled, at most one proxy may be specified across the
+// three headers (duplicate identical values are tolerated); the value must
+// be a valid proxy URL with a scheme matching its header family, a host, and
+// no query string or fragment. A non-nil error means the request should be
+// rejected with 400.
+func ExtractClientForwardProxy(r *http.Request, enabled bool) (*url.URL, error) {
+	type headerVal struct {
+		header  string
+		value   string
+		schemes []string
+	}
+	vals := []headerVal{
+		{ForwardProxyHeaderHTTP, r.Header.Get(ForwardProxyHeaderHTTP), []string{"http", "https"}},
+		{ForwardProxyHeaderHTTPS, r.Header.Get(ForwardProxyHeaderHTTPS), []string{"http", "https"}},
+		{ForwardProxyHeaderSOCKS, r.Header.Get(ForwardProxyHeaderSOCKS), []string{"socks5", "socks5h"}},
+	}
+	// Always strip: the headers are ghp-internal routing hints and must
+	// never reach GitHub or any other upstream.
+	r.Header.Del(ForwardProxyHeaderHTTP)
+	r.Header.Del(ForwardProxyHeaderHTTPS)
+	r.Header.Del(ForwardProxyHeaderSOCKS)
+
+	if !enabled {
+		return nil, nil
+	}
+
+	var chosen *headerVal
+	for i := range vals {
+		v := &vals[i]
+		if v.value == "" {
+			continue
+		}
+		if chosen != nil && chosen.value != v.value {
+			return nil, fmt.Errorf("conflicting forward proxy headers: %s and %s specify different proxies", chosen.header, v.header)
+		}
+		if chosen == nil {
+			chosen = v
+		}
+	}
+	if chosen == nil {
+		return nil, nil
+	}
+
+	u, err := url.Parse(chosen.value)
+	if err != nil {
+		return nil, fmt.Errorf("%s: malformed proxy URL", chosen.header)
+	}
+	schemeOK := false
+	for _, s := range chosen.schemes {
+		if u.Scheme == s {
+			schemeOK = true
+			break
+		}
+	}
+	if !schemeOK {
+		return nil, fmt.Errorf("%s: scheme must be one of %s", chosen.header, strings.Join(chosen.schemes, ", "))
+	}
+	if u.Host == "" {
+		return nil, fmt.Errorf("%s: host is required", chosen.header)
+	}
+	if u.RawQuery != "" || u.Fragment != "" {
+		return nil, fmt.Errorf("%s: query string and fragment are not allowed", chosen.header)
+	}
+	return u, nil
+}
 
 // compiledTarget is a validated upstream forward proxy within a ruleset.
 type compiledTarget struct {
@@ -365,6 +451,18 @@ func (fr *ForwardProxyRouter) ProxyFunc() func(*http.Request) (*url.URL, error) 
 		}
 		if info.Control {
 			return fr.controlProxy(req)
+		}
+		// A client-specified proxy (validated at the edge, feature-gated by
+		// forward_proxy.allow_request_header) beats every ruleset layer —
+		// the client may know something the operator's rules cannot.
+		if info.ClientProxy != nil {
+			metrics.ForwardProxySelectTotal.WithLabelValues("", ForwardProxyLayerHeader).Inc()
+			tokenType := info.TokenType
+			if tokenType == "" {
+				tokenType = "unknown"
+			}
+			metrics.ForwardProxyClientSpecifiedTotal.WithLabelValues(info.ClientProxy.Scheme, tokenType).Inc()
+			return info.ClientProxy, nil
 		}
 		start := time.Now()
 		u, ruleset, layer := fr.Select(info.ClientIP, info.TokenID, info.AppID)

--- a/internal/proxy/forwardproxy.go
+++ b/internal/proxy/forwardproxy.go
@@ -29,6 +29,11 @@ const (
 	ForwardProxyLayerSystem  = "system"
 	ForwardProxyLayerControl = "control"
 	ForwardProxyLayerAmbient = "ambient"
+	// ForwardProxyLayerDirect marks non-GitHub control calls (release HEAD
+	// probes against the operator's mirror) sent with no proxy at all — the
+	// default for those calls unless a control rule opts them in via
+	// include_non_github.
+	ForwardProxyLayerDirect = "direct"
 )
 
 // compiledTarget is a validated upstream forward proxy within a ruleset.
@@ -63,6 +68,10 @@ type routeTable struct {
 	byNet   []netRule // sorted most-specific prefix first
 	system  *compiledRuleset
 	control *compiledRuleset // ghp's own control-plane traffic
+	// controlNonGitHub extends the control ruleset to ghp control calls
+	// targeting non-GitHub hosts; set from the winning control rule's
+	// include_non_github flag.
+	controlNonGitHub bool
 }
 
 // ForwardProxyRouter selects which upstream forward proxy (if any) an
@@ -163,12 +172,15 @@ func (fr *ForwardProxyRouter) Reload(ctx context.Context) error {
 				table.system = compiled
 				bound = true
 			case database.ForwardProxyRuleControl:
-				if table.control != nil {
+				if table.control != nil && table.control != compiled {
 					fr.logger.Warn("forward proxy: multiple control rulesets; first by name wins",
 						"kept", table.control.name, "ignored", rs.Name)
 					continue
 				}
 				table.control = compiled
+				if rule.IncludeNonGitHub {
+					table.controlNonGitHub = true
+				}
 				bound = true
 			default:
 				fr.logger.Warn("forward proxy: skipping unknown rule type",
@@ -380,10 +392,32 @@ func (fr *ForwardProxyRouter) controlProxy(req *http.Request) (*url.URL, error) 
 
 // ControlProxyFunc returns a proxy selection function that always routes as
 // control-plane traffic, regardless of request context. Use it for internal
-// clients that are not tied to a proxied request (App installation token
-// minting, username resolution, OAuth login flows, release HEAD probes).
+// clients whose destination is GitHub (App installation token minting,
+// username resolution, OAuth login flows).
 func (fr *ForwardProxyRouter) ControlProxyFunc() func(*http.Request) (*url.URL, error) {
 	return fr.controlProxy
+}
+
+// nonGitHubControlProxy resolves the egress proxy for ghp control calls that
+// target non-GitHub hosts (release redirect HEAD probes against the
+// operator's mirror). Those hosts are typically internal, so the default is
+// DIRECT — no proxy at all, not even the ambient environment. A control rule
+// with include_non_github=true opts them into the control ruleset instead.
+func (fr *ForwardProxyRouter) nonGitHubControlProxy(_ *http.Request) (*url.URL, error) {
+	fr.mu.RLock()
+	table := fr.table
+	fr.mu.RUnlock()
+
+	start := time.Now()
+	if table.control != nil && table.controlNonGitHub {
+		u := table.control.pick("")
+		metrics.ObserveDecision(metrics.StageForwardProxySelection, "", time.Since(start))
+		metrics.ForwardProxySelectTotal.WithLabelValues(table.control.name, ForwardProxyLayerControl).Inc()
+		return u, nil
+	}
+	metrics.ObserveDecision(metrics.StageForwardProxySelection, "", time.Since(start))
+	metrics.ForwardProxySelectTotal.WithLabelValues("", ForwardProxyLayerDirect).Inc()
+	return nil, nil
 }
 
 // NewForwardProxyTransport returns an http.Transport cloned from
@@ -404,5 +438,15 @@ func NewForwardProxyTransport(fr *ForwardProxyRouter) *http.Transport {
 func NewForwardProxyControlTransport(fr *ForwardProxyRouter) *http.Transport {
 	t := http.DefaultTransport.(*http.Transport).Clone()
 	t.Proxy = fr.ControlProxyFunc()
+	return t
+}
+
+// NewForwardProxyNonGitHubControlTransport returns a transport for ghp
+// control calls whose destination is not GitHub (release redirect HEAD
+// probes). Requests are sent direct unless a control rule sets
+// include_non_github, in which case they follow the control ruleset.
+func NewForwardProxyNonGitHubControlTransport(fr *ForwardProxyRouter) *http.Transport {
+	t := http.DefaultTransport.(*http.Transport).Clone()
+	t.Proxy = fr.nonGitHubControlProxy
 	return t
 }

--- a/internal/proxy/forwardproxy.go
+++ b/internal/proxy/forwardproxy.go
@@ -1,0 +1,344 @@
+package proxy
+
+import (
+	"context"
+	"hash/fnv"
+	"log/slog"
+	"math/rand/v2"
+	"net"
+	"net/http"
+	"net/url"
+	"sort"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/goodtune/ghp/internal/database"
+	"github.com/goodtune/ghp/internal/metrics"
+)
+
+// Forward proxy selection layers, from most to least specific. The layer a
+// request matched is exported as the `layer` label on
+// ghp_forward_proxy_select_total. "ambient" means no ruleset matched and the
+// upstream connection falls back to the process environment
+// (HTTPS_PROXY/HTTP_PROXY/NO_PROXY via http.ProxyFromEnvironment).
+const (
+	ForwardProxyLayerToken   = "token"
+	ForwardProxyLayerApp     = "app"
+	ForwardProxyLayerNet     = "net"
+	ForwardProxyLayerSystem  = "system"
+	ForwardProxyLayerAmbient = "ambient"
+)
+
+// compiledTarget is a validated upstream forward proxy within a ruleset.
+type compiledTarget struct {
+	u      *url.URL
+	weight int
+}
+
+// compiledRuleset is the in-memory, validated form of a ForwardProxyRuleset.
+// Selection state (the round-robin counter) lives here so it survives across
+// requests but resets naturally on Reload.
+type compiledRuleset struct {
+	name        string
+	algorithm   string
+	targets     []compiledTarget
+	totalWeight int
+	rr          atomic.Uint64
+}
+
+// netRule binds a source CIDR to a ruleset.
+type netRule struct {
+	cidr    *net.IPNet
+	ruleset *compiledRuleset
+}
+
+// routeTable is the immutable compiled snapshot the router serves selections
+// from. A whole new table is built on Reload and swapped in under the lock,
+// so in-flight selections never observe a partially-updated state.
+type routeTable struct {
+	byToken map[string]*compiledRuleset
+	byApp   map[string]*compiledRuleset
+	byNet   []netRule // sorted most-specific prefix first
+	system  *compiledRuleset
+}
+
+// ForwardProxyRouter selects which upstream forward proxy (if any) an
+// outbound GitHub request should egress through. Rulesets are runtime
+// configuration loaded from the database; Reload rebuilds the in-memory
+// route table. Selection precedence is most-specific first:
+// token rule → app rule → net (CIDR) rule → system rule → ambient
+// environment (http.ProxyFromEnvironment).
+type ForwardProxyRouter struct {
+	store  database.Store
+	logger *slog.Logger
+
+	// ambient is the fallback proxy function used when no ruleset matches.
+	// Defaults to http.ProxyFromEnvironment; overridable for tests (that
+	// function caches the process environment on first use).
+	ambient func(*http.Request) (*url.URL, error)
+
+	mu    sync.RWMutex
+	table *routeTable
+}
+
+// NewForwardProxyRouter creates a router with an empty route table. Call
+// Reload to populate it from the store.
+func NewForwardProxyRouter(store database.Store, logger *slog.Logger) *ForwardProxyRouter {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &ForwardProxyRouter{
+		store:   store,
+		logger:  logger,
+		ambient: http.ProxyFromEnvironment,
+		table:   &routeTable{byToken: map[string]*compiledRuleset{}, byApp: map[string]*compiledRuleset{}},
+	}
+}
+
+// Reload rebuilds the route table from the store. Disabled rulesets, rulesets
+// with no valid proxy target, and malformed rules are skipped with a warning —
+// a bad ruleset must never take down egress for the rest of the system. When
+// multiple rulesets bind the same token, app, or the system layer, the first
+// by name wins deterministically and a warning is logged.
+func (fr *ForwardProxyRouter) Reload(ctx context.Context) error {
+	rulesets, err := fr.store.ListForwardProxyRulesets(ctx)
+	if err != nil {
+		return err
+	}
+
+	// ListForwardProxyRulesets orders by name; sort defensively so conflict
+	// resolution stays deterministic even if a backend deviates.
+	sort.Slice(rulesets, func(i, j int) bool { return rulesets[i].Name < rulesets[j].Name })
+
+	table := &routeTable{
+		byToken: map[string]*compiledRuleset{},
+		byApp:   map[string]*compiledRuleset{},
+	}
+	active := 0
+	for _, rs := range rulesets {
+		if !rs.Enabled {
+			continue
+		}
+		compiled := fr.compile(rs)
+		if compiled == nil {
+			continue
+		}
+		bound := false
+		for _, rule := range rs.Rules {
+			switch rule.Type {
+			case database.ForwardProxyRuleToken:
+				if existing, ok := table.byToken[rule.Value]; ok {
+					fr.logger.Warn("forward proxy: token bound by multiple rulesets; first by name wins",
+						"token_id", rule.Value, "kept", existing.name, "ignored", rs.Name)
+					continue
+				}
+				table.byToken[rule.Value] = compiled
+				bound = true
+			case database.ForwardProxyRuleApp:
+				if existing, ok := table.byApp[rule.Value]; ok {
+					fr.logger.Warn("forward proxy: app bound by multiple rulesets; first by name wins",
+						"app_record_id", rule.Value, "kept", existing.name, "ignored", rs.Name)
+					continue
+				}
+				table.byApp[rule.Value] = compiled
+				bound = true
+			case database.ForwardProxyRuleNet:
+				_, cidr, err := net.ParseCIDR(rule.Value)
+				if err != nil {
+					fr.logger.Warn("forward proxy: skipping invalid CIDR rule",
+						"ruleset", rs.Name, "cidr", rule.Value, "error", err)
+					continue
+				}
+				table.byNet = append(table.byNet, netRule{cidr: cidr, ruleset: compiled})
+				bound = true
+			case database.ForwardProxyRuleSystem:
+				if table.system != nil {
+					fr.logger.Warn("forward proxy: multiple system rulesets; first by name wins",
+						"kept", table.system.name, "ignored", rs.Name)
+					continue
+				}
+				table.system = compiled
+				bound = true
+			default:
+				fr.logger.Warn("forward proxy: skipping unknown rule type",
+					"ruleset", rs.Name, "type", rule.Type)
+			}
+		}
+		if bound {
+			active++
+		}
+	}
+
+	// Most-specific CIDR wins; break prefix-length ties by ruleset name for
+	// determinism.
+	sort.SliceStable(table.byNet, func(i, j int) bool {
+		li, _ := table.byNet[i].cidr.Mask.Size()
+		lj, _ := table.byNet[j].cidr.Mask.Size()
+		if li != lj {
+			return li > lj
+		}
+		return table.byNet[i].ruleset.name < table.byNet[j].ruleset.name
+	})
+
+	fr.mu.Lock()
+	fr.table = table
+	fr.mu.Unlock()
+
+	metrics.ForwardProxyRulesetsActive.Set(float64(active))
+	fr.logger.Info("forward proxy route table reloaded",
+		"rulesets", active,
+		"token_rules", len(table.byToken),
+		"app_rules", len(table.byApp),
+		"net_rules", len(table.byNet),
+		"system_rule", table.system != nil)
+	return nil
+}
+
+// compile validates a ruleset's targets and returns nil when none are usable.
+func (fr *ForwardProxyRouter) compile(rs *database.ForwardProxyRuleset) *compiledRuleset {
+	c := &compiledRuleset{name: rs.Name, algorithm: rs.Algorithm}
+	for _, p := range rs.Proxies {
+		u, err := url.Parse(p.URL)
+		if err != nil || u.Host == "" || (u.Scheme != "http" && u.Scheme != "https" && u.Scheme != "socks5" && u.Scheme != "socks5h") {
+			fr.logger.Warn("forward proxy: skipping invalid proxy target",
+				"ruleset", rs.Name, "url", p.URL)
+			continue
+		}
+		w := p.Weight
+		if w < 1 {
+			w = 1
+		}
+		c.targets = append(c.targets, compiledTarget{u: u, weight: w})
+		c.totalWeight += w
+	}
+	if len(c.targets) == 0 {
+		fr.logger.Warn("forward proxy: ruleset has no valid proxy targets; skipping", "ruleset", rs.Name)
+		return nil
+	}
+	return c
+}
+
+// StartRefresh reloads the route table on the given interval until ctx is
+// cancelled. Admin API mutations reload immediately on the instance that
+// served them; the periodic refresh is what propagates changes to other
+// instances in HA deployments.
+func (fr *ForwardProxyRouter) StartRefresh(ctx context.Context, interval time.Duration) {
+	if interval <= 0 {
+		interval = time.Minute
+	}
+	go func() {
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				if err := fr.Reload(ctx); err != nil {
+					fr.logger.Warn("forward proxy: periodic reload failed", "error", err)
+				}
+			}
+		}
+	}()
+}
+
+// Select returns the forward proxy URL for a request, together with the name
+// of the matched ruleset and the layer that matched. A nil URL with layer
+// "ambient" means no ruleset applies and the caller should fall back to the
+// process environment.
+func (fr *ForwardProxyRouter) Select(clientIP, tokenID, appID string) (*url.URL, string, string) {
+	fr.mu.RLock()
+	table := fr.table
+	fr.mu.RUnlock()
+
+	if tokenID != "" {
+		if rs, ok := table.byToken[tokenID]; ok {
+			return rs.pick(clientIP), rs.name, ForwardProxyLayerToken
+		}
+	}
+	if appID != "" {
+		if rs, ok := table.byApp[appID]; ok {
+			return rs.pick(clientIP), rs.name, ForwardProxyLayerApp
+		}
+	}
+	if clientIP != "" && len(table.byNet) > 0 {
+		if ip := net.ParseIP(clientIP); ip != nil {
+			for _, nr := range table.byNet {
+				if nr.cidr.Contains(ip) {
+					return nr.ruleset.pick(clientIP), nr.ruleset.name, ForwardProxyLayerNet
+				}
+			}
+		}
+	}
+	if table.system != nil {
+		return table.system.pick(clientIP), table.system.name, ForwardProxyLayerSystem
+	}
+	return nil, "", ForwardProxyLayerAmbient
+}
+
+// pick chooses a target according to the ruleset's algorithm. clientIP is
+// only consulted by the sticky algorithm.
+func (c *compiledRuleset) pick(clientIP string) *url.URL {
+	if len(c.targets) == 1 {
+		return c.targets[0].u
+	}
+	switch c.algorithm {
+	case database.ForwardProxyAlgoWeighted:
+		return c.pickByWeight(rand.IntN(c.totalWeight))
+	case database.ForwardProxyAlgoSticky:
+		h := fnv.New32a()
+		h.Write([]byte(clientIP))
+		return c.pickByWeight(int(h.Sum32() % uint32(c.totalWeight)))
+	default: // round_robin
+		n := c.rr.Add(1) - 1
+		return c.targets[n%uint64(len(c.targets))].u
+	}
+}
+
+// pickByWeight maps a point in [0, totalWeight) onto the cumulative weight
+// distribution of the targets.
+func (c *compiledRuleset) pickByWeight(point int) *url.URL {
+	for _, t := range c.targets {
+		if point < t.weight {
+			return t.u
+		}
+		point -= t.weight
+	}
+	return c.targets[len(c.targets)-1].u
+}
+
+// ProxyFunc returns a per-request proxy selection function suitable for
+// http.Transport.Proxy. It reads the request identity (client IP, token ID,
+// app record ID) from the outbound request's context — populated by the
+// server middleware and the token-resolving handlers on the inbound request,
+// and inherited by outbound requests created with the inbound context — and
+// falls back to http.ProxyFromEnvironment when no ruleset matches or the
+// request carries no route info (e.g. internal OAuth refresh calls).
+func (fr *ForwardProxyRouter) ProxyFunc() func(*http.Request) (*url.URL, error) {
+	return func(req *http.Request) (*url.URL, error) {
+		info := ForwardProxyInfoFromContext(req.Context())
+		if info == nil {
+			return fr.ambient(req)
+		}
+		start := time.Now()
+		u, ruleset, layer := fr.Select(info.ClientIP, info.TokenID, info.AppID)
+		metrics.ObserveDecision(metrics.StageForwardProxySelection, info.TokenType, time.Since(start))
+		metrics.ForwardProxySelectTotal.WithLabelValues(ruleset, layer).Inc()
+		if u == nil {
+			return fr.ambient(req)
+		}
+		return u, nil
+	}
+}
+
+// NewForwardProxyTransport returns an http.Transport cloned from
+// http.DefaultTransport whose Proxy function consults the router per request.
+// All outbound GitHub transports (API proxy, github.com passthrough,
+// codeload, Copilot) share one instance so connection pools are reused per
+// selected proxy.
+func NewForwardProxyTransport(fr *ForwardProxyRouter) *http.Transport {
+	t := http.DefaultTransport.(*http.Transport).Clone()
+	t.Proxy = fr.ProxyFunc()
+	return t
+}

--- a/internal/proxy/forwardproxy.go
+++ b/internal/proxy/forwardproxy.go
@@ -307,11 +307,17 @@ func (fr *ForwardProxyRouter) Reload(ctx context.Context) error {
 // compile validates a ruleset's targets and returns nil when none are usable.
 func (fr *ForwardProxyRouter) compile(rs *database.ForwardProxyRuleset) *compiledRuleset {
 	c := &compiledRuleset{name: rs.Name, algorithm: rs.Algorithm}
-	for _, p := range rs.Proxies {
+	for i, p := range rs.Proxies {
 		u, err := url.Parse(p.URL)
 		if err != nil || u.Host == "" || (u.Scheme != "http" && u.Scheme != "https" && u.Scheme != "socks5" && u.Scheme != "socks5h") {
+			// Log a redacted form only: target URLs may embed proxy
+			// credentials in the userinfo component.
+			redacted := "(unparseable)"
+			if err == nil {
+				redacted = u.Redacted()
+			}
 			fr.logger.Warn("forward proxy: skipping invalid proxy target",
-				"ruleset", rs.Name, "url", p.URL)
+				"ruleset", rs.Name, "index", i, "url", redacted)
 			continue
 		}
 		w := p.Weight
@@ -454,14 +460,16 @@ func (fr *ForwardProxyRouter) ProxyFunc() func(*http.Request) (*url.URL, error) 
 		}
 		// A client-specified proxy (validated at the edge, feature-gated by
 		// forward_proxy.allow_request_header) beats every ruleset layer —
-		// the client may know something the operator's rules cannot.
-		if info.ClientProxy != nil {
+		// the client may know something the operator's rules cannot. It is
+		// only honoured once a ghx_/gha_ token has been resolved: without
+		// the identity gate, an unauthenticated caller on the passthrough
+		// path could use the header to make ghp dial arbitrary internal
+		// host:port targets (SSRF/port-scan). Unauthenticated requests fall
+		// through to normal ruleset selection.
+		if info.ClientProxy != nil && info.TokenID != "" {
+			metrics.ObserveDecision(metrics.StageForwardProxySelection, info.TokenType, 0)
 			metrics.ForwardProxySelectTotal.WithLabelValues("", ForwardProxyLayerHeader).Inc()
-			tokenType := info.TokenType
-			if tokenType == "" {
-				tokenType = "unknown"
-			}
-			metrics.ForwardProxyClientSpecifiedTotal.WithLabelValues(info.ClientProxy.Scheme, tokenType).Inc()
+			metrics.ForwardProxyClientSpecifiedTotal.WithLabelValues(info.ClientProxy.Scheme, info.TokenType).Inc()
 			return info.ClientProxy, nil
 		}
 		start := time.Now()

--- a/internal/proxy/forwardproxy.go
+++ b/internal/proxy/forwardproxy.go
@@ -27,6 +27,7 @@ const (
 	ForwardProxyLayerApp     = "app"
 	ForwardProxyLayerNet     = "net"
 	ForwardProxyLayerSystem  = "system"
+	ForwardProxyLayerControl = "control"
 	ForwardProxyLayerAmbient = "ambient"
 )
 
@@ -61,6 +62,7 @@ type routeTable struct {
 	byApp   map[string]*compiledRuleset
 	byNet   []netRule // sorted most-specific prefix first
 	system  *compiledRuleset
+	control *compiledRuleset // ghp's own control-plane traffic
 }
 
 // ForwardProxyRouter selects which upstream forward proxy (if any) an
@@ -160,6 +162,14 @@ func (fr *ForwardProxyRouter) Reload(ctx context.Context) error {
 				}
 				table.system = compiled
 				bound = true
+			case database.ForwardProxyRuleControl:
+				if table.control != nil {
+					fr.logger.Warn("forward proxy: multiple control rulesets; first by name wins",
+						"kept", table.control.name, "ignored", rs.Name)
+					continue
+				}
+				table.control = compiled
+				bound = true
 			default:
 				fr.logger.Warn("forward proxy: skipping unknown rule type",
 					"ruleset", rs.Name, "type", rule.Type)
@@ -191,7 +201,8 @@ func (fr *ForwardProxyRouter) Reload(ctx context.Context) error {
 		"token_rules", len(table.byToken),
 		"app_rules", len(table.byApp),
 		"net_rules", len(table.byNet),
-		"system_rule", table.system != nil)
+		"system_rule", table.system != nil,
+		"control_rule", table.control != nil)
 	return nil
 }
 
@@ -277,6 +288,25 @@ func (fr *ForwardProxyRouter) Select(clientIP, tokenID, appID string) (*url.URL,
 	return nil, "", ForwardProxyLayerAmbient
 }
 
+// SelectControl returns the forward proxy URL for ghp's own control-plane
+// traffic (OAuth flows and token refresh, App installation token minting,
+// username resolution, release redirect HEAD probes). Precedence: control
+// rule → system rule → ambient. Token, app, and net layers never apply —
+// control traffic is not attributable to a client.
+func (fr *ForwardProxyRouter) SelectControl() (*url.URL, string, string) {
+	fr.mu.RLock()
+	table := fr.table
+	fr.mu.RUnlock()
+
+	if table.control != nil {
+		return table.control.pick(""), table.control.name, ForwardProxyLayerControl
+	}
+	if table.system != nil {
+		return table.system.pick(""), table.system.name, ForwardProxyLayerSystem
+	}
+	return nil, "", ForwardProxyLayerAmbient
+}
+
 // pick chooses a target according to the ruleset's algorithm. clientIP is
 // only consulted by the sticky algorithm.
 func (c *compiledRuleset) pick(clientIP string) *url.URL {
@@ -321,6 +351,9 @@ func (fr *ForwardProxyRouter) ProxyFunc() func(*http.Request) (*url.URL, error) 
 		if info == nil {
 			return fr.ambient(req)
 		}
+		if info.Control {
+			return fr.controlProxy(req)
+		}
 		start := time.Now()
 		u, ruleset, layer := fr.Select(info.ClientIP, info.TokenID, info.AppID)
 		metrics.ObserveDecision(metrics.StageForwardProxySelection, info.TokenType, time.Since(start))
@@ -332,6 +365,27 @@ func (fr *ForwardProxyRouter) ProxyFunc() func(*http.Request) (*url.URL, error) 
 	}
 }
 
+// controlProxy resolves the egress proxy for a control-plane request and
+// records the routing decision.
+func (fr *ForwardProxyRouter) controlProxy(req *http.Request) (*url.URL, error) {
+	start := time.Now()
+	u, ruleset, layer := fr.SelectControl()
+	metrics.ObserveDecision(metrics.StageForwardProxySelection, "", time.Since(start))
+	metrics.ForwardProxySelectTotal.WithLabelValues(ruleset, layer).Inc()
+	if u == nil {
+		return fr.ambient(req)
+	}
+	return u, nil
+}
+
+// ControlProxyFunc returns a proxy selection function that always routes as
+// control-plane traffic, regardless of request context. Use it for internal
+// clients that are not tied to a proxied request (App installation token
+// minting, username resolution, OAuth login flows, release HEAD probes).
+func (fr *ForwardProxyRouter) ControlProxyFunc() func(*http.Request) (*url.URL, error) {
+	return fr.controlProxy
+}
+
 // NewForwardProxyTransport returns an http.Transport cloned from
 // http.DefaultTransport whose Proxy function consults the router per request.
 // All outbound GitHub transports (API proxy, github.com passthrough,
@@ -340,5 +394,15 @@ func (fr *ForwardProxyRouter) ProxyFunc() func(*http.Request) (*url.URL, error) 
 func NewForwardProxyTransport(fr *ForwardProxyRouter) *http.Transport {
 	t := http.DefaultTransport.(*http.Transport).Clone()
 	t.Proxy = fr.ProxyFunc()
+	return t
+}
+
+// NewForwardProxyControlTransport returns a transport that routes every
+// request as control-plane traffic (control rule → system rule → ambient).
+// It is installed on ghp's internal clients so operators can pin the proxy's
+// own GitHub traffic to a dedicated egress path.
+func NewForwardProxyControlTransport(fr *ForwardProxyRouter) *http.Transport {
+	t := http.DefaultTransport.(*http.Transport).Clone()
+	t.Proxy = fr.ControlProxyFunc()
 	return t
 }

--- a/internal/proxy/forwardproxy_test.go
+++ b/internal/proxy/forwardproxy_test.go
@@ -1,0 +1,269 @@
+package proxy
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/goodtune/ghp/internal/database"
+)
+
+// fpStore is a minimal Store stub for router tests: only
+// ListForwardProxyRulesets is implemented.
+type fpStore struct {
+	database.Store
+	rulesets []*database.ForwardProxyRuleset
+	err      error
+}
+
+func (s *fpStore) ListForwardProxyRulesets(ctx context.Context) ([]*database.ForwardProxyRuleset, error) {
+	return s.rulesets, s.err
+}
+
+func reloadedRouter(t *testing.T, rulesets ...*database.ForwardProxyRuleset) *ForwardProxyRouter {
+	t.Helper()
+	fr := NewForwardProxyRouter(&fpStore{rulesets: rulesets}, nil)
+	if err := fr.Reload(context.Background()); err != nil {
+		t.Fatalf("Reload: %v", err)
+	}
+	return fr
+}
+
+func TestForwardProxyRouter_LayerPrecedence(t *testing.T) {
+	fr := reloadedRouter(t,
+		&database.ForwardProxyRuleset{
+			Name: "app-rs", Algorithm: database.ForwardProxyAlgoRoundRobin, Enabled: true,
+			Proxies: []database.ForwardProxyEntry{{URL: "http://app-proxy:3128"}},
+			Rules:   []database.ForwardProxyRule{{Type: database.ForwardProxyRuleApp, Value: "app-1"}},
+		},
+		&database.ForwardProxyRuleset{
+			Name: "net-rs", Algorithm: database.ForwardProxyAlgoRoundRobin, Enabled: true,
+			Proxies: []database.ForwardProxyEntry{{URL: "http://net-proxy:3128"}},
+			Rules:   []database.ForwardProxyRule{{Type: database.ForwardProxyRuleNet, Value: "10.0.0.0/8"}},
+		},
+		&database.ForwardProxyRuleset{
+			Name: "sys-rs", Algorithm: database.ForwardProxyAlgoRoundRobin, Enabled: true,
+			Proxies: []database.ForwardProxyEntry{{URL: "http://sys-proxy:3128"}},
+			Rules:   []database.ForwardProxyRule{{Type: database.ForwardProxyRuleSystem}},
+		},
+		&database.ForwardProxyRuleset{
+			Name: "tok-rs", Algorithm: database.ForwardProxyAlgoRoundRobin, Enabled: true,
+			Proxies: []database.ForwardProxyEntry{{URL: "http://tok-proxy:3128"}},
+			Rules:   []database.ForwardProxyRule{{Type: database.ForwardProxyRuleToken, Value: "tok-1"}},
+		},
+	)
+
+	tests := []struct {
+		name                     string
+		clientIP, tokenID, appID string
+		wantHost, wantLayer      string
+	}{
+		{"token wins over all", "10.1.2.3", "tok-1", "app-1", "tok-proxy:3128", ForwardProxyLayerToken},
+		{"app wins over net and system", "10.1.2.3", "other-token", "app-1", "app-proxy:3128", ForwardProxyLayerApp},
+		{"net wins over system", "10.1.2.3", "", "", "net-proxy:3128", ForwardProxyLayerNet},
+		{"system catches the rest", "192.168.1.1", "", "", "sys-proxy:3128", ForwardProxyLayerSystem},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			u, _, layer := fr.Select(tt.clientIP, tt.tokenID, tt.appID)
+			if u == nil || u.Host != tt.wantHost {
+				t.Fatalf("Select() url = %v, want host %s", u, tt.wantHost)
+			}
+			if layer != tt.wantLayer {
+				t.Errorf("Select() layer = %q, want %q", layer, tt.wantLayer)
+			}
+		})
+	}
+}
+
+func TestForwardProxyRouter_AmbientFallback(t *testing.T) {
+	fr := reloadedRouter(t) // empty table
+
+	u, ruleset, layer := fr.Select("10.0.0.1", "tok", "app")
+	if u != nil || ruleset != "" || layer != ForwardProxyLayerAmbient {
+		t.Fatalf("Select() = (%v, %q, %q), want (nil, \"\", ambient)", u, ruleset, layer)
+	}
+}
+
+func TestForwardProxyRouter_DisabledAndInvalidRulesetsSkipped(t *testing.T) {
+	fr := reloadedRouter(t,
+		&database.ForwardProxyRuleset{
+			Name: "disabled", Algorithm: database.ForwardProxyAlgoRoundRobin, Enabled: false,
+			Proxies: []database.ForwardProxyEntry{{URL: "http://disabled-proxy:3128"}},
+			Rules:   []database.ForwardProxyRule{{Type: database.ForwardProxyRuleSystem}},
+		},
+		&database.ForwardProxyRuleset{
+			Name: "no-valid-targets", Algorithm: database.ForwardProxyAlgoRoundRobin, Enabled: true,
+			Proxies: []database.ForwardProxyEntry{{URL: "not a url"}, {URL: "ftp://nope:21"}},
+			Rules:   []database.ForwardProxyRule{{Type: database.ForwardProxyRuleSystem}},
+		},
+		&database.ForwardProxyRuleset{
+			Name: "bad-cidr", Algorithm: database.ForwardProxyAlgoRoundRobin, Enabled: true,
+			Proxies: []database.ForwardProxyEntry{{URL: "http://ok-proxy:3128"}},
+			Rules:   []database.ForwardProxyRule{{Type: database.ForwardProxyRuleNet, Value: "not-a-cidr"}},
+		},
+	)
+
+	if u, _, layer := fr.Select("10.0.0.1", "", ""); u != nil || layer != ForwardProxyLayerAmbient {
+		t.Fatalf("Select() = (%v, %q), want ambient fallback", u, layer)
+	}
+}
+
+func TestForwardProxyRouter_MostSpecificCIDRWins(t *testing.T) {
+	fr := reloadedRouter(t,
+		&database.ForwardProxyRuleset{
+			Name: "wide", Algorithm: database.ForwardProxyAlgoRoundRobin, Enabled: true,
+			Proxies: []database.ForwardProxyEntry{{URL: "http://wide-proxy:3128"}},
+			Rules:   []database.ForwardProxyRule{{Type: database.ForwardProxyRuleNet, Value: "10.0.0.0/8"}},
+		},
+		&database.ForwardProxyRuleset{
+			Name: "narrow", Algorithm: database.ForwardProxyAlgoRoundRobin, Enabled: true,
+			Proxies: []database.ForwardProxyEntry{{URL: "http://narrow-proxy:3128"}},
+			Rules:   []database.ForwardProxyRule{{Type: database.ForwardProxyRuleNet, Value: "10.42.0.0/16"}},
+		},
+	)
+
+	if u, _, _ := fr.Select("10.42.1.1", "", ""); u == nil || u.Host != "narrow-proxy:3128" {
+		t.Fatalf("Select(10.42.1.1) = %v, want narrow-proxy:3128", u)
+	}
+	if u, _, _ := fr.Select("10.7.1.1", "", ""); u == nil || u.Host != "wide-proxy:3128" {
+		t.Fatalf("Select(10.7.1.1) = %v, want wide-proxy:3128", u)
+	}
+	if u, _, layer := fr.Select("172.16.0.1", "", ""); u != nil || layer != ForwardProxyLayerAmbient {
+		t.Fatalf("Select(172.16.0.1) = (%v, %q), want ambient", u, layer)
+	}
+}
+
+func TestForwardProxyRouter_RoundRobinCycles(t *testing.T) {
+	fr := reloadedRouter(t,
+		&database.ForwardProxyRuleset{
+			Name: "rr", Algorithm: database.ForwardProxyAlgoRoundRobin, Enabled: true,
+			Proxies: []database.ForwardProxyEntry{
+				{URL: "http://p1:3128"}, {URL: "http://p2:3128"}, {URL: "http://p3:3128"},
+			},
+			Rules: []database.ForwardProxyRule{{Type: database.ForwardProxyRuleSystem}},
+		},
+	)
+
+	seen := make(map[string]int)
+	for i := 0; i < 6; i++ {
+		u, _, _ := fr.Select("", "", "")
+		seen[u.Host]++
+	}
+	for _, host := range []string{"p1:3128", "p2:3128", "p3:3128"} {
+		if seen[host] != 2 {
+			t.Errorf("round robin: %s selected %d times over 6 requests, want 2 (all: %v)", host, seen[host], seen)
+		}
+	}
+}
+
+func TestForwardProxyRouter_WeightedDistribution(t *testing.T) {
+	fr := reloadedRouter(t,
+		&database.ForwardProxyRuleset{
+			Name: "weighted", Algorithm: database.ForwardProxyAlgoWeighted, Enabled: true,
+			Proxies: []database.ForwardProxyEntry{
+				{URL: "http://heavy:3128", Weight: 80},
+				{URL: "http://light:3128", Weight: 20},
+			},
+			Rules: []database.ForwardProxyRule{{Type: database.ForwardProxyRuleSystem}},
+		},
+	)
+
+	seen := make(map[string]int)
+	const n = 5000
+	for i := 0; i < n; i++ {
+		u, _, _ := fr.Select("", "", "")
+		seen[u.Host]++
+	}
+	// 80/20 split: allow generous tolerance to keep the test deterministic
+	// enough (P(fail) is negligible with ±10 percentage points at n=5000).
+	if frac := float64(seen["heavy:3128"]) / n; frac < 0.70 || frac > 0.90 {
+		t.Errorf("weighted: heavy fraction = %.3f, want ~0.80 (counts: %v)", frac, seen)
+	}
+}
+
+func TestForwardProxyRouter_StickyIsDeterministicPerIP(t *testing.T) {
+	fr := reloadedRouter(t,
+		&database.ForwardProxyRuleset{
+			Name: "sticky", Algorithm: database.ForwardProxyAlgoSticky, Enabled: true,
+			Proxies: []database.ForwardProxyEntry{
+				{URL: "http://s1:3128"}, {URL: "http://s2:3128"}, {URL: "http://s3:3128"},
+			},
+			Rules: []database.ForwardProxyRule{{Type: database.ForwardProxyRuleSystem}},
+		},
+	)
+
+	first := make(map[string]string)
+	for _, ip := range []string{"10.0.0.1", "10.0.0.2", "10.0.0.3", "192.168.7.9"} {
+		u, _, _ := fr.Select(ip, "", "")
+		first[ip] = u.Host
+		for i := 0; i < 20; i++ {
+			if u2, _, _ := fr.Select(ip, "", ""); u2.Host != first[ip] {
+				t.Fatalf("sticky: ip %s flapped from %s to %s", ip, first[ip], u2.Host)
+			}
+		}
+	}
+}
+
+func TestForwardProxyRouter_ProxyFunc(t *testing.T) {
+	fr := reloadedRouter(t,
+		&database.ForwardProxyRuleset{
+			Name: "tok-rs", Algorithm: database.ForwardProxyAlgoRoundRobin, Enabled: true,
+			Proxies: []database.ForwardProxyEntry{{URL: "http://tok-proxy:3128"}},
+			Rules:   []database.ForwardProxyRule{{Type: database.ForwardProxyRuleToken, Value: "tok-1"}},
+		},
+	)
+	// Stub the ambient fallback: http.ProxyFromEnvironment caches the process
+	// environment on first use, so tests can't rely on t.Setenv.
+	fr.ambient = func(*http.Request) (*url.URL, error) { return nil, nil }
+	proxyFn := fr.ProxyFunc()
+
+	// No route info on the context → ambient fallback.
+	bare := httptest.NewRequest(http.MethodGet, "https://api.github.com/", nil)
+	if u, err := proxyFn(bare); err != nil || u != nil {
+		t.Fatalf("ProxyFunc(no info) = (%v, %v), want (nil, nil)", u, err)
+	}
+
+	// Route info present and token bound → ruleset proxy.
+	r := httptest.NewRequest(http.MethodGet, "https://api.github.com/", nil)
+	r = PrepareForwardProxyInfo(r, "10.0.0.1")
+	SetForwardProxyIdentity(r, "tok-1", "", "proxy")
+	out, _ := http.NewRequestWithContext(r.Context(), http.MethodGet, "https://api.github.com/user", nil)
+	u, err := proxyFn(out)
+	if err != nil || u == nil || u.Host != "tok-proxy:3128" {
+		t.Fatalf("ProxyFunc(token info) = (%v, %v), want tok-proxy:3128", u, err)
+	}
+
+	// Route info present but nothing matches → ambient fallback.
+	r2 := httptest.NewRequest(http.MethodGet, "https://api.github.com/", nil)
+	r2 = PrepareForwardProxyInfo(r2, "10.0.0.1")
+	out2, _ := http.NewRequestWithContext(r2.Context(), http.MethodGet, "https://api.github.com/user", nil)
+	if u2, err := proxyFn(out2); err != nil || u2 != nil {
+		t.Fatalf("ProxyFunc(unmatched info) = (%v, %v), want (nil, nil)", u2, err)
+	}
+}
+
+func TestForwardProxyRouter_ReloadSwapsTable(t *testing.T) {
+	store := &fpStore{rulesets: []*database.ForwardProxyRuleset{{
+		Name: "sys", Algorithm: database.ForwardProxyAlgoRoundRobin, Enabled: true,
+		Proxies: []database.ForwardProxyEntry{{URL: "http://old-proxy:3128"}},
+		Rules:   []database.ForwardProxyRule{{Type: database.ForwardProxyRuleSystem}},
+	}}}
+	fr := NewForwardProxyRouter(store, nil)
+	if err := fr.Reload(context.Background()); err != nil {
+		t.Fatalf("Reload: %v", err)
+	}
+	if u, _, _ := fr.Select("", "", ""); u == nil || u.Host != "old-proxy:3128" {
+		t.Fatalf("Select before swap = %v, want old-proxy:3128", u)
+	}
+
+	store.rulesets = nil
+	if err := fr.Reload(context.Background()); err != nil {
+		t.Fatalf("Reload: %v", err)
+	}
+	if u, _, layer := fr.Select("", "", ""); u != nil || layer != ForwardProxyLayerAmbient {
+		t.Fatalf("Select after swap = (%v, %q), want ambient", u, layer)
+	}
+}

--- a/internal/proxy/forwardproxy_test.go
+++ b/internal/proxy/forwardproxy_test.go
@@ -397,3 +397,106 @@ func TestForwardProxyRouter_NonGitHubControlOptIn(t *testing.T) {
 		t.Fatalf("non-GitHub control transport Proxy() = (%v, %v), want control-proxy:3128", u, err)
 	}
 }
+
+func TestExtractClientForwardProxy(t *testing.T) {
+	mk := func(headers map[string]string) *http.Request {
+		r := httptest.NewRequest(http.MethodGet, "https://api.github.com/user", nil)
+		for k, v := range headers {
+			r.Header.Set(k, v)
+		}
+		return r
+	}
+
+	t.Run("disabled strips and ignores", func(t *testing.T) {
+		r := mk(map[string]string{ForwardProxyHeaderHTTPS: "http://team-proxy:3128"})
+		u, err := ExtractClientForwardProxy(r, false)
+		if err != nil || u != nil {
+			t.Fatalf("got (%v, %v), want (nil, nil)", u, err)
+		}
+		if r.Header.Get(ForwardProxyHeaderHTTPS) != "" {
+			t.Error("header not stripped when disabled")
+		}
+	})
+
+	t.Run("no headers", func(t *testing.T) {
+		u, err := ExtractClientForwardProxy(mk(nil), true)
+		if err != nil || u != nil {
+			t.Fatalf("got (%v, %v), want (nil, nil)", u, err)
+		}
+	})
+
+	valid := []struct {
+		name, header, value, wantHost, wantScheme string
+	}{
+		{"https header with http proxy", ForwardProxyHeaderHTTPS, "http://team-proxy:3128", "team-proxy:3128", "http"},
+		{"http header alias", ForwardProxyHeaderHTTP, "https://team-proxy:443", "team-proxy:443", "https"},
+		{"socks header", ForwardProxyHeaderSOCKS, "socks5://egress:1080", "egress:1080", "socks5"},
+		{"socks5h", ForwardProxyHeaderSOCKS, "socks5h://egress:1080", "egress:1080", "socks5h"},
+		{"credentials allowed", ForwardProxyHeaderHTTPS, "http://user:pass@team-proxy:3128", "team-proxy:3128", "http"},
+	}
+	for _, tt := range valid {
+		t.Run(tt.name, func(t *testing.T) {
+			r := mk(map[string]string{tt.header: tt.value})
+			u, err := ExtractClientForwardProxy(r, true)
+			if err != nil || u == nil || u.Host != tt.wantHost || u.Scheme != tt.wantScheme {
+				t.Fatalf("got (%v, %v), want %s://%s", u, err, tt.wantScheme, tt.wantHost)
+			}
+			for _, h := range []string{ForwardProxyHeaderHTTP, ForwardProxyHeaderHTTPS, ForwardProxyHeaderSOCKS} {
+				if r.Header.Get(h) != "" {
+					t.Errorf("header %s not stripped", h)
+				}
+			}
+		})
+	}
+
+	invalid := []struct {
+		name    string
+		headers map[string]string
+	}{
+		{"socks scheme on https header", map[string]string{ForwardProxyHeaderHTTPS: "socks5://egress:1080"}},
+		{"http scheme on socks header", map[string]string{ForwardProxyHeaderSOCKS: "http://team-proxy:3128"}},
+		{"missing host", map[string]string{ForwardProxyHeaderHTTPS: "http://"}},
+		{"query string", map[string]string{ForwardProxyHeaderHTTPS: "http://p:3128?x=1"}},
+		{"conflicting headers", map[string]string{ForwardProxyHeaderHTTPS: "http://a:3128", ForwardProxyHeaderSOCKS: "socks5://b:1080"}},
+	}
+	for _, tt := range invalid {
+		t.Run(tt.name, func(t *testing.T) {
+			if u, err := ExtractClientForwardProxy(mk(tt.headers), true); err == nil {
+				t.Fatalf("got (%v, nil), want error", u)
+			}
+		})
+	}
+
+	t.Run("duplicate identical values tolerated", func(t *testing.T) {
+		r := mk(map[string]string{
+			ForwardProxyHeaderHTTP:  "http://team-proxy:3128",
+			ForwardProxyHeaderHTTPS: "http://team-proxy:3128",
+		})
+		u, err := ExtractClientForwardProxy(r, true)
+		if err != nil || u == nil || u.Host != "team-proxy:3128" {
+			t.Fatalf("got (%v, %v), want team-proxy:3128", u, err)
+		}
+	})
+}
+
+func TestForwardProxyRouter_ClientChoiceBeatsRulesets(t *testing.T) {
+	fr := reloadedRouter(t,
+		&database.ForwardProxyRuleset{
+			Name: "tok-rs", Algorithm: database.ForwardProxyAlgoRoundRobin, Enabled: true,
+			Proxies: []database.ForwardProxyEntry{{URL: "http://tok-proxy:3128"}},
+			Rules:   []database.ForwardProxyRule{{Type: database.ForwardProxyRuleToken, Value: "tok-1"}},
+		},
+	)
+
+	r := httptest.NewRequest(http.MethodGet, "https://api.github.com/", nil)
+	r = PrepareForwardProxyInfo(r, "10.0.0.1")
+	SetForwardProxyIdentity(r, "tok-1", "", "proxy")
+	team, _ := url.Parse("http://team-proxy:3128")
+	SetForwardProxyClientChoice(r, team)
+
+	out, _ := http.NewRequestWithContext(r.Context(), http.MethodGet, "https://api.github.com/user", nil)
+	u, err := fr.ProxyFunc()(out)
+	if err != nil || u == nil || u.Host != "team-proxy:3128" {
+		t.Fatalf("ProxyFunc(client choice) = (%v, %v), want team-proxy:3128 over token ruleset", u, err)
+	}
+}

--- a/internal/proxy/forwardproxy_test.go
+++ b/internal/proxy/forwardproxy_test.go
@@ -340,3 +340,60 @@ func TestForwardProxyRouter_ControlTransportAndContext(t *testing.T) {
 		t.Fatalf("ProxyFunc(control ctx) = (%v, %v), want control-proxy:3128", u, err)
 	}
 }
+
+func TestForwardProxyRouter_NonGitHubControlDirectByDefault(t *testing.T) {
+	// No rules at all → direct.
+	empty := reloadedRouter(t)
+	req := httptest.NewRequest(http.MethodHead, "https://mirror.internal/org/repo/releases/download/v1/a.tgz", nil)
+	if u, err := empty.nonGitHubControlProxy(req); err != nil || u != nil {
+		t.Fatalf("nonGitHubControlProxy(no rules) = (%v, %v), want direct (nil, nil)", u, err)
+	}
+
+	// Control rule without include_non_github → still direct, even though
+	// GitHub-destined control traffic is routed.
+	fr := reloadedRouter(t,
+		&database.ForwardProxyRuleset{
+			Name: "control-rs", Algorithm: database.ForwardProxyAlgoRoundRobin, Enabled: true,
+			Proxies: []database.ForwardProxyEntry{{URL: "http://control-proxy:3128"}},
+			Rules:   []database.ForwardProxyRule{{Type: database.ForwardProxyRuleControl}},
+		},
+	)
+	if u, err := fr.nonGitHubControlProxy(req); err != nil || u != nil {
+		t.Fatalf("nonGitHubControlProxy(control without flag) = (%v, %v), want direct", u, err)
+	}
+	if u, _, _ := fr.SelectControl(); u == nil || u.Host != "control-proxy:3128" {
+		t.Fatalf("SelectControl() = %v, want control-proxy (GitHub-destined control still routed)", u)
+	}
+
+	// System rule alone never captures non-GitHub control calls.
+	sys := reloadedRouter(t,
+		&database.ForwardProxyRuleset{
+			Name: "sys-rs", Algorithm: database.ForwardProxyAlgoRoundRobin, Enabled: true,
+			Proxies: []database.ForwardProxyEntry{{URL: "http://sys-proxy:3128"}},
+			Rules:   []database.ForwardProxyRule{{Type: database.ForwardProxyRuleSystem}},
+		},
+	)
+	if u, err := sys.nonGitHubControlProxy(req); err != nil || u != nil {
+		t.Fatalf("nonGitHubControlProxy(system only) = (%v, %v), want direct", u, err)
+	}
+}
+
+func TestForwardProxyRouter_NonGitHubControlOptIn(t *testing.T) {
+	fr := reloadedRouter(t,
+		&database.ForwardProxyRuleset{
+			Name: "control-rs", Algorithm: database.ForwardProxyAlgoRoundRobin, Enabled: true,
+			Proxies: []database.ForwardProxyEntry{{URL: "http://control-proxy:3128"}},
+			Rules:   []database.ForwardProxyRule{{Type: database.ForwardProxyRuleControl, IncludeNonGitHub: true}},
+		},
+	)
+	req := httptest.NewRequest(http.MethodHead, "https://mirror.internal/org/repo/releases/download/v1/a.tgz", nil)
+	if u, err := fr.nonGitHubControlProxy(req); err != nil || u == nil || u.Host != "control-proxy:3128" {
+		t.Fatalf("nonGitHubControlProxy(opt-in) = (%v, %v), want control-proxy:3128", u, err)
+	}
+
+	// The transport constructor wires the same behaviour.
+	nt := NewForwardProxyNonGitHubControlTransport(fr)
+	if u, err := nt.Proxy(req); err != nil || u == nil || u.Host != "control-proxy:3128" {
+		t.Fatalf("non-GitHub control transport Proxy() = (%v, %v), want control-proxy:3128", u, err)
+	}
+}

--- a/internal/proxy/forwardproxy_test.go
+++ b/internal/proxy/forwardproxy_test.go
@@ -267,3 +267,76 @@ func TestForwardProxyRouter_ReloadSwapsTable(t *testing.T) {
 		t.Fatalf("Select after swap = (%v, %q), want ambient", u, layer)
 	}
 }
+
+func TestForwardProxyRouter_ControlLayer(t *testing.T) {
+	fr := reloadedRouter(t,
+		&database.ForwardProxyRuleset{
+			Name: "control-rs", Algorithm: database.ForwardProxyAlgoRoundRobin, Enabled: true,
+			Proxies: []database.ForwardProxyEntry{{URL: "http://control-proxy:3128"}},
+			Rules:   []database.ForwardProxyRule{{Type: database.ForwardProxyRuleControl}},
+		},
+		&database.ForwardProxyRuleset{
+			Name: "sys-rs", Algorithm: database.ForwardProxyAlgoRoundRobin, Enabled: true,
+			Proxies: []database.ForwardProxyEntry{{URL: "http://sys-proxy:3128"}},
+			Rules:   []database.ForwardProxyRule{{Type: database.ForwardProxyRuleSystem}},
+		},
+	)
+
+	// Control traffic uses the control rule ahead of system.
+	u, ruleset, layer := fr.SelectControl()
+	if u == nil || u.Host != "control-proxy:3128" || layer != ForwardProxyLayerControl || ruleset != "control-rs" {
+		t.Fatalf("SelectControl() = (%v, %q, %q), want control-proxy via control layer", u, ruleset, layer)
+	}
+
+	// Regular traffic never matches the control rule.
+	if u, _, layer := fr.Select("10.0.0.1", "", ""); u == nil || u.Host != "sys-proxy:3128" || layer != ForwardProxyLayerSystem {
+		t.Fatalf("Select() = (%v, %q), want sys-proxy via system layer", u, layer)
+	}
+}
+
+func TestForwardProxyRouter_ControlFallsBackToSystem(t *testing.T) {
+	fr := reloadedRouter(t,
+		&database.ForwardProxyRuleset{
+			Name: "sys-rs", Algorithm: database.ForwardProxyAlgoRoundRobin, Enabled: true,
+			Proxies: []database.ForwardProxyEntry{{URL: "http://sys-proxy:3128"}},
+			Rules:   []database.ForwardProxyRule{{Type: database.ForwardProxyRuleSystem}},
+		},
+	)
+	if u, _, layer := fr.SelectControl(); u == nil || u.Host != "sys-proxy:3128" || layer != ForwardProxyLayerSystem {
+		t.Fatalf("SelectControl() = (%v, %q), want system fallback", u, layer)
+	}
+
+	empty := reloadedRouter(t)
+	if u, _, layer := empty.SelectControl(); u != nil || layer != ForwardProxyLayerAmbient {
+		t.Fatalf("SelectControl() on empty table = (%v, %q), want ambient", u, layer)
+	}
+}
+
+func TestForwardProxyRouter_ControlTransportAndContext(t *testing.T) {
+	fr := reloadedRouter(t,
+		&database.ForwardProxyRuleset{
+			Name: "control-rs", Algorithm: database.ForwardProxyAlgoRoundRobin, Enabled: true,
+			Proxies: []database.ForwardProxyEntry{{URL: "http://control-proxy:3128"}},
+			Rules:   []database.ForwardProxyRule{{Type: database.ForwardProxyRuleControl}},
+		},
+	)
+	fr.ambient = func(*http.Request) (*url.URL, error) { return nil, nil }
+
+	// The dedicated control transport routes without any context marker.
+	ct := NewForwardProxyControlTransport(fr)
+	bare := httptest.NewRequest(http.MethodGet, "https://api.github.com/app/installations", nil)
+	if u, err := ct.Proxy(bare); err != nil || u == nil || u.Host != "control-proxy:3128" {
+		t.Fatalf("control transport Proxy() = (%v, %v), want control-proxy:3128", u, err)
+	}
+
+	// WithForwardProxyControl overrides request-derived route info on the
+	// shared transport (e.g. OAuth refresh inside a proxied request).
+	r := httptest.NewRequest(http.MethodGet, "https://api.github.com/", nil)
+	r = PrepareForwardProxyInfo(r, "10.0.0.1")
+	SetForwardProxyIdentity(r, "tok-1", "", "proxy")
+	ctlCtx := WithForwardProxyControl(r.Context())
+	out, _ := http.NewRequestWithContext(ctlCtx, http.MethodPost, "https://github.com/login/oauth/access_token", nil)
+	if u, err := fr.ProxyFunc()(out); err != nil || u == nil || u.Host != "control-proxy:3128" {
+		t.Fatalf("ProxyFunc(control ctx) = (%v, %v), want control-proxy:3128", u, err)
+	}
+}

--- a/internal/proxy/forwardproxy_test.go
+++ b/internal/proxy/forwardproxy_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"testing"
+	"time"
 
 	"github.com/goodtune/ghp/internal/database"
 )
@@ -499,4 +500,76 @@ func TestForwardProxyRouter_ClientChoiceBeatsRulesets(t *testing.T) {
 	if err != nil || u == nil || u.Host != "team-proxy:3128" {
 		t.Fatalf("ProxyFunc(client choice) = (%v, %v), want team-proxy:3128 over token ruleset", u, err)
 	}
+}
+
+func TestForwardProxyRouter_ClientChoiceRequiresToken(t *testing.T) {
+	fr := reloadedRouter(t,
+		&database.ForwardProxyRuleset{
+			Name: "sys-rs", Algorithm: database.ForwardProxyAlgoRoundRobin, Enabled: true,
+			Proxies: []database.ForwardProxyEntry{{URL: "http://sys-proxy:3128"}},
+			Rules:   []database.ForwardProxyRule{{Type: database.ForwardProxyRuleSystem}},
+		},
+	)
+
+	// Client proxy present but no resolved token: the header must be
+	// ignored (anti-SSRF gate) and normal ruleset selection applies.
+	r := httptest.NewRequest(http.MethodGet, "https://api.github.com/", nil)
+	r = PrepareForwardProxyInfo(r, "10.0.0.1")
+	team, _ := url.Parse("http://team-proxy:3128")
+	SetForwardProxyClientChoice(r, team)
+
+	out, _ := http.NewRequestWithContext(r.Context(), http.MethodGet, "https://api.github.com/user", nil)
+	u, err := fr.ProxyFunc()(out)
+	if err != nil || u == nil || u.Host != "sys-proxy:3128" {
+		t.Fatalf("ProxyFunc(unauthenticated client choice) = (%v, %v), want sys-proxy:3128 (header ignored)", u, err)
+	}
+}
+
+func TestForwardProxyRouter_IPv6NetRule(t *testing.T) {
+	fr := reloadedRouter(t,
+		&database.ForwardProxyRuleset{
+			Name: "v6", Algorithm: database.ForwardProxyAlgoRoundRobin, Enabled: true,
+			Proxies: []database.ForwardProxyEntry{{URL: "http://v6-proxy:3128"}},
+			Rules:   []database.ForwardProxyRule{{Type: database.ForwardProxyRuleNet, Value: "2001:db8::/32"}},
+		},
+	)
+
+	if u, _, layer := fr.Select("2001:db8::1", "", ""); u == nil || u.Host != "v6-proxy:3128" || layer != ForwardProxyLayerNet {
+		t.Fatalf("Select(v6 in range) = (%v, %q), want v6-proxy via net", u, layer)
+	}
+	if u, _, layer := fr.Select("2001:db9::1", "", ""); u != nil || layer != ForwardProxyLayerAmbient {
+		t.Fatalf("Select(v6 out of range) = (%v, %q), want ambient", u, layer)
+	}
+}
+
+func TestForwardProxyRouter_StartRefresh(t *testing.T) {
+	store := &fpStore{}
+	fr := NewForwardProxyRouter(store, nil)
+	if err := fr.Reload(context.Background()); err != nil {
+		t.Fatalf("Reload: %v", err)
+	}
+	if u, _, _ := fr.Select("", "", ""); u != nil {
+		t.Fatalf("expected empty table before refresh, got %v", u)
+	}
+
+	// Populate the store after the initial load; the periodic refresh must
+	// pick it up without an explicit Reload call.
+	store.rulesets = []*database.ForwardProxyRuleset{{
+		Name: "sys", Algorithm: database.ForwardProxyAlgoRoundRobin, Enabled: true,
+		Proxies: []database.ForwardProxyEntry{{URL: "http://sys-proxy:3128"}},
+		Rules:   []database.ForwardProxyRule{{Type: database.ForwardProxyRuleSystem}},
+	}}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	fr.StartRefresh(ctx, 5*time.Millisecond)
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if u, _, _ := fr.Select("", "", ""); u != nil && u.Host == "sys-proxy:3128" {
+			return // refresh applied
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatal("periodic refresh never applied the new ruleset")
 }

--- a/internal/proxy/passthrough.go
+++ b/internal/proxy/passthrough.go
@@ -241,6 +241,16 @@ func NewScopedPassthroughHandler(inner http.Handler, enforcer ScopeEnforcer, res
 
 		tokenType := pt.TokenType
 
+		// Record the resolved token identity for forward proxy routing: the
+		// reverse proxy clones this request (context included), so the
+		// transport's per-request proxy selection can match token- and
+		// app-bound rulesets.
+		ptAppID := ""
+		if pt.AppID != nil {
+			ptAppID = *pt.AppID
+		}
+		SetForwardProxyIdentity(r, pt.ID, ptAppID, tokenType)
+
 		// Inject the token creator's user ID for auditing. The actual GitHub
 		// username is resolved later via the GraphQL viewer endpoint, after the
 		// real GitHub token is obtained — giving the authenticated identity

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -151,6 +151,14 @@ func NewHandler(cfg *config.Config, ts *token.Service, store database.Store, enc
 	}
 }
 
+// SetTransport sets the transport used for upstream GitHub requests (and the
+// OAuth token refresh endpoint). The server installs the forward proxy
+// router's transport here so ruleset-based egress selection applies to API
+// proxy traffic.
+func (h *Handler) SetTransport(rt http.RoundTripper) {
+	h.client.Transport = rt
+}
+
 // ServeHTTP handles proxied requests.
 func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	start := time.Now()
@@ -234,6 +242,15 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	tokenType := pt.TokenType
+
+	// Record the resolved token identity for forward proxy routing: outbound
+	// requests inherit this context, so the transport's per-request proxy
+	// selection can match token- and app-bound rulesets.
+	tokenAppID := ""
+	if pt.AppID != nil {
+		tokenAppID = *pt.AppID
+	}
+	SetForwardProxyIdentity(r, pt.ID, tokenAppID, tokenType)
 
 	// Inject the token creator's user ID into the request context for auditing.
 	// Username resolution happens later, after the real GitHub token is obtained,

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -715,6 +715,10 @@ type tokenRefreshResponse struct {
 // GitHub's OAuth token endpoint. On success it persists the new encrypted
 // tokens and returns the new plaintext access token.
 func (h *Handler) refreshGitHubToken(ctx context.Context, gt *database.GitHubToken) (string, error) {
+	// Token refresh is ghp control traffic: route it via the control layer
+	// rather than inheriting the triggering request's token/app/net routing.
+	ctx = WithForwardProxyControl(ctx)
+
 	refreshPlaintext, err := h.encryptor.Decrypt(gt.RefreshToken)
 	if err != nil {
 		return "", fmt.Errorf("decrypting refresh token: %w", err)

--- a/internal/proxy/releases.go
+++ b/internal/proxy/releases.go
@@ -169,7 +169,10 @@ func (c *netrcCreds) setBasicAuth(req *http.Request) {
 // Any other mode value or an empty mode passes all requests through to inner
 // unchanged. The allow list check is always performed before applying the
 // policy, so explicitly listed orgs and repos are never affected.
-func NewReleasesHandler(inner http.Handler, cfg *config.Config, logger *slog.Logger) http.Handler {
+// The optional transport parameter overrides the HEAD-check probe client's
+// transport (e.g. the forward proxy control transport, so probes follow the
+// control-layer egress routing); pass none to use the default transport.
+func NewReleasesHandler(inner http.Handler, cfg *config.Config, logger *slog.Logger, transport ...http.RoundTripper) http.Handler {
 	var creds *netrcCreds
 	if cfg.Releases.RedirectHeadCheckNetrc != "" {
 		var err error
@@ -181,7 +184,13 @@ func NewReleasesHandler(inner http.Handler, cfg *config.Config, logger *slog.Log
 			}
 		}
 	}
-	return NewReleasesHandlerWithClient(inner, cfg, logger, headCheckClient, creds)
+	client := headCheckClient
+	if len(transport) > 0 && transport[0] != nil {
+		c := *headCheckClient
+		c.Transport = transport[0]
+		client = &c
+	}
+	return NewReleasesHandlerWithClient(inner, cfg, logger, client, creds)
 }
 
 // NewReleasesHandlerWithClient is like NewReleasesHandler but accepts a custom

--- a/internal/proxy/releases.go
+++ b/internal/proxy/releases.go
@@ -170,8 +170,9 @@ func (c *netrcCreds) setBasicAuth(req *http.Request) {
 // unchanged. The allow list check is always performed before applying the
 // policy, so explicitly listed orgs and repos are never affected.
 // The optional transport parameter overrides the HEAD-check probe client's
-// transport (e.g. the forward proxy control transport, so probes follow the
-// control-layer egress routing); pass none to use the default transport.
+// transport (the server passes the non-GitHub control transport, which sends
+// probes direct unless a control rule sets include_non_github); pass none to
+// use the default transport.
 func NewReleasesHandler(inner http.Handler, cfg *config.Config, logger *slog.Logger, transport ...http.RoundTripper) http.Handler {
 	var creds *netrcCreds
 	if cfg.Releases.RedirectHeadCheckNetrc != "" {

--- a/internal/proxy/username.go
+++ b/internal/proxy/username.go
@@ -87,6 +87,13 @@ func NewUsernameResolver(store database.Store, logger *slog.Logger, opts ...func
 	return r
 }
 
+// SetTransport sets the transport used for GraphQL viewer lookups. The server
+// installs the forward proxy control transport here so username resolution —
+// ghp control traffic — follows the control-layer egress routing.
+func (u *UsernameResolver) SetTransport(rt http.RoundTripper) {
+	u.httpClient.Transport = rt
+}
+
 // WithGraphQLURL returns an option that overrides the GitHub GraphQL endpoint
 // URL. This is primarily intended for testing with mock servers.
 func WithGraphQLURL(url string) func(*UsernameResolver) {

--- a/internal/server/api.go
+++ b/internal/server/api.go
@@ -97,6 +97,7 @@ type API struct {
 	logger             *slog.Logger
 	httpClient         *http.Client // used for outbound GitHub API calls
 	auditLog           *auditLogWriter
+	forwardProxyRouter *proxy.ForwardProxyRouter // nil when ruleset routing is not wired (tests)
 
 	tokenCreateLimiter *auth.IPRateLimiter // POST /api/tokens
 }
@@ -122,6 +123,12 @@ func NewAPI(ctx context.Context, cfg *config.Config, store database.Store, ts *t
 		auditLog:           aw,
 		tokenCreateLimiter: auth.NewIPRateLimiter(20, time.Minute, "/api/tokens", netutil.IPHeader(cfg.Server.ClientIPHeader), logger),
 	}
+}
+
+// SetForwardProxyRouter wires the forward proxy router so ruleset mutations
+// via the admin API rebuild the route table immediately.
+func (a *API) SetForwardProxyRouter(fr *proxy.ForwardProxyRouter) {
+	a.forwardProxyRouter = fr
 }
 
 // RegisterRoutes adds API routes to the given mux.
@@ -151,6 +158,13 @@ func (a *API) RegisterRoutes(mux *http.ServeMux) {
 	mux.Handle("GET /api/apps/{id}/installations/{iid}/repositories", a.authHandler.RequireAdmin(http.HandlerFunc(a.handleListAppInstallationRepos)))
 
 	// Cached repository management routes.
+	// Forward proxy rulesets (admin, runtime egress routing).
+	mux.Handle("GET /api/forward-proxy-rulesets", a.authHandler.RequireAdmin(http.HandlerFunc(a.handleListForwardProxyRulesets)))
+	mux.Handle("POST /api/forward-proxy-rulesets", a.authHandler.RequireAdmin(http.HandlerFunc(a.handleCreateForwardProxyRuleset)))
+	mux.Handle("GET /api/forward-proxy-rulesets/{id}", a.authHandler.RequireAdmin(http.HandlerFunc(a.handleGetForwardProxyRuleset)))
+	mux.Handle("PATCH /api/forward-proxy-rulesets/{id}", a.authHandler.RequireAdmin(http.HandlerFunc(a.handleUpdateForwardProxyRuleset)))
+	mux.Handle("DELETE /api/forward-proxy-rulesets/{id}", a.authHandler.RequireAdmin(http.HandlerFunc(a.handleDeleteForwardProxyRuleset)))
+
 	mux.Handle("GET /api/cached-repos", a.authHandler.RequireAdmin(http.HandlerFunc(a.handleListCachedRepos)))
 	mux.Handle("POST /api/cached-repos", a.authHandler.RequireAdmin(http.HandlerFunc(a.handleCreateCachedRepo)))
 	mux.Handle("GET /api/cached-repos/{id}", a.authHandler.RequireAdmin(http.HandlerFunc(a.handleGetCachedRepo)))

--- a/internal/server/forwardproxy_api.go
+++ b/internal/server/forwardproxy_api.go
@@ -135,9 +135,9 @@ func validateForwardProxyRules(rules []database.ForwardProxyRule) error {
 	}
 	for i, rule := range rules {
 		switch rule.Type {
-		case database.ForwardProxyRuleSystem:
+		case database.ForwardProxyRuleSystem, database.ForwardProxyRuleControl:
 			if rule.Value != "" {
-				return fmt.Errorf("rules[%d]: system rules must not carry a value", i)
+				return fmt.Errorf("rules[%d]: %s rules must not carry a value", i, rule.Type)
 			}
 		case database.ForwardProxyRuleApp:
 			if !isValidUUID(rule.Value) {
@@ -152,7 +152,7 @@ func validateForwardProxyRules(rules []database.ForwardProxyRule) error {
 				return fmt.Errorf("rules[%d]: net rules require a valid CIDR (e.g. 10.0.0.0/16)", i)
 			}
 		default:
-			return fmt.Errorf("rules[%d]: type must be one of system, app, token, net", i)
+			return fmt.Errorf("rules[%d]: type must be one of system, app, token, net, control", i)
 		}
 	}
 	return nil

--- a/internal/server/forwardproxy_api.go
+++ b/internal/server/forwardproxy_api.go
@@ -285,12 +285,12 @@ func (a *API) handleGetForwardProxyRuleset(w http.ResponseWriter, r *http.Reques
 	}
 	rs, err := a.store.GetForwardProxyRulesetByID(r.Context(), id)
 	if err != nil {
+		if errors.Is(err, database.ErrNotFound) {
+			writeJSON(w, http.StatusNotFound, map[string]string{"message": "Forward proxy ruleset not found"})
+			return
+		}
 		a.logger.Error("failed to get forward proxy ruleset", "error", err)
 		writeJSON(w, http.StatusInternalServerError, map[string]string{"message": "Internal error"})
-		return
-	}
-	if rs == nil {
-		writeJSON(w, http.StatusNotFound, map[string]string{"message": "Forward proxy ruleset not found"})
 		return
 	}
 	writeJSON(w, http.StatusOK, forwardProxyRulesetToResponse(rs))
@@ -326,12 +326,12 @@ func (a *API) handleUpdateForwardProxyRuleset(w http.ResponseWriter, r *http.Req
 
 	existing, err := a.store.GetForwardProxyRulesetByID(r.Context(), id)
 	if err != nil {
+		if errors.Is(err, database.ErrNotFound) {
+			writeJSON(w, http.StatusNotFound, map[string]string{"message": "Forward proxy ruleset not found"})
+			return
+		}
 		a.logger.Error("failed to get forward proxy ruleset", "error", err)
 		writeJSON(w, http.StatusInternalServerError, map[string]string{"message": "Internal error"})
-		return
-	}
-	if existing == nil {
-		writeJSON(w, http.StatusNotFound, map[string]string{"message": "Forward proxy ruleset not found"})
 		return
 	}
 

--- a/internal/server/forwardproxy_api.go
+++ b/internal/server/forwardproxy_api.go
@@ -1,0 +1,421 @@
+package server
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"net/url"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/goodtune/ghp/internal/auth"
+	"github.com/goodtune/ghp/internal/database"
+)
+
+// Bounds for forward proxy ruleset inputs. Rulesets are admin-managed, so the
+// limits are generous; they exist to keep route table compilation and the
+// JSON columns bounded.
+const (
+	maxForwardProxyNameLength        = 128
+	maxForwardProxyDescriptionLength = 1024
+	maxForwardProxyTargets           = 32
+	maxForwardProxyRules             = 128
+	maxForwardProxyWeight            = 10000
+)
+
+// forwardProxyNameRe restricts ruleset names to path- and label-safe
+// characters: the name is used as a Prometheus label value and as a Vault KV
+// path segment.
+var forwardProxyNameRe = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9._-]*$`)
+
+type forwardProxyRulesetResponse struct {
+	ID          string                       `json:"id"`
+	Name        string                       `json:"name"`
+	Description string                       `json:"description"`
+	Algorithm   string                       `json:"algorithm"`
+	Proxies     []database.ForwardProxyEntry `json:"proxies"`
+	Rules       []database.ForwardProxyRule  `json:"rules"`
+	Enabled     bool                         `json:"enabled"`
+	CreatedAt   string                       `json:"created_at"`
+	UpdatedAt   string                       `json:"updated_at"`
+}
+
+func forwardProxyRulesetToResponse(rs *database.ForwardProxyRuleset) forwardProxyRulesetResponse {
+	proxies := rs.Proxies
+	if proxies == nil {
+		proxies = make([]database.ForwardProxyEntry, 0)
+	}
+	rules := rs.Rules
+	if rules == nil {
+		rules = make([]database.ForwardProxyRule, 0)
+	}
+	return forwardProxyRulesetResponse{
+		ID:          rs.ID,
+		Name:        rs.Name,
+		Description: rs.Description,
+		Algorithm:   rs.Algorithm,
+		Proxies:     proxies,
+		Rules:       rules,
+		Enabled:     rs.Enabled,
+		CreatedAt:   rs.CreatedAt.Format(time.RFC3339),
+		UpdatedAt:   rs.UpdatedAt.Format(time.RFC3339),
+	}
+}
+
+func validForwardProxyAlgorithm(algo string) bool {
+	switch algo {
+	case database.ForwardProxyAlgoRoundRobin, database.ForwardProxyAlgoWeighted, database.ForwardProxyAlgoSticky:
+		return true
+	}
+	return false
+}
+
+// validateForwardProxyName checks ruleset name syntax and length.
+func validateForwardProxyName(name string) error {
+	if name == "" {
+		return fmt.Errorf("name is required")
+	}
+	if len(name) > maxForwardProxyNameLength {
+		return fmt.Errorf("name must be at most %d characters", maxForwardProxyNameLength)
+	}
+	if !forwardProxyNameRe.MatchString(name) {
+		return fmt.Errorf("name may only contain alphanumerics, dots, hyphens, and underscores, and must start with an alphanumeric")
+	}
+	return nil
+}
+
+// validateForwardProxyEntries validates the proxy target list and normalizes
+// omitted weights to 1 in place.
+func validateForwardProxyEntries(entries []database.ForwardProxyEntry) error {
+	if len(entries) == 0 {
+		return fmt.Errorf("at least one proxy target is required")
+	}
+	if len(entries) > maxForwardProxyTargets {
+		return fmt.Errorf("at most %d proxy targets are allowed", maxForwardProxyTargets)
+	}
+	for i := range entries {
+		e := &entries[i]
+		u, err := url.Parse(e.URL)
+		if err != nil {
+			return fmt.Errorf("proxies[%d]: malformed URL", i)
+		}
+		switch u.Scheme {
+		case "http", "https", "socks5", "socks5h":
+		default:
+			return fmt.Errorf("proxies[%d]: scheme must be http, https, socks5, or socks5h", i)
+		}
+		if u.Host == "" {
+			return fmt.Errorf("proxies[%d]: host is required", i)
+		}
+		if u.RawQuery != "" || u.Fragment != "" {
+			return fmt.Errorf("proxies[%d]: query string and fragment are not allowed", i)
+		}
+		if e.Weight < 0 {
+			return fmt.Errorf("proxies[%d]: weight must not be negative", i)
+		}
+		if e.Weight == 0 {
+			e.Weight = 1
+		}
+		if e.Weight > maxForwardProxyWeight {
+			return fmt.Errorf("proxies[%d]: weight must be at most %d", i, maxForwardProxyWeight)
+		}
+	}
+	return nil
+}
+
+// validateForwardProxyRules validates the rule list: rule types must be
+// known, app/token values must be well-formed UUIDs, net values must be valid
+// CIDRs, and system rules must carry no value.
+func validateForwardProxyRules(rules []database.ForwardProxyRule) error {
+	if len(rules) > maxForwardProxyRules {
+		return fmt.Errorf("at most %d rules are allowed", maxForwardProxyRules)
+	}
+	for i, rule := range rules {
+		switch rule.Type {
+		case database.ForwardProxyRuleSystem:
+			if rule.Value != "" {
+				return fmt.Errorf("rules[%d]: system rules must not carry a value", i)
+			}
+		case database.ForwardProxyRuleApp:
+			if !isValidUUID(rule.Value) {
+				return fmt.Errorf("rules[%d]: app rules require a valid app record UUID", i)
+			}
+		case database.ForwardProxyRuleToken:
+			if !isValidUUID(rule.Value) {
+				return fmt.Errorf("rules[%d]: token rules require a valid token UUID", i)
+			}
+		case database.ForwardProxyRuleNet:
+			if _, _, err := net.ParseCIDR(rule.Value); err != nil {
+				return fmt.Errorf("rules[%d]: net rules require a valid CIDR (e.g. 10.0.0.0/16)", i)
+			}
+		default:
+			return fmt.Errorf("rules[%d]: type must be one of system, app, token, net", i)
+		}
+	}
+	return nil
+}
+
+// reloadForwardProxyRouter rebuilds the router's route table after a ruleset
+// mutation so changes take effect immediately on this instance. Failures are
+// logged but not surfaced to the API caller: the mutation is already
+// persisted, and the periodic refresh will converge the route table.
+func (a *API) reloadForwardProxyRouter(r *http.Request) {
+	if a.forwardProxyRouter == nil {
+		return
+	}
+	if err := a.forwardProxyRouter.Reload(r.Context()); err != nil {
+		a.logger.Error("forward proxy router reload failed after mutation", "error", err)
+	}
+}
+
+func (a *API) handleListForwardProxyRulesets(w http.ResponseWriter, r *http.Request) {
+	rulesets, err := a.store.ListForwardProxyRulesets(r.Context())
+	if err != nil {
+		a.logger.Error("failed to list forward proxy rulesets", "error", err)
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"message": "Internal error"})
+		return
+	}
+	result := make([]forwardProxyRulesetResponse, 0, len(rulesets))
+	for _, rs := range rulesets {
+		result = append(result, forwardProxyRulesetToResponse(rs))
+	}
+	writeJSON(w, http.StatusOK, result)
+}
+
+type createForwardProxyRulesetRequest struct {
+	Name        string                       `json:"name"`
+	Description string                       `json:"description"`
+	Algorithm   string                       `json:"algorithm"`
+	Proxies     []database.ForwardProxyEntry `json:"proxies"`
+	Rules       []database.ForwardProxyRule  `json:"rules"`
+	Enabled     *bool                        `json:"enabled"`
+}
+
+func (a *API) handleCreateForwardProxyRuleset(w http.ResponseWriter, r *http.Request) {
+	r.Body = http.MaxBytesReader(w, r.Body, maxRequestBodySize)
+	var req createForwardProxyRulesetRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		var maxErr *http.MaxBytesError
+		if errors.As(err, &maxErr) {
+			writeJSON(w, http.StatusRequestEntityTooLarge, map[string]string{"message": "Request body too large"})
+		} else {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"message": "Invalid request body"})
+		}
+		return
+	}
+
+	if err := validateForwardProxyName(req.Name); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"message": err.Error()})
+		return
+	}
+	if len(req.Description) > maxForwardProxyDescriptionLength {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"message": fmt.Sprintf("description must be at most %d characters", maxForwardProxyDescriptionLength)})
+		return
+	}
+	if !validForwardProxyAlgorithm(req.Algorithm) {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"message": "algorithm must be one of round_robin, weighted, sticky"})
+		return
+	}
+	if err := validateForwardProxyEntries(req.Proxies); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"message": err.Error()})
+		return
+	}
+	if err := validateForwardProxyRules(req.Rules); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"message": err.Error()})
+		return
+	}
+
+	// Check for duplicate names up front for a clean 409.
+	existing, err := a.store.GetForwardProxyRulesetByName(r.Context(), req.Name)
+	if err != nil {
+		a.logger.Error("failed to check forward proxy ruleset name", "error", err)
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"message": "Internal error"})
+		return
+	}
+	if existing != nil {
+		writeJSON(w, http.StatusConflict, map[string]string{"message": "A forward proxy ruleset with this name already exists"})
+		return
+	}
+
+	enabled := true
+	if req.Enabled != nil {
+		enabled = *req.Enabled
+	}
+	if req.Rules == nil {
+		req.Rules = make([]database.ForwardProxyRule, 0)
+	}
+
+	rs := &database.ForwardProxyRuleset{
+		Name:        req.Name,
+		Description: req.Description,
+		Algorithm:   req.Algorithm,
+		Proxies:     req.Proxies,
+		Rules:       req.Rules,
+		Enabled:     enabled,
+	}
+	if err := a.store.CreateForwardProxyRuleset(r.Context(), rs); err != nil {
+		// Handle race condition: concurrent create may hit the unique constraint.
+		if strings.Contains(err.Error(), "UNIQUE constraint") || strings.Contains(err.Error(), "duplicate key") || strings.Contains(err.Error(), "already exists") {
+			writeJSON(w, http.StatusConflict, map[string]string{"message": "A forward proxy ruleset with this name already exists"})
+			return
+		}
+		a.logger.Error("failed to create forward proxy ruleset", "error", err)
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"message": "Failed to create forward proxy ruleset"})
+		return
+	}
+
+	session := auth.SessionFromContext(r.Context())
+	a.logger.Info("forward_proxy_ruleset_created", "user", session.Username, "ruleset", rs.Name, "ruleset_id", rs.ID)
+	a.reloadForwardProxyRouter(r)
+
+	writeJSON(w, http.StatusCreated, forwardProxyRulesetToResponse(rs))
+}
+
+func (a *API) handleGetForwardProxyRuleset(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	if !isValidUUID(id) {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"message": "Invalid forward proxy ruleset ID format"})
+		return
+	}
+	rs, err := a.store.GetForwardProxyRulesetByID(r.Context(), id)
+	if err != nil {
+		a.logger.Error("failed to get forward proxy ruleset", "error", err)
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"message": "Internal error"})
+		return
+	}
+	if rs == nil {
+		writeJSON(w, http.StatusNotFound, map[string]string{"message": "Forward proxy ruleset not found"})
+		return
+	}
+	writeJSON(w, http.StatusOK, forwardProxyRulesetToResponse(rs))
+}
+
+type updateForwardProxyRulesetRequest struct {
+	Name        *string                       `json:"name"`
+	Description *string                       `json:"description"`
+	Algorithm   *string                       `json:"algorithm"`
+	Proxies     *[]database.ForwardProxyEntry `json:"proxies"`
+	Rules       *[]database.ForwardProxyRule  `json:"rules"`
+	Enabled     *bool                         `json:"enabled"`
+}
+
+func (a *API) handleUpdateForwardProxyRuleset(w http.ResponseWriter, r *http.Request) {
+	r.Body = http.MaxBytesReader(w, r.Body, maxRequestBodySize)
+	var req updateForwardProxyRulesetRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		var maxErr *http.MaxBytesError
+		if errors.As(err, &maxErr) {
+			writeJSON(w, http.StatusRequestEntityTooLarge, map[string]string{"message": "Request body too large"})
+		} else {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"message": "Invalid request body"})
+		}
+		return
+	}
+
+	id := r.PathValue("id")
+	if !isValidUUID(id) {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"message": "Invalid forward proxy ruleset ID format"})
+		return
+	}
+
+	existing, err := a.store.GetForwardProxyRulesetByID(r.Context(), id)
+	if err != nil {
+		a.logger.Error("failed to get forward proxy ruleset", "error", err)
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"message": "Internal error"})
+		return
+	}
+	if existing == nil {
+		writeJSON(w, http.StatusNotFound, map[string]string{"message": "Forward proxy ruleset not found"})
+		return
+	}
+
+	if req.Name != nil && *req.Name != existing.Name {
+		if err := validateForwardProxyName(*req.Name); err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"message": err.Error()})
+			return
+		}
+		conflicting, err := a.store.GetForwardProxyRulesetByName(r.Context(), *req.Name)
+		if err != nil {
+			a.logger.Error("failed to check forward proxy ruleset name", "error", err)
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"message": "Internal error"})
+			return
+		}
+		if conflicting != nil {
+			writeJSON(w, http.StatusConflict, map[string]string{"message": "A forward proxy ruleset with this name already exists"})
+			return
+		}
+		existing.Name = *req.Name
+	}
+	if req.Description != nil {
+		if len(*req.Description) > maxForwardProxyDescriptionLength {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"message": fmt.Sprintf("description must be at most %d characters", maxForwardProxyDescriptionLength)})
+			return
+		}
+		existing.Description = *req.Description
+	}
+	if req.Algorithm != nil {
+		if !validForwardProxyAlgorithm(*req.Algorithm) {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"message": "algorithm must be one of round_robin, weighted, sticky"})
+			return
+		}
+		existing.Algorithm = *req.Algorithm
+	}
+	if req.Proxies != nil {
+		if err := validateForwardProxyEntries(*req.Proxies); err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"message": err.Error()})
+			return
+		}
+		existing.Proxies = *req.Proxies
+	}
+	if req.Rules != nil {
+		if err := validateForwardProxyRules(*req.Rules); err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"message": err.Error()})
+			return
+		}
+		existing.Rules = *req.Rules
+	}
+	if req.Enabled != nil {
+		existing.Enabled = *req.Enabled
+	}
+
+	if err := a.store.UpdateForwardProxyRuleset(r.Context(), existing); err != nil {
+		if strings.Contains(err.Error(), "UNIQUE constraint") || strings.Contains(err.Error(), "duplicate key") || strings.Contains(err.Error(), "already exists") {
+			writeJSON(w, http.StatusConflict, map[string]string{"message": "A forward proxy ruleset with this name already exists"})
+			return
+		}
+		a.logger.Error("failed to update forward proxy ruleset", "error", err)
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"message": "Failed to update forward proxy ruleset"})
+		return
+	}
+
+	session := auth.SessionFromContext(r.Context())
+	a.logger.Info("forward_proxy_ruleset_updated", "user", session.Username, "ruleset", existing.Name, "ruleset_id", existing.ID)
+	a.reloadForwardProxyRouter(r)
+
+	writeJSON(w, http.StatusOK, forwardProxyRulesetToResponse(existing))
+}
+
+func (a *API) handleDeleteForwardProxyRuleset(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	if !isValidUUID(id) {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"message": "Invalid forward proxy ruleset ID format"})
+		return
+	}
+	if err := a.store.DeleteForwardProxyRuleset(r.Context(), id); err != nil {
+		if errors.Is(err, database.ErrNotFound) {
+			writeJSON(w, http.StatusNotFound, map[string]string{"message": "Forward proxy ruleset not found"})
+		} else {
+			a.logger.Error("failed to delete forward proxy ruleset", "error", err)
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"message": "Failed to delete forward proxy ruleset"})
+		}
+		return
+	}
+
+	session := auth.SessionFromContext(r.Context())
+	a.logger.Info("forward_proxy_ruleset_deleted", "user", session.Username, "ruleset_id", id)
+	a.reloadForwardProxyRouter(r)
+	writeJSON(w, http.StatusOK, map[string]string{"message": "Forward proxy ruleset deleted"})
+}

--- a/internal/server/forwardproxy_api.go
+++ b/internal/server/forwardproxy_api.go
@@ -134,6 +134,9 @@ func validateForwardProxyRules(rules []database.ForwardProxyRule) error {
 		return fmt.Errorf("at most %d rules are allowed", maxForwardProxyRules)
 	}
 	for i, rule := range rules {
+		if rule.IncludeNonGitHub && rule.Type != database.ForwardProxyRuleControl {
+			return fmt.Errorf("rules[%d]: include_non_github is only valid on control rules", i)
+		}
 		switch rule.Type {
 		case database.ForwardProxyRuleSystem, database.ForwardProxyRuleControl:
 			if rule.Value != "" {

--- a/internal/server/forwardproxy_api_test.go
+++ b/internal/server/forwardproxy_api_test.go
@@ -121,6 +121,17 @@ func TestForwardProxyRulesetsCRUD(t *testing.T) {
 		t.Errorf("patched proxies len = %d, want 2 (field was omitted)", n)
 	}
 
+	// Patch: clearing proxies is rejected (a ruleset must keep at least one
+	// target), unlike rules which may be cleared.
+	req = httptest.NewRequest("PATCH", "/api/forward-proxy-rulesets/"+id,
+		strings.NewReader(`{"proxies":[]}`)).WithContext(adminCtx())
+	req.SetPathValue("id", id)
+	w = httptest.NewRecorder()
+	a.handleUpdateForwardProxyRuleset(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("patch empty proxies: expected %d, got %d: %s", http.StatusBadRequest, w.Code, w.Body.String())
+	}
+
 	// Delete
 	req = httptest.NewRequest("DELETE", "/api/forward-proxy-rulesets/"+id, nil).WithContext(adminCtx())
 	req.SetPathValue("id", id)

--- a/internal/server/forwardproxy_api_test.go
+++ b/internal/server/forwardproxy_api_test.go
@@ -1,0 +1,252 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/goodtune/ghp/internal/auth"
+)
+
+func adminCtx() context.Context {
+	return auth.NewContextWithSession(context.Background(), &auth.Session{Username: "admin"})
+}
+
+func TestForwardProxyRulesetsCRUD(t *testing.T) {
+	a := newTestAPIWithStore(t)
+
+	appRuleID := uuid.New().String()
+
+	// Create
+	body := `{
+		"name": "ci-egress",
+		"description": "CI split",
+		"algorithm": "weighted",
+		"proxies": [
+			{"url": "http://proxy-a.internal:3128", "weight": 80},
+			{"url": "http://proxy-b.internal:3128", "weight": 20}
+		],
+		"rules": [
+			{"type": "net", "value": "10.42.0.0/16"},
+			{"type": "app", "value": "` + appRuleID + `"}
+		]
+	}`
+	req := httptest.NewRequest("POST", "/api/forward-proxy-rulesets", strings.NewReader(body)).WithContext(adminCtx())
+	w := httptest.NewRecorder()
+	a.handleCreateForwardProxyRuleset(w, req)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("create: expected %d, got %d: %s", http.StatusCreated, w.Code, w.Body.String())
+	}
+	var created map[string]interface{}
+	if err := json.NewDecoder(w.Body).Decode(&created); err != nil {
+		t.Fatalf("decode create response: %v", err)
+	}
+	id := created["id"].(string)
+	if created["enabled"] != true {
+		t.Errorf("expected enabled to default to true, got %v", created["enabled"])
+	}
+
+	// Duplicate name → 409
+	req = httptest.NewRequest("POST", "/api/forward-proxy-rulesets",
+		strings.NewReader(`{"name":"ci-egress","algorithm":"round_robin","proxies":[{"url":"http://p:1"}]}`)).WithContext(adminCtx())
+	w = httptest.NewRecorder()
+	a.handleCreateForwardProxyRuleset(w, req)
+	if w.Code != http.StatusConflict {
+		t.Fatalf("duplicate create: expected %d, got %d: %s", http.StatusConflict, w.Code, w.Body.String())
+	}
+
+	// List
+	req = httptest.NewRequest("GET", "/api/forward-proxy-rulesets", nil)
+	w = httptest.NewRecorder()
+	a.handleListForwardProxyRulesets(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("list: expected %d, got %d", http.StatusOK, w.Code)
+	}
+	var list []map[string]interface{}
+	if err := json.NewDecoder(w.Body).Decode(&list); err != nil {
+		t.Fatalf("decode list: %v", err)
+	}
+	if len(list) != 1 {
+		t.Fatalf("list: expected 1 item, got %d", len(list))
+	}
+
+	// Get
+	req = httptest.NewRequest("GET", "/api/forward-proxy-rulesets/"+id, nil)
+	req.SetPathValue("id", id)
+	w = httptest.NewRecorder()
+	a.handleGetForwardProxyRuleset(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("get: expected %d, got %d", http.StatusOK, w.Code)
+	}
+	var got map[string]interface{}
+	if err := json.NewDecoder(w.Body).Decode(&got); err != nil {
+		t.Fatalf("decode get: %v", err)
+	}
+	if got["algorithm"] != "weighted" {
+		t.Errorf("algorithm = %v, want weighted", got["algorithm"])
+	}
+	if n := len(got["proxies"].([]interface{})); n != 2 {
+		t.Errorf("proxies len = %d, want 2", n)
+	}
+	if n := len(got["rules"].([]interface{})); n != 2 {
+		t.Errorf("rules len = %d, want 2", n)
+	}
+
+	// Patch: disable, change algorithm, clear rules.
+	req = httptest.NewRequest("PATCH", "/api/forward-proxy-rulesets/"+id,
+		strings.NewReader(`{"enabled":false,"algorithm":"sticky","rules":[]}`)).WithContext(adminCtx())
+	req.SetPathValue("id", id)
+	w = httptest.NewRecorder()
+	a.handleUpdateForwardProxyRuleset(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("patch: expected %d, got %d: %s", http.StatusOK, w.Code, w.Body.String())
+	}
+	var patched map[string]interface{}
+	if err := json.NewDecoder(w.Body).Decode(&patched); err != nil {
+		t.Fatalf("decode patch: %v", err)
+	}
+	if patched["enabled"] != false || patched["algorithm"] != "sticky" {
+		t.Errorf("patched = %v, want disabled sticky", patched)
+	}
+	if n := len(patched["rules"].([]interface{})); n != 0 {
+		t.Errorf("patched rules len = %d, want 0", n)
+	}
+	// Omitted fields are untouched.
+	if n := len(patched["proxies"].([]interface{})); n != 2 {
+		t.Errorf("patched proxies len = %d, want 2 (field was omitted)", n)
+	}
+
+	// Delete
+	req = httptest.NewRequest("DELETE", "/api/forward-proxy-rulesets/"+id, nil).WithContext(adminCtx())
+	req.SetPathValue("id", id)
+	w = httptest.NewRecorder()
+	a.handleDeleteForwardProxyRuleset(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("delete: expected %d, got %d: %s", http.StatusOK, w.Code, w.Body.String())
+	}
+
+	// Get after delete → 404
+	req = httptest.NewRequest("GET", "/api/forward-proxy-rulesets/"+id, nil)
+	req.SetPathValue("id", id)
+	w = httptest.NewRecorder()
+	a.handleGetForwardProxyRuleset(w, req)
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("get after delete: expected %d, got %d", http.StatusNotFound, w.Code)
+	}
+}
+
+func TestForwardProxyRulesets_CreateValidation(t *testing.T) {
+	a := newTestAPIWithStore(t)
+
+	tests := []struct {
+		name string
+		body string
+	}{
+		{"missing name", `{"algorithm":"round_robin","proxies":[{"url":"http://p:1"}]}`},
+		{"bad name chars", `{"name":"bad name!","algorithm":"round_robin","proxies":[{"url":"http://p:1"}]}`},
+		{"bad algorithm", `{"name":"ok","algorithm":"lru","proxies":[{"url":"http://p:1"}]}`},
+		{"no proxies", `{"name":"ok","algorithm":"round_robin","proxies":[]}`},
+		{"bad proxy scheme", `{"name":"ok","algorithm":"round_robin","proxies":[{"url":"ftp://p:21"}]}`},
+		{"proxy without host", `{"name":"ok","algorithm":"round_robin","proxies":[{"url":"http://"}]}`},
+		{"negative weight", `{"name":"ok","algorithm":"round_robin","proxies":[{"url":"http://p:1","weight":-1}]}`},
+		{"bad rule type", `{"name":"ok","algorithm":"round_robin","proxies":[{"url":"http://p:1"}],"rules":[{"type":"user","value":"x"}]}`},
+		{"bad cidr", `{"name":"ok","algorithm":"round_robin","proxies":[{"url":"http://p:1"}],"rules":[{"type":"net","value":"10.0.0.1"}]}`},
+		{"app rule not uuid", `{"name":"ok","algorithm":"round_robin","proxies":[{"url":"http://p:1"}],"rules":[{"type":"app","value":"not-a-uuid"}]}`},
+		{"token rule not uuid", `{"name":"ok","algorithm":"round_robin","proxies":[{"url":"http://p:1"}],"rules":[{"type":"token","value":"not-a-uuid"}]}`},
+		{"system rule with value", `{"name":"ok","algorithm":"round_robin","proxies":[{"url":"http://p:1"}],"rules":[{"type":"system","value":"x"}]}`},
+		{"invalid json", `{`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest("POST", "/api/forward-proxy-rulesets", strings.NewReader(tt.body)).WithContext(adminCtx())
+			w := httptest.NewRecorder()
+			a.handleCreateForwardProxyRuleset(w, req)
+			if w.Code != http.StatusBadRequest {
+				t.Fatalf("expected %d, got %d: %s", http.StatusBadRequest, w.Code, w.Body.String())
+			}
+		})
+	}
+}
+
+func TestForwardProxyRulesets_BodyTooLarge(t *testing.T) {
+	a := newTestAPIWithStore(t)
+	big := strings.Repeat("x", maxRequestBodySize+1)
+	req := httptest.NewRequest("POST", "/api/forward-proxy-rulesets", strings.NewReader(`{"name":"`+big+`"}`)).WithContext(adminCtx())
+	w := httptest.NewRecorder()
+	a.handleCreateForwardProxyRuleset(w, req)
+	if w.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("expected %d, got %d", http.StatusRequestEntityTooLarge, w.Code)
+	}
+}
+
+func TestForwardProxyRulesets_InvalidAndMissingIDs(t *testing.T) {
+	a := newTestAPIWithStore(t)
+
+	// Malformed UUIDs → 400 on every ID-taking handler.
+	for _, tc := range []struct {
+		method string
+		h      func(http.ResponseWriter, *http.Request)
+	}{
+		{"GET", a.handleGetForwardProxyRuleset},
+		{"PATCH", a.handleUpdateForwardProxyRuleset},
+		{"DELETE", a.handleDeleteForwardProxyRuleset},
+	} {
+		req := httptest.NewRequest(tc.method, "/api/forward-proxy-rulesets/nope", strings.NewReader(`{}`)).WithContext(adminCtx())
+		req.SetPathValue("id", "nope")
+		w := httptest.NewRecorder()
+		tc.h(w, req)
+		if w.Code != http.StatusBadRequest {
+			t.Errorf("%s with malformed id: expected %d, got %d", tc.method, http.StatusBadRequest, w.Code)
+		}
+	}
+
+	// Well-formed but unknown UUID → 404.
+	missing := uuid.New().String()
+	req := httptest.NewRequest("PATCH", "/api/forward-proxy-rulesets/"+missing, strings.NewReader(`{"enabled":true}`)).WithContext(adminCtx())
+	req.SetPathValue("id", missing)
+	w := httptest.NewRecorder()
+	a.handleUpdateForwardProxyRuleset(w, req)
+	if w.Code != http.StatusNotFound {
+		t.Errorf("patch unknown id: expected %d, got %d", http.StatusNotFound, w.Code)
+	}
+	req = httptest.NewRequest("DELETE", "/api/forward-proxy-rulesets/"+missing, nil).WithContext(adminCtx())
+	req.SetPathValue("id", missing)
+	w = httptest.NewRecorder()
+	a.handleDeleteForwardProxyRuleset(w, req)
+	if w.Code != http.StatusNotFound {
+		t.Errorf("delete unknown id: expected %d, got %d", http.StatusNotFound, w.Code)
+	}
+}
+
+func TestForwardProxyRulesets_RenameConflict(t *testing.T) {
+	a := newTestAPIWithStore(t)
+
+	mk := func(name string) string {
+		req := httptest.NewRequest("POST", "/api/forward-proxy-rulesets",
+			strings.NewReader(`{"name":"`+name+`","algorithm":"round_robin","proxies":[{"url":"http://p:1"}]}`)).WithContext(adminCtx())
+		w := httptest.NewRecorder()
+		a.handleCreateForwardProxyRuleset(w, req)
+		if w.Code != http.StatusCreated {
+			t.Fatalf("create %s: got %d: %s", name, w.Code, w.Body.String())
+		}
+		var resp map[string]interface{}
+		json.NewDecoder(w.Body).Decode(&resp)
+		return resp["id"].(string)
+	}
+	mk("first")
+	secondID := mk("second")
+
+	req := httptest.NewRequest("PATCH", "/api/forward-proxy-rulesets/"+secondID,
+		strings.NewReader(`{"name":"first"}`)).WithContext(adminCtx())
+	req.SetPathValue("id", secondID)
+	w := httptest.NewRecorder()
+	a.handleUpdateForwardProxyRuleset(w, req)
+	if w.Code != http.StatusConflict {
+		t.Fatalf("rename conflict: expected %d, got %d: %s", http.StatusConflict, w.Code, w.Body.String())
+	}
+}

--- a/internal/server/forwardproxy_api_test.go
+++ b/internal/server/forwardproxy_api_test.go
@@ -159,6 +159,7 @@ func TestForwardProxyRulesets_CreateValidation(t *testing.T) {
 		{"app rule not uuid", `{"name":"ok","algorithm":"round_robin","proxies":[{"url":"http://p:1"}],"rules":[{"type":"app","value":"not-a-uuid"}]}`},
 		{"token rule not uuid", `{"name":"ok","algorithm":"round_robin","proxies":[{"url":"http://p:1"}],"rules":[{"type":"token","value":"not-a-uuid"}]}`},
 		{"system rule with value", `{"name":"ok","algorithm":"round_robin","proxies":[{"url":"http://p:1"}],"rules":[{"type":"system","value":"x"}]}`},
+		{"control rule with value", `{"name":"ok","algorithm":"round_robin","proxies":[{"url":"http://p:1"}],"rules":[{"type":"control","value":"x"}]}`},
 		{"invalid json", `{`},
 	}
 	for _, tt := range tests {
@@ -170,6 +171,15 @@ func TestForwardProxyRulesets_CreateValidation(t *testing.T) {
 				t.Fatalf("expected %d, got %d: %s", http.StatusBadRequest, w.Code, w.Body.String())
 			}
 		})
+	}
+
+	// A bare control rule (no value) is valid.
+	req := httptest.NewRequest("POST", "/api/forward-proxy-rulesets",
+		strings.NewReader(`{"name":"control-ok","algorithm":"round_robin","proxies":[{"url":"http://p:1"}],"rules":[{"type":"control"}]}`)).WithContext(adminCtx())
+	w := httptest.NewRecorder()
+	a.handleCreateForwardProxyRuleset(w, req)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("control rule create: expected %d, got %d: %s", http.StatusCreated, w.Code, w.Body.String())
 	}
 }
 

--- a/internal/server/forwardproxy_api_test.go
+++ b/internal/server/forwardproxy_api_test.go
@@ -160,6 +160,7 @@ func TestForwardProxyRulesets_CreateValidation(t *testing.T) {
 		{"token rule not uuid", `{"name":"ok","algorithm":"round_robin","proxies":[{"url":"http://p:1"}],"rules":[{"type":"token","value":"not-a-uuid"}]}`},
 		{"system rule with value", `{"name":"ok","algorithm":"round_robin","proxies":[{"url":"http://p:1"}],"rules":[{"type":"system","value":"x"}]}`},
 		{"control rule with value", `{"name":"ok","algorithm":"round_robin","proxies":[{"url":"http://p:1"}],"rules":[{"type":"control","value":"x"}]}`},
+		{"include_non_github on non-control rule", `{"name":"ok","algorithm":"round_robin","proxies":[{"url":"http://p:1"}],"rules":[{"type":"system","include_non_github":true}]}`},
 		{"invalid json", `{`},
 	}
 	for _, tt := range tests {
@@ -180,6 +181,24 @@ func TestForwardProxyRulesets_CreateValidation(t *testing.T) {
 	a.handleCreateForwardProxyRuleset(w, req)
 	if w.Code != http.StatusCreated {
 		t.Fatalf("control rule create: expected %d, got %d: %s", http.StatusCreated, w.Code, w.Body.String())
+	}
+
+	// include_non_github is valid on a control rule and round-trips.
+	req = httptest.NewRequest("POST", "/api/forward-proxy-rulesets",
+		strings.NewReader(`{"name":"control-ngh","algorithm":"round_robin","proxies":[{"url":"http://p:1"}],"rules":[{"type":"control","include_non_github":true}]}`)).WithContext(adminCtx())
+	w = httptest.NewRecorder()
+	a.handleCreateForwardProxyRuleset(w, req)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("control include_non_github create: expected %d, got %d: %s", http.StatusCreated, w.Code, w.Body.String())
+	}
+	var resp struct {
+		Rules []map[string]interface{} `json:"rules"`
+	}
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(resp.Rules) != 1 || resp.Rules[0]["include_non_github"] != true {
+		t.Fatalf("rules = %v, want include_non_github=true", resp.Rules)
 	}
 }
 

--- a/internal/server/forwardproxy_middleware_test.go
+++ b/internal/server/forwardproxy_middleware_test.go
@@ -1,0 +1,81 @@
+package server
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/goodtune/ghp/internal/config"
+	"github.com/goodtune/ghp/internal/netutil"
+	"github.com/goodtune/ghp/internal/proxy"
+)
+
+func TestForwardProxyRouteInfoMiddleware(t *testing.T) {
+	newCfg := func(allow bool) *config.Config {
+		return &config.Config{ForwardProxy: config.ForwardProxyConfig{AllowRequestHeader: allow}}
+	}
+
+	t.Run("seeds client IP and strips headers when disabled", func(t *testing.T) {
+		var info *proxy.ForwardProxyRouteInfo
+		var upstreamHeader string
+		inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			info = proxy.ForwardProxyInfoFromContext(r.Context())
+			upstreamHeader = r.Header.Get(proxy.ForwardProxyHeaderHTTPS)
+		})
+		h := forwardProxyRouteInfoMiddleware(inner, newCfg(false), netutil.IPHeaderNone)
+
+		req := httptest.NewRequest(http.MethodGet, "https://api.github.com/user", nil)
+		req.RemoteAddr = "10.9.8.7:4242"
+		req.Header.Set(proxy.ForwardProxyHeaderHTTPS, "http://team-proxy:3128")
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, req)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("status = %d, want 200", w.Code)
+		}
+		if info == nil || info.ClientIP != "10.9.8.7" {
+			t.Fatalf("route info = %+v, want ClientIP 10.9.8.7", info)
+		}
+		if info.ClientProxy != nil {
+			t.Errorf("ClientProxy = %v, want nil when feature disabled", info.ClientProxy)
+		}
+		if upstreamHeader != "" {
+			t.Error("proxy header reached the inner handler; must be stripped")
+		}
+	})
+
+	t.Run("records client proxy when enabled", func(t *testing.T) {
+		var info *proxy.ForwardProxyRouteInfo
+		inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			info = proxy.ForwardProxyInfoFromContext(r.Context())
+		})
+		h := forwardProxyRouteInfoMiddleware(inner, newCfg(true), netutil.IPHeaderNone)
+
+		req := httptest.NewRequest(http.MethodGet, "https://api.github.com/user", nil)
+		req.Header.Set(proxy.ForwardProxyHeaderHTTPS, "http://team-proxy:3128")
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, req)
+
+		if info == nil || info.ClientProxy == nil || info.ClientProxy.Host != "team-proxy:3128" {
+			t.Fatalf("route info = %+v, want ClientProxy team-proxy:3128", info)
+		}
+	})
+
+	t.Run("invalid header value returns 400 when enabled", func(t *testing.T) {
+		called := false
+		inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { called = true })
+		h := forwardProxyRouteInfoMiddleware(inner, newCfg(true), netutil.IPHeaderNone)
+
+		req := httptest.NewRequest(http.MethodGet, "https://api.github.com/user", nil)
+		req.Header.Set(proxy.ForwardProxyHeaderSOCKS, "http://wrong-scheme:3128")
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, req)
+
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("status = %d, want 400", w.Code)
+		}
+		if called {
+			t.Error("inner handler called despite invalid proxy header")
+		}
+	})
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -502,9 +502,20 @@ func (s *Server) Run(ctx context.Context) error {
 	// Seed the forward proxy route-info slot (client IP; token identity is
 	// filled in later by the token-resolving handlers) on every proxied
 	// backend so the shared transport can select an egress proxy per request.
+	// Client-selected proxy headers are validated and stripped here — they
+	// must never reach the upstream — and only honoured when
+	// forward_proxy.allow_request_header is enabled.
 	withRouteInfo := func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			clientProxy, err := proxy.ExtractClientForwardProxy(r, s.cfg.ForwardProxy.AllowRequestHeader)
+			if err != nil {
+				writeJSON(w, http.StatusBadRequest, map[string]string{"message": err.Error()})
+				return
+			}
 			r = proxy.PrepareForwardProxyInfo(r, netutil.ClientIP(r, clientIPHeader))
+			if clientProxy != nil {
+				proxy.SetForwardProxyClientChoice(r, clientProxy)
+			}
 			next.ServeHTTP(w, r)
 		})
 	}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -297,13 +297,16 @@ func (s *Server) Run(ctx context.Context) error {
 	// Forward proxy rulesets: runtime egress routing loaded from the store.
 	// All outbound GitHub transports (API proxy, github.com passthrough,
 	// codeload, Copilot) share one transport whose per-request Proxy function
-	// consults the router; ghp's own control traffic (OAuth flows and token
-	// refresh, installation token minting, username resolution, release HEAD
-	// probes) uses the control transport, which routes control rule → system
-	// rule → ambient. When no ruleset matches, the ambient environment
-	// (HTTPS_PROXY et al.) applies as before. Admin API mutations reload the
-	// route table immediately on this instance; the periodic refresh
-	// propagates changes to other instances in HA deployments.
+	// consults the router; ghp's own GitHub-destined control traffic (OAuth
+	// flows and token refresh, installation token minting, username
+	// resolution) uses the control transport, which routes control rule →
+	// system rule → ambient. Release HEAD probes target the operator's
+	// mirror, not GitHub, and use the non-GitHub control transport: direct
+	// unless a control rule sets include_non_github. When no ruleset
+	// matches, the ambient environment (HTTPS_PROXY et al.) applies as
+	// before. Admin API mutations reload the route table immediately on this
+	// instance; the periodic refresh propagates changes to other instances
+	// in HA deployments.
 	forwardProxyRouter := proxy.NewForwardProxyRouter(store, s.logger)
 	if err := forwardProxyRouter.Reload(ctx); err != nil {
 		s.logger.Warn("forward proxy ruleset load failed; egress uses ambient environment until reload succeeds", "error", err)
@@ -383,14 +386,17 @@ func (s *Server) Run(ctx context.Context) error {
 	// Periodically purge expired sessions, oauth_states, and
 	// cli_device_authorizations rows so the tables don't grow unbounded.
 	authHandler.StartCleanup(lifecycleCtx)
+	// Install the control transport on the resolver before WarmCache spawns
+	// its background lookups: setting it later would race with in-flight
+	// requests and let warm-cache traffic bypass control-layer routing.
 	usernameResolver := proxy.NewUsernameResolver(store, s.logger)
+	usernameResolver.SetTransport(forwardProxyControlTransport)
+	authHandler.SetTransport(forwardProxyControlTransport)
 	proxyTokenResolver := proxy.NewProxyTokenResolver(tokenSvc, store, enc, appTokenProvider)
 	usernameResolver.WarmCache(lifecycleCtx, proxyTokenResolver)
 	proxyHandler := proxy.NewHandler(s.cfg, tokenSvc, store, enc, appTokenProvider, usernameResolver, s.logger)
 	proxyHandler.SetTransport(forwardProxyTransport)
 	forwardProxyRouter.StartRefresh(lifecycleCtx, time.Minute)
-	authHandler.SetTransport(forwardProxyControlTransport)
-	usernameResolver.SetTransport(forwardProxyControlTransport)
 
 	// Build the enterprise access restriction policy with the app registry as
 	// the identity source so exceptions can substitute managed installation
@@ -499,25 +505,8 @@ func (s *Server) Run(ctx context.Context) error {
 
 	// Build host dispatch with access logging on all handlers.
 	clientIPHeader := netutil.IPHeader(s.cfg.Server.ClientIPHeader)
-	// Seed the forward proxy route-info slot (client IP; token identity is
-	// filled in later by the token-resolving handlers) on every proxied
-	// backend so the shared transport can select an egress proxy per request.
-	// Client-selected proxy headers are validated and stripped here — they
-	// must never reach the upstream — and only honoured when
-	// forward_proxy.allow_request_header is enabled.
 	withRouteInfo := func(next http.Handler) http.Handler {
-		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			clientProxy, err := proxy.ExtractClientForwardProxy(r, s.cfg.ForwardProxy.AllowRequestHeader)
-			if err != nil {
-				writeJSON(w, http.StatusBadRequest, map[string]string{"message": err.Error()})
-				return
-			}
-			r = proxy.PrepareForwardProxyInfo(r, netutil.ClientIP(r, clientIPHeader))
-			if clientProxy != nil {
-				proxy.SetForwardProxyClientChoice(r, clientProxy)
-			}
-			next.ServeHTTP(w, r)
-		})
+		return forwardProxyRouteInfoMiddleware(next, s.cfg, clientIPHeader)
 	}
 	dispatch := newHostDispatch(hostDispatchConfig{
 		apiHandler:      accessLogHandler(backend.API, withRouteInfo(proxyHandler), aw, clientIPHeader),
@@ -792,6 +781,27 @@ func systemdListeners() ([]net.Listener, error) {
 		listeners = append(listeners, ln)
 	}
 	return listeners, nil
+}
+
+// forwardProxyRouteInfoMiddleware seeds the forward proxy route-info slot
+// (client IP; token identity is filled in later by the token-resolving
+// handlers) on every proxied backend so the shared transport can select an
+// egress proxy per request. Client-selected proxy headers are validated and
+// stripped here — they must never reach the upstream — and only honoured
+// when forward_proxy.allow_request_header is enabled.
+func forwardProxyRouteInfoMiddleware(next http.Handler, cfg *config.Config, clientIPHeader netutil.IPHeader) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		clientProxy, err := proxy.ExtractClientForwardProxy(r, cfg.ForwardProxy.AllowRequestHeader)
+		if err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"message": err.Error()})
+			return
+		}
+		r = proxy.PrepareForwardProxyInfo(r, netutil.ClientIP(r, clientIPHeader))
+		if clientProxy != nil {
+			proxy.SetForwardProxyClientChoice(r, clientProxy)
+		}
+		next.ServeHTTP(w, r)
+	})
 }
 
 type hostDispatchConfig struct {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -294,8 +294,26 @@ func (s *Server) Run(ctx context.Context) error {
 		s.logger.Warn("default app seeding failed", "error", err)
 	}
 
+	// Forward proxy rulesets: runtime egress routing loaded from the store.
+	// All outbound GitHub transports (API proxy, github.com passthrough,
+	// codeload, Copilot) share one transport whose per-request Proxy function
+	// consults the router; ghp's own control traffic (OAuth flows and token
+	// refresh, installation token minting, username resolution, release HEAD
+	// probes) uses the control transport, which routes control rule → system
+	// rule → ambient. When no ruleset matches, the ambient environment
+	// (HTTPS_PROXY et al.) applies as before. Admin API mutations reload the
+	// route table immediately on this instance; the periodic refresh
+	// propagates changes to other instances in HA deployments.
+	forwardProxyRouter := proxy.NewForwardProxyRouter(store, s.logger)
+	if err := forwardProxyRouter.Reload(ctx); err != nil {
+		s.logger.Warn("forward proxy ruleset load failed; egress uses ambient environment until reload succeeds", "error", err)
+	}
+	forwardProxyTransport := proxy.NewForwardProxyTransport(forwardProxyRouter)
+	forwardProxyControlTransport := proxy.NewForwardProxyControlTransport(forwardProxyRouter)
+
 	// Build the AppRegistry with all apps from the store.
 	appRegistry := github.NewAppRegistry(store, enc, s.logger)
+	appRegistry.SetTransport(forwardProxyControlTransport)
 	loadAllFailed := false
 	if err := appRegistry.LoadAll(ctx); err != nil {
 		s.logger.Warn("failed to load app registry", "error", err)
@@ -342,6 +360,7 @@ func (s *Server) Run(ctx context.Context) error {
 			if err != nil {
 				return fmt.Errorf("initializing GitHub App token provider: %w", err)
 			}
+			atp.SetTransport(forwardProxyControlTransport)
 			appTokenProvider = atp
 			s.logger.Info("github app token provider initialized (config fallback)", "app_id", s.cfg.GitHub.AppID)
 		}
@@ -368,21 +387,10 @@ func (s *Server) Run(ctx context.Context) error {
 	proxyTokenResolver := proxy.NewProxyTokenResolver(tokenSvc, store, enc, appTokenProvider)
 	usernameResolver.WarmCache(lifecycleCtx, proxyTokenResolver)
 	proxyHandler := proxy.NewHandler(s.cfg, tokenSvc, store, enc, appTokenProvider, usernameResolver, s.logger)
-
-	// Forward proxy rulesets: runtime egress routing loaded from the store.
-	// All outbound GitHub transports (API proxy, github.com passthrough,
-	// codeload, Copilot) share one transport whose per-request Proxy function
-	// consults the router; when no ruleset matches, the ambient environment
-	// (HTTPS_PROXY et al.) applies as before. Admin API mutations reload the
-	// route table immediately on this instance; the periodic refresh
-	// propagates changes to other instances in HA deployments.
-	forwardProxyRouter := proxy.NewForwardProxyRouter(store, s.logger)
-	if err := forwardProxyRouter.Reload(lifecycleCtx); err != nil {
-		s.logger.Warn("forward proxy ruleset load failed; egress uses ambient environment until reload succeeds", "error", err)
-	}
-	forwardProxyRouter.StartRefresh(lifecycleCtx, time.Minute)
-	forwardProxyTransport := proxy.NewForwardProxyTransport(forwardProxyRouter)
 	proxyHandler.SetTransport(forwardProxyTransport)
+	forwardProxyRouter.StartRefresh(lifecycleCtx, time.Minute)
+	authHandler.SetTransport(forwardProxyControlTransport)
+	usernameResolver.SetTransport(forwardProxyControlTransport)
 
 	// Build the enterprise access restriction policy with the app registry as
 	// the identity source so exceptions can substitute managed installation
@@ -477,7 +485,7 @@ func (s *Server) Run(ctx context.Context) error {
 
 	githubPassthrough := proxy.NewScopedPassthroughHandler(
 		githubInner, tokenSvc, proxyTokenResolver, usernameResolver, enterprisePolicy, s.logger, s.cfg)
-	githubPassthrough = proxy.NewReleasesHandler(githubPassthrough, s.cfg, s.logger)
+	githubPassthrough = proxy.NewReleasesHandler(githubPassthrough, s.cfg, s.logger, forwardProxyControlTransport)
 
 	codeloadHandler := proxy.NewCodeloadHandler(s.cfg, s.logger, forwardProxyTransport)
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -369,6 +369,21 @@ func (s *Server) Run(ctx context.Context) error {
 	usernameResolver.WarmCache(lifecycleCtx, proxyTokenResolver)
 	proxyHandler := proxy.NewHandler(s.cfg, tokenSvc, store, enc, appTokenProvider, usernameResolver, s.logger)
 
+	// Forward proxy rulesets: runtime egress routing loaded from the store.
+	// All outbound GitHub transports (API proxy, github.com passthrough,
+	// codeload, Copilot) share one transport whose per-request Proxy function
+	// consults the router; when no ruleset matches, the ambient environment
+	// (HTTPS_PROXY et al.) applies as before. Admin API mutations reload the
+	// route table immediately on this instance; the periodic refresh
+	// propagates changes to other instances in HA deployments.
+	forwardProxyRouter := proxy.NewForwardProxyRouter(store, s.logger)
+	if err := forwardProxyRouter.Reload(lifecycleCtx); err != nil {
+		s.logger.Warn("forward proxy ruleset load failed; egress uses ambient environment until reload succeeds", "error", err)
+	}
+	forwardProxyRouter.StartRefresh(lifecycleCtx, time.Minute)
+	forwardProxyTransport := proxy.NewForwardProxyTransport(forwardProxyRouter)
+	proxyHandler.SetTransport(forwardProxyTransport)
+
 	// Build the enterprise access restriction policy with the app registry as
 	// the identity source so exceptions can substitute managed installation
 	// tokens and verify team membership. NewHandler installed a baseline
@@ -394,6 +409,7 @@ func (s *Server) Run(ctx context.Context) error {
 		}
 	}
 	api := NewAPI(lifecycleCtx, s.cfg, store, tokenSvc, authHandler, enc, concreteATP, appRegistry, proxyTokenResolver, usernameResolver, s.logger, auditWriter)
+	api.SetForwardProxyRouter(forwardProxyRouter)
 	webUI := web.NewHandler(authHandler, store, s.cfg.DevMode, s.version, s.logger)
 
 	// Build HTTP mux.
@@ -421,7 +437,7 @@ func (s *Server) Run(ctx context.Context) error {
 	// Create passthrough handlers for github.com and *.githubcopilot.com.
 	// Reuse proxyTokenResolver created above for cache warming to avoid duplication.
 	githubInner := proxy.NewPassthroughHandler(
-		"https://github.com", proxyTokenResolver, s.logger, nil)
+		"https://github.com", proxyTokenResolver, s.logger, forwardProxyTransport)
 
 	// Wrap with git cache handler if enabled. The cache middleware wraps
 	// githubInner (the raw passthrough). The resulting handler is then wrapped
@@ -463,21 +479,30 @@ func (s *Server) Run(ctx context.Context) error {
 		githubInner, tokenSvc, proxyTokenResolver, usernameResolver, enterprisePolicy, s.logger, s.cfg)
 	githubPassthrough = proxy.NewReleasesHandler(githubPassthrough, s.cfg, s.logger)
 
-	codeloadHandler := proxy.NewCodeloadHandler(s.cfg, s.logger, nil)
+	codeloadHandler := proxy.NewCodeloadHandler(s.cfg, s.logger, forwardProxyTransport)
 
 	copilotPassthrough := proxy.NewCopilotPassthroughHandler(
-		"https://copilot-proxy.githubusercontent.com", s.cfg.GitHub.EnterpriseSlug, s.logger, nil)
+		"https://copilot-proxy.githubusercontent.com", s.cfg.GitHub.EnterpriseSlug, s.logger, forwardProxyTransport)
 
 	// Build access log writer for OpenTelemetry access log records.
 	aw := newAccessLogWriter(s.logProvider.Logger(accessLogScope))
 
 	// Build host dispatch with access logging on all handlers.
 	clientIPHeader := netutil.IPHeader(s.cfg.Server.ClientIPHeader)
+	// Seed the forward proxy route-info slot (client IP; token identity is
+	// filled in later by the token-resolving handlers) on every proxied
+	// backend so the shared transport can select an egress proxy per request.
+	withRouteInfo := func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			r = proxy.PrepareForwardProxyInfo(r, netutil.ClientIP(r, clientIPHeader))
+			next.ServeHTTP(w, r)
+		})
+	}
 	dispatch := newHostDispatch(hostDispatchConfig{
-		apiHandler:      accessLogHandler(backend.API, proxyHandler, aw, clientIPHeader),
-		githubHandler:   accessLogHandler(backend.GitHub, githubPassthrough, aw, clientIPHeader),
-		codeloadHandler: accessLogHandler(backend.Codeload, codeloadHandler, aw, clientIPHeader),
-		copilotHandler:  accessLogHandler(backend.Copilot, copilotPassthrough, aw, clientIPHeader),
+		apiHandler:      accessLogHandler(backend.API, withRouteInfo(proxyHandler), aw, clientIPHeader),
+		githubHandler:   accessLogHandler(backend.GitHub, withRouteInfo(githubPassthrough), aw, clientIPHeader),
+		codeloadHandler: accessLogHandler(backend.Codeload, withRouteInfo(codeloadHandler), aw, clientIPHeader),
+		copilotHandler:  accessLogHandler(backend.Copilot, withRouteInfo(copilotPassthrough), aw, clientIPHeader),
 		mgmtHandler:     accessLogHandler(backend.Mgmt, web.SessionUsernameMiddleware(authHandler)(web.SecurityHeadersMiddleware(mux)), aw, clientIPHeader),
 		managementHost:  s.cfg.Server.ManagementHost,
 	})

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -403,6 +403,7 @@ func (s *Server) Run(ctx context.Context) error {
 	// tokens and verify team membership. NewHandler installed a baseline
 	// policy (matching only); this replaces it with the full-featured one.
 	enterprisePolicy := proxy.NewEnterprisePolicy(s.cfg.GitHub, appRegistry, s.logger)
+	enterprisePolicy.SetTransport(forwardProxyControlTransport)
 	proxyHandler.SetEnterprisePolicy(enterprisePolicy)
 
 	// Build audit log writer for OpenTelemetry audit log records.
@@ -444,9 +445,14 @@ func (s *Server) Run(ctx context.Context) error {
 		http.Redirect(w, r, "/docs/", http.StatusMovedPermanently)
 	})
 
-	// Proxy routes — these catch /api/v3/* and /api/graphql.
-	mux.Handle("/api/v3/", proxyHandler)
-	mux.Handle("/api/graphql", proxyHandler)
+	// Proxy routes — these catch /api/v3/* and /api/graphql. These mux
+	// registrations serve GHE-style API paths on the management host, which
+	// bypasses the host-dispatch wrapping below, so the forward proxy
+	// route-info middleware must be applied here too or these requests
+	// would silently fall back to ambient egress.
+	mgmtProxyHandler := forwardProxyRouteInfoMiddleware(proxyHandler, s.cfg, netutil.IPHeader(s.cfg.Server.ClientIPHeader))
+	mux.Handle("/api/v3/", mgmtProxyHandler)
+	mux.Handle("/api/graphql", mgmtProxyHandler)
 
 	// Create passthrough handlers for github.com and *.githubcopilot.com.
 	// Reuse proxyTokenResolver created above for cache warming to avoid duplication.
@@ -480,6 +486,9 @@ func (s *Server) Run(ctx context.Context) error {
 			"https://github.com",
 			s.cfg.Cache.StoragePath,
 		)
+		// Cached-repo git traffic must follow the same ruleset egress
+		// selection as the raw passthrough it intercepts.
+		cacheHandler.SetTransport(forwardProxyTransport)
 		githubInner = gitcache.NewCacheLookup(githubInner, cacheHandler, store, s.logger)
 		gitcache.SyncCacheReposMetric(lifecycleCtx, store)
 		gitcache.StartCleanup(lifecycleCtx, s.cfg.Cache.StoragePath, store, 10*time.Minute)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -485,7 +485,9 @@ func (s *Server) Run(ctx context.Context) error {
 
 	githubPassthrough := proxy.NewScopedPassthroughHandler(
 		githubInner, tokenSvc, proxyTokenResolver, usernameResolver, enterprisePolicy, s.logger, s.cfg)
-	githubPassthrough = proxy.NewReleasesHandler(githubPassthrough, s.cfg, s.logger, forwardProxyControlTransport)
+	// Release HEAD probes target the operator's redirect mirror, not GitHub;
+	// they go direct unless a control rule opts them in via include_non_github.
+	githubPassthrough = proxy.NewReleasesHandler(githubPassthrough, s.cfg, s.logger, proxy.NewForwardProxyNonGitHubControlTransport(forwardProxyRouter))
 
 	codeloadHandler := proxy.NewCodeloadHandler(s.cfg, s.logger, forwardProxyTransport)
 

--- a/internal/token/cache_test.go
+++ b/internal/token/cache_test.go
@@ -48,28 +48,46 @@ func (m *mockStore) CreateProxyToken(_ context.Context, pt *database.ProxyToken)
 }
 
 // The remaining Store interface methods are unused by the cache tests.
-func (m *mockStore) UpsertUser(_ context.Context, _ *database.User) error                          { return nil }
-func (m *mockStore) GetUserByGitHubID(_ context.Context, _ int64) (*database.User, error)          { return nil, nil }
-func (m *mockStore) GetUserByID(_ context.Context, _ string) (*database.User, error)               { return nil, nil }
-func (m *mockStore) ListUsers(_ context.Context) ([]*database.User, error)                         { return nil, nil }
-func (m *mockStore) SyncAdminRoles(_ context.Context, _ []string) error                            { return nil }
-func (m *mockStore) UpsertGitHubToken(_ context.Context, _ *database.GitHubToken) error            { return nil }
-func (m *mockStore) GetGitHubToken(_ context.Context, _ string) (*database.GitHubToken, error)     { return nil, nil }
-func (m *mockStore) GetGitHubTokenByID(_ context.Context, _ string) (*database.GitHubToken, error) { return nil, nil }
-func (m *mockStore) GetProxyTokenByID(_ context.Context, _ string) (*database.ProxyToken, error)   { return nil, nil }
-func (m *mockStore) ListProxyTokens(_ context.Context, _ string) ([]*database.ProxyToken, error)   { return nil, nil }
-func (m *mockStore) ListAllProxyTokens(_ context.Context) ([]*database.ProxyToken, error)          { return nil, nil }
-func (m *mockStore) UpdateProxyTokenAppID(_ context.Context, _ string, _ string) error              { return nil }
-func (m *mockStore) UpdateProxyTokenScopes(_ context.Context, _ string, _ json.RawMessage, _ json.RawMessage) error { return nil }
-func (m *mockStore) DeleteExpiredProxyTokens(_ context.Context, _ time.Duration) (int64, error)     { return 0, nil }
-func (m *mockStore) GetDefaultApp(_ context.Context) (*database.App, error)                        { return nil, nil }
-func (m *mockStore) SetDefaultApp(_ context.Context, _ string) error                              { return nil }
-func (m *mockStore) CreateApp(_ context.Context, _ *database.App) error                            { return nil }
-func (m *mockStore) GetAppByID(_ context.Context, _ string) (*database.App, error)                 { return nil, nil }
-func (m *mockStore) ListApps(_ context.Context) ([]*database.App, error)                           { return nil, nil }
-func (m *mockStore) UpdateApp(_ context.Context, _ *database.App) error                            { return nil }
-func (m *mockStore) DeleteApp(_ context.Context, _ string) error                                   { return nil }
-func (m *mockStore) CreateCachedRepository(_ context.Context, _ *database.CachedRepository) error  { return nil }
+func (m *mockStore) UpsertUser(_ context.Context, _ *database.User) error { return nil }
+func (m *mockStore) GetUserByGitHubID(_ context.Context, _ int64) (*database.User, error) {
+	return nil, nil
+}
+func (m *mockStore) GetUserByID(_ context.Context, _ string) (*database.User, error)    { return nil, nil }
+func (m *mockStore) ListUsers(_ context.Context) ([]*database.User, error)              { return nil, nil }
+func (m *mockStore) SyncAdminRoles(_ context.Context, _ []string) error                 { return nil }
+func (m *mockStore) UpsertGitHubToken(_ context.Context, _ *database.GitHubToken) error { return nil }
+func (m *mockStore) GetGitHubToken(_ context.Context, _ string) (*database.GitHubToken, error) {
+	return nil, nil
+}
+func (m *mockStore) GetGitHubTokenByID(_ context.Context, _ string) (*database.GitHubToken, error) {
+	return nil, nil
+}
+func (m *mockStore) GetProxyTokenByID(_ context.Context, _ string) (*database.ProxyToken, error) {
+	return nil, nil
+}
+func (m *mockStore) ListProxyTokens(_ context.Context, _ string) ([]*database.ProxyToken, error) {
+	return nil, nil
+}
+func (m *mockStore) ListAllProxyTokens(_ context.Context) ([]*database.ProxyToken, error) {
+	return nil, nil
+}
+func (m *mockStore) UpdateProxyTokenAppID(_ context.Context, _ string, _ string) error { return nil }
+func (m *mockStore) UpdateProxyTokenScopes(_ context.Context, _ string, _ json.RawMessage, _ json.RawMessage) error {
+	return nil
+}
+func (m *mockStore) DeleteExpiredProxyTokens(_ context.Context, _ time.Duration) (int64, error) {
+	return 0, nil
+}
+func (m *mockStore) GetDefaultApp(_ context.Context) (*database.App, error)        { return nil, nil }
+func (m *mockStore) SetDefaultApp(_ context.Context, _ string) error               { return nil }
+func (m *mockStore) CreateApp(_ context.Context, _ *database.App) error            { return nil }
+func (m *mockStore) GetAppByID(_ context.Context, _ string) (*database.App, error) { return nil, nil }
+func (m *mockStore) ListApps(_ context.Context) ([]*database.App, error)           { return nil, nil }
+func (m *mockStore) UpdateApp(_ context.Context, _ *database.App) error            { return nil }
+func (m *mockStore) DeleteApp(_ context.Context, _ string) error                   { return nil }
+func (m *mockStore) CreateCachedRepository(_ context.Context, _ *database.CachedRepository) error {
+	return nil
+}
 func (m *mockStore) GetCachedRepositoryByID(_ context.Context, _ string) (*database.CachedRepository, error) {
 	return nil, nil
 }
@@ -79,14 +97,16 @@ func (m *mockStore) GetCachedRepositoryByOwnerName(_ context.Context, _, _ strin
 func (m *mockStore) ListCachedRepositories(_ context.Context) ([]*database.CachedRepository, error) {
 	return nil, nil
 }
-func (m *mockStore) UpdateCachedRepository(_ context.Context, _ *database.CachedRepository) error { return nil }
-func (m *mockStore) DeleteCachedRepository(_ context.Context, _ string) error                     { return nil }
-func (m *mockStore) CreateSession(_ context.Context, _ *database.Session) error                   { return nil }
+func (m *mockStore) UpdateCachedRepository(_ context.Context, _ *database.CachedRepository) error {
+	return nil
+}
+func (m *mockStore) DeleteCachedRepository(_ context.Context, _ string) error   { return nil }
+func (m *mockStore) CreateSession(_ context.Context, _ *database.Session) error { return nil }
 func (m *mockStore) GetSessionByTokenHash(_ context.Context, _ string) (*database.Session, error) {
 	return nil, database.ErrNotFound
 }
-func (m *mockStore) DeleteSession(_ context.Context, _ string) error             { return nil }
-func (m *mockStore) DeleteExpiredSessions(_ context.Context) (int64, error)      { return 0, nil }
+func (m *mockStore) DeleteSession(_ context.Context, _ string) error                  { return nil }
+func (m *mockStore) DeleteExpiredSessions(_ context.Context) (int64, error)           { return 0, nil }
 func (m *mockStore) CreateOAuthState(_ context.Context, _ *database.OAuthState) error { return nil }
 func (m *mockStore) ConsumeOAuthState(_ context.Context, _, _ string) (*database.OAuthState, error) {
 	return nil, database.ErrNotFound
@@ -102,7 +122,23 @@ func (m *mockStore) GetDeviceAuthByUserCode(_ context.Context, _ string) (*datab
 func (m *mockStore) UpdateDeviceAuth(_ context.Context, _ *database.DeviceAuth) error { return nil }
 func (m *mockStore) DeleteDeviceAuth(_ context.Context, _ string) error               { return nil }
 func (m *mockStore) DeleteExpiredDeviceAuths(_ context.Context) (int64, error)        { return 0, nil }
-func (m *mockStore) Close() error                                                     { return nil }
+func (m *mockStore) CreateForwardProxyRuleset(_ context.Context, _ *database.ForwardProxyRuleset) error {
+	return nil
+}
+func (m *mockStore) GetForwardProxyRulesetByID(_ context.Context, _ string) (*database.ForwardProxyRuleset, error) {
+	return nil, nil
+}
+func (m *mockStore) GetForwardProxyRulesetByName(_ context.Context, _ string) (*database.ForwardProxyRuleset, error) {
+	return nil, nil
+}
+func (m *mockStore) ListForwardProxyRulesets(_ context.Context) ([]*database.ForwardProxyRuleset, error) {
+	return nil, nil
+}
+func (m *mockStore) UpdateForwardProxyRuleset(_ context.Context, _ *database.ForwardProxyRuleset) error {
+	return nil
+}
+func (m *mockStore) DeleteForwardProxyRuleset(_ context.Context, _ string) error { return nil }
+func (m *mockStore) Close() error                                                { return nil }
 
 // newTestToken creates a valid proxy token for testing with the given hash, ID,
 // and expiry.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -35,6 +35,7 @@ nav:
     - Token Type Border Policy: features/border-policy.md
     - Release Download Controls: features/release-controls.md
     - Codeload Redirect: features/codeload.md
+    - Forward Proxy Rulesets: features/forward-proxy-rulesets.md
     - OAuth Broker: features/oauth-broker.md
   - Administration:
     - Installation: admin/installation.md


### PR DESCRIPTION
## Summary

Outbound GitHub traffic keeps its existing default — the ambient environment (`HTTPS_PROXY` et al.) — but operators can now build **forward proxy rulesets** at runtime to deliberately steer GitHub-destined traffic across egress paths. Motivating case: CI fleets whose concentrated API/clone traffic gets an egress IP throttled or banned; splitting or pinning that traffic contains the blast radius.

## What's included

**Data model & storage**
- `ForwardProxyRuleset` (name, description, algorithm, proxy targets with weights, rules, enabled) with CRUD `Store` methods on all three backends (SQLite, Postgres, Vault) and migration `011_add_forward_proxy_rulesets` (unique name index, algorithm CHECK constraint).
- Contract test `testForwardProxyRulesetCRUD` covering every field, name uniqueness, rename, `ErrNotFound` paths.

**Selection engine (`internal/proxy/forwardproxy.go`)**
- `ForwardProxyRouter` compiles enabled rulesets into an immutable route table; `Reload` swaps atomically.
- Rule layers, most-specific first: client `header` → `token` → `app` → `net` (CIDR, longest prefix wins) → `system` → ambient environment.
- Algorithms: `round_robin` (atomic counter), `weighted` (random over weight distribution, e.g. 80/20), `sticky` (FNV hash of client source IP over the weighted target list).
- Fail-open: disabled rulesets, invalid URLs/CIDRs, or load failures skip with a warning and never block egress.

**Control-plane routing**
- A `control` rule type routes ghp's own outbound calls — OAuth login flows and token refresh, App installation token minting, username resolution lookups — via a dedicated egress path. This is ghp's most important traffic: losing it to a banned egress IP takes down every client behind the proxy.
- Control traffic resolves `control` → `system` → ambient; token/app/net layers never apply (not attributable to a client). A dedicated control transport is installed on the app registry, auth handler, and username resolver; OAuth refresh triggered inside a proxied request is re-classified so it doesn't inherit the client's routing.
- **Non-GitHub control destinations go direct by default.** Release redirect HEAD probes target the operator's mirror, which is typically internal — they are sent with no proxy at all (not even ambient). Setting `include_non_github: true` on the control rule opts them into control-layer routing, giving non-GitHub domains the same treatment as GitHub targets.

**Per-request client selection**
- With `forward_proxy.allow_request_header: true` (default **false**; `GHP_FORWARD_PROXY_ALLOW_REQUEST_HEADER`), a client may pick the forward proxy for a single request via `X-GitHub-Proxy-Forward-HTTP`/`-HTTPS` (http/https proxies) or `X-GitHub-Proxy-Forward-SOCKS` (socks5/socks5h). Use case: a team with its own egress (e.g. IP allow-listed on the far side) that only needs it on particular requests.
- The client choice beats every ruleset layer while still flowing through ghp — scoping, audit logs, and metrics all apply. At most one proxy per request; invalid or conflicting values → 400; headers are always stripped before forwarding upstream. Counted in `ghp_forward_proxy_client_specified_total{scheme,token_type}` (proxy URL deliberately never a label).

**Wiring**
- One shared `http.Transport` whose per-request `Proxy` function consults the router; installed on the API proxy, github.com passthrough, codeload, and Copilot backends — connection pools are kept per selected proxy.
- Route info is seeded per request (client IP via `server.client_ip_header`) and enriched with token/app identity after token resolution in both the API handler and the git passthrough.

**Runtime management**
- Admin-only CRUD at `/api/forward-proxy-rulesets` (list/create/get/PATCH/delete) following the repo's validation conventions (UUID checks, MaxBytesReader/413, pointer-based PATCH semantics, 409 on duplicate names).
- Mutations reload the route table immediately; a periodic refresh (1 min) converges other instances in HA deployments.

**Observability**
- New decision stage `forward_proxy_selection`, counters `ghp_forward_proxy_select_total{ruleset,layer}` (layer ∈ header/token/app/net/system/control/ambient/direct) and `ghp_forward_proxy_client_specified_total{scheme,token_type}`, gauge `ghp_forward_proxy_rulesets_active` — all with tests; CLAUDE.md metric tables updated.

**Docs**
- New page `docs/features/forward-proxy-rulesets.md` (concepts, API examples, control-plane routing, per-request client selection, failure modes, known limitations), configuration reference, how-it-works summary, mkdocs nav.

## Testing

- `go build ./...`, `go vet ./...` clean.
- New unit tests: router (precedence, CIDR specificity, all three algorithms, ambient fallback, reload swap, ProxyFunc context flow, control layer + control transport, non-GitHub direct default + opt-in, client-header extraction/validation/stripping and precedence), admin API handlers (CRUD, validation matrix, 404/400/409/413), metrics, SQLite store contract.
- Full suite green except the Docker-based Postgres/Vault container tests, which cannot run in this sandbox (no Docker provider) — unrelated to this change; CI's SQLite path covers the store contract.

## Known limitations

- Round-robin/sticky state is per-instance; HA instances cycle independently.
- Token/app rules require ghp-resolved tokens; raw-credential passthrough traffic is covered by `net`/`system` rules.
- Admin-UI convenience lookups through the GitHub SDK (installation/repository listings) use the ambient environment; all request-path control calls follow control-layer routing, and release HEAD probes follow it only with `include_non_github`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MWmuf2JwYiQ5VFeXHPWHxG